### PR TITLE
feat(core): Add support for checkup config file

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,6 +11,7 @@ A CLI that provides health check information about your project.
 <!-- toc -->
 
 - [Usage](#usage)
+- [Configuration](#configuration)
 - [Commands](#commands)
   <!-- tocstop -->
 
@@ -34,6 +35,32 @@ USAGE
 ```
 
 <!-- usagestop -->
+
+# Configuration
+
+<!-- configuration -->
+
+checkup is designed to be completely configurable via a configuration object.
+
+checkup uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find and load your configuration object. Starting from the current working directory, it looks for the following possible sources:
+                                        
+- a checkup property in package.json
+- a .checkuprc file
+- a checkup.config.js file exporting a JS object
+
+The search stops when one of these is found, and checkup uses that object. 
+
+The .checkuprc file (without extension) can be in JSON or YAML format. You can add a filename extension to help your text editor provide syntax checking and highlighting:
+
+- checkup.json
+- checkup.yaml / .checkup.yml
+- checkup.js
+
+The configuration object has the following properties:
+__
+<!-- TODO: Describe properties in CheckupConfig -->
+
+<!-- configurationstop -->
 
 # Commands
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "@types/jest": "^25.1.1",
     "@types/node": "^10",
     "chai": "^4.2.0",
+    "cosmiconfig": "^6.0.0",
     "jest": "^25.1.0",
     "stdout-stderr": "^0.1.13",
     "ts-jest": "^25.2.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export { default as TaskList } from './task-list';
 export { default as FileSearcherTask } from './file-searcher-task';
 export { default as FileSearcher } from './searchers/file-searcher';
 export { getPackageJson } from './utils/get-package-json';
+export { getConfig } from './utils/get-config';
 export { ui } from './utils/ui';
 export { wrapEntries } from './utils/data-formatter';
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -18,3 +18,10 @@ export interface TaskItemData {
 }
 
 export type SearchPatterns = Record<string, string[]>;
+
+export interface TaskConfig {}
+
+export interface CheckupConfig {
+  // an object from task name to task configuration
+  tasks: Record<string, TaskConfig>;
+}

--- a/packages/core/src/utils/get-config.ts
+++ b/packages/core/src/utils/get-config.ts
@@ -1,0 +1,18 @@
+import { cosmiconfig } from 'cosmiconfig';
+import { CheckupConfig } from '../types';
+
+let config: CheckupConfig;
+const DEFAULT_CONFIG: CheckupConfig = { tasks: {} };
+
+/**
+ * Get the checkup config via {@link cosmiconfig#search}
+ * @return the parsed config file, if found, else the default config
+ */
+export async function getConfig(): Promise<CheckupConfig> {
+  if (config !== undefined) {
+    return config;
+  }
+
+  const configResult = await cosmiconfig('checkup').search();
+  return (config = configResult?.config || DEFAULT_CONFIG);
+}


### PR DESCRIPTION
Add support for a consumer provided checkup config file, such as a .checkuprc, loaded via cosmiconfig. Add scaffolding to pass the checkup config to the
checkup task runner.