### PR TITLE
Adding path argument to specify directory to run in

### DIFF
--- a/packages/cli/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/index-test.ts.snap
@@ -4,7 +4,7 @@ exports[`@checkup/cli should output checkup result 1`] = `
 "=== Project Info
 
 name:    @checkup/cli
-type:    unknown
+type:    Ember.js unknown
 version: 0.0.0
 
 === Dependencies - Core Libraries
@@ -36,55 +36,11 @@ templates             0
 "
 `;
 
-exports[`@checkup/cli should output checkup result for dependencies task 1`] = `
-"=== Dependencies - Core Libraries
-
-Dependency   Version   
-ember-source Not found 
-ember-cli    Not found 
-ember-data   Not found 
-
-=== Dependencies - Ember Addons
-
-Dependency            Version 
-ember-template-recast ^4.0.0  
-
-"
-`;
-
-exports[`@checkup/cli should output checkup result for project info task 1`] = `
-"=== Project Info
-
-name:    @checkup/cli
-type:    unknown
-version: 0.0.0
-
-"
-`;
-
-exports[`@checkup/cli should output checkup result for types task 1`] = `
-"=== Types
-
-Type                  Total 
-components            0     
-controllers           0     
-helpers               0     
-initializers          0     
-instance-initializers 0     
-mixins                0     
-models                0     
-routes                0     
-services              0     
-templates             0     
-
-"
-`;
-
 exports[`@checkup/cli should output checkup result in JSON 1`] = `
 "{
   \\"project-info\\": {
     \\"name\\": \\"@checkup/cli\\",
-    \\"type\\": \\"unknown\\",
+    \\"type\\": \\"Ember.js unknown\\",
     \\"version\\": \\"0.0.0\\"
   },
   \\"dependencies\\": {

--- a/packages/cli/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/index-test.ts.snap
@@ -10,9 +10,9 @@ version: 0.0.0
 === Dependencies - Core Libraries
 
 Dependency   Version   
-ember-source undefined 
-ember-cli    undefined 
-ember-data   undefined 
+ember-source Not found 
+ember-cli    Not found 
+ember-data   Not found 
 
 === Dependencies - Ember Addons
 
@@ -40,9 +40,9 @@ exports[`@checkup/cli should output checkup result for dependencies task 1`] = `
 "=== Dependencies - Core Libraries
 
 Dependency   Version   
-ember-source undefined 
-ember-cli    undefined 
-ember-data   undefined 
+ember-source Not found 
+ember-cli    Not found 
+ember-data   Not found 
 
 === Dependencies - Ember Addons
 
@@ -88,7 +88,11 @@ exports[`@checkup/cli should output checkup result in JSON 1`] = `
     \\"version\\": \\"0.0.0\\"
   },
   \\"dependencies\\": {
-    \\"emberLibraries\\": {},
+    \\"emberLibraries\\": {
+      \\"ember-source\\": \\"Not found\\",
+      \\"ember-cli\\": \\"Not found\\",
+      \\"ember-data\\": \\"Not found\\"
+    },
     \\"emberAddons\\": {
       \\"dependencies\\": {
         \\"ember-template-recast\\": \\"^4.0.0\\"

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -14,22 +14,4 @@ describe('@checkup/cli', () => {
 
     expect(stdout()).toMatchSnapshot();
   });
-
-  it('should output checkup result for project info task', async () => {
-    await cmd.run(['--task', 'ProjectInfo']);
-
-    expect(stdout()).toMatchSnapshot();
-  });
-
-  it('should output checkup result for dependencies task', async () => {
-    await cmd.run(['--task', 'Dependencies']);
-
-    expect(stdout()).toMatchSnapshot();
-  });
-
-  it('should output checkup result for types task', async () => {
-    await cmd.run(['--task', 'Types']);
-
-    expect(stdout()).toMatchSnapshot();
-  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,15 @@ import { TaskConstructor, TaskList, getRegisteredTasks, ui } from '@checkup/core
 class Checkup extends Command {
   static description = 'A CLI that provides health check information about your project';
 
+  static args = [
+    {
+      name: 'path',
+      required: true,
+      description: 'The path referring to the root directory that Checkup will run in',
+      default: '.',
+    },
+  ];
+
   static flags = {
     version: flags.version({ char: 'v' }),
     help: flags.help({ char: 'h' }),
@@ -14,7 +23,7 @@ class Checkup extends Command {
   };
 
   async run() {
-    let { flags } = this.parse(Checkup);
+    let { args, flags } = this.parse(Checkup);
     let registeredTasks: TaskConstructor[];
 
     await this.config.runHook('register-tasks', {});
@@ -29,10 +38,10 @@ class Checkup extends Command {
       );
 
       if (task !== undefined) {
-        tasksToBeRun.addTask(task);
+        tasksToBeRun.addTask(task, args);
       }
     } else {
-      tasksToBeRun.addTasks(registeredTasks);
+      tasksToBeRun.addTasks(registeredTasks, args);
     }
 
     ui.action.start('Checking up on your project');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
+import * as path from 'path';
+
 import { Command, flags } from '@oclif/command';
-import { TaskConstructor, TaskList, getRegisteredTasks, ui } from '@checkup/core';
+import { TaskConstructor, TaskList, getPackageJson, getRegisteredTasks, ui } from '@checkup/core';
 
 class Checkup extends Command {
   static description = 'A CLI that provides health check information about your project';
@@ -25,6 +27,17 @@ class Checkup extends Command {
   async run() {
     let { args, flags } = this.parse(Checkup);
     let registeredTasks: TaskConstructor[];
+
+    try {
+      getPackageJson(args.path);
+    } catch (e) {
+      this.error(
+        `The ${path.resolve(
+          args.path
+        )} directory found through the 'path' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`,
+        e
+      );
+    }
 
     await this.config.runHook('register-tasks', {});
 

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -1,0 +1,11 @@
+import { Task, TaskResult } from './types';
+
+export default abstract class BaseTask implements Task {
+  args: any;
+
+  constructor(args: any) {
+    this.args = args;
+  }
+
+  abstract run(): Promise<TaskResult>;
+}

--- a/packages/core/src/file-searcher-task.ts
+++ b/packages/core/src/file-searcher-task.ts
@@ -1,6 +1,6 @@
-import { SearchPatterns, Task, TaskResult } from './types';
-
+import BaseTask from './base-task';
 import FileSearcher from './searchers/file-searcher';
+import { SearchPatterns } from './types';
 
 /**
  * @class FileSearcherTask
@@ -10,7 +10,7 @@ import FileSearcher from './searchers/file-searcher';
  * A checkup task specific to file searcher used to encapsulate an operation that
  * checks certain characteristics of your Ember project.
  */
-export default abstract class FileSearcherTask implements Task {
+export default abstract class FileSearcherTask extends BaseTask {
   searcher: FileSearcher;
 
   /**
@@ -18,9 +18,9 @@ export default abstract class FileSearcherTask implements Task {
    * @param result {TaskResult[]} the result object that aggregates data together for output.
    * @param searchPatterns {SearchPatterns} the search pattern that your filesearcher uses to return the results.
    */
-  constructor(searchPatterns: SearchPatterns) {
-    this.searcher = new FileSearcher(process.cwd(), searchPatterns);
-  }
+  constructor(args: any, searchPatterns: SearchPatterns) {
+    super(args);
 
-  abstract run(): Promise<TaskResult>;
+    this.searcher = new FileSearcher(args.path, searchPatterns);
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { getRegisteredTasks, registerTask, registerTasks } from './tasks';
+export { default as BaseTask } from './base-task';
 export { default as TaskList } from './task-list';
 export { default as FileSearcherTask } from './file-searcher-task';
 export { default as FileSearcher } from './searchers/file-searcher';

--- a/packages/core/src/task-list.ts
+++ b/packages/core/src/task-list.ts
@@ -25,8 +25,8 @@ export default class TaskList {
    *
    * @param taskConstructor {TaskConstructor} a constructor representing a Task class
    */
-  addTask(taskConstructor: TaskConstructor) {
-    this.defaultTasks.push(new taskConstructor());
+  addTask(taskConstructor: TaskConstructor, args: any) {
+    this.defaultTasks.push(new taskConstructor(args));
   }
 
   /**
@@ -36,9 +36,9 @@ export default class TaskList {
    *
    * @param taskConstructor {TaskConstructor[]} an array of constructors representing a Task classes
    */
-  addTasks(taskConstructors: TaskConstructor[]) {
+  addTasks(taskConstructors: TaskConstructor[], args: any) {
     taskConstructors.forEach((taskConstructor: TaskConstructor) => {
-      this.addTask(taskConstructor);
+      this.addTask(taskConstructor, args);
     });
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -3,7 +3,7 @@ export interface Task {
 }
 
 export interface TaskConstructor {
-  new (): Task;
+  new (args: any): Task;
 }
 
 export interface TaskResult {

--- a/packages/core/src/utils/get-package-json.ts
+++ b/packages/core/src/utils/get-package-json.ts
@@ -5,9 +5,9 @@ import { PackageJson } from 'type-fest';
 
 let pkg: PackageJson;
 
-export function getPackageJson(): PackageJson {
+export function getPackageJson(basePath: string): PackageJson {
   if (pkg === undefined) {
-    pkg = fs.readJsonSync(path.join(process.cwd(), 'package.json'));
+    pkg = fs.readJsonSync(path.join(path.resolve(basePath), 'package.json'));
   }
 
   return pkg;

--- a/packages/core/src/utils/get-package-json.ts
+++ b/packages/core/src/utils/get-package-json.ts
@@ -3,17 +3,15 @@ import * as path from 'path';
 
 import { PackageJson } from 'type-fest';
 
-let pkg: PackageJson;
-
 export function getPackageJson(basePath: string): PackageJson {
-  if (pkg === undefined) {
-    let packageJsonPath = path.join(path.resolve(basePath), 'package.json');
-    try {
-      pkg = fs.readJsonSync(packageJsonPath);
-    } catch (e) {
-      if (e.code === 'ENOENT') {
-        throw new Error(`No package.json file detected at ${packageJsonPath}`);
-      }
+  let pkg: PackageJson = {};
+  let packageJsonPath = path.join(path.resolve(basePath), 'package.json');
+
+  try {
+    pkg = fs.readJsonSync(packageJsonPath);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      throw new Error(`No package.json file detected at ${packageJsonPath}`);
     }
   }
 

--- a/packages/core/src/utils/get-package-json.ts
+++ b/packages/core/src/utils/get-package-json.ts
@@ -7,7 +7,14 @@ let pkg: PackageJson;
 
 export function getPackageJson(basePath: string): PackageJson {
   if (pkg === undefined) {
-    pkg = fs.readJsonSync(path.join(path.resolve(basePath), 'package.json'));
+    let packageJsonPath = path.join(path.resolve(basePath), 'package.json');
+    try {
+      pkg = fs.readJsonSync(packageJsonPath);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        throw new Error(`No package.json file detected at ${packageJsonPath}`);
+      }
+    }
   }
 
   return pkg;

--- a/packages/plugin-ember/__tests__/__fixtures__/addon-package.json
+++ b/packages/plugin-ember/__tests__/__fixtures__/addon-package.json
@@ -1,0 +1,61 @@
+{
+  "name": "my-addon",
+  "version": "0.0.0",
+  "description": "The default blueprint for ember-cli addons.",
+  "keywords": ["ember-addon"],
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "lint:hbs": "ember-template-lint .",
+    "lint:js": "eslint .",
+    "start": "ember serve",
+    "test": "ember test",
+    "test:all": "ember try:each"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^7.13.0",
+    "ember-cli-htmlbars": "^4.2.0"
+  },
+  "devDependencies": {
+    "@ember/optional-features": "^1.1.0",
+    "@glimmer/component": "^1.0.0",
+    "babel-eslint": "^10.0.3",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.3",
+    "ember-cli": "~3.15.0-beta.3",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-eslint": "^5.1.0",
+    "ember-cli-inject-live-reload": "^2.0.1",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-template-lint": "^1.0.0-beta.3",
+    "ember-cli-uglify": "^3.0.0",
+    "ember-disable-prototype-extensions": "^1.1.3",
+    "ember-export-application-global": "^2.0.1",
+    "ember-load-initializers": "^2.1.1",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit": "^4.6.0",
+    "ember-resolver": "^6.0.0",
+    "ember-source": "~3.15.0",
+    "ember-source-channel-url": "^2.0.1",
+    "ember-try": "^1.4.0",
+    "eslint-plugin-ember": "^7.7.1",
+    "eslint-plugin-node": "^10.0.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^0.9.2"
+  },
+  "engines": {
+    "node": "8.* || >= 10.*"
+  },
+  "ember": {
+    "edition": "octane"
+  },
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
+  }
+}

--- a/packages/plugin-ember/__tests__/__fixtures__/app-package.json
+++ b/packages/plugin-ember/__tests__/__fixtures__/app-package.json
@@ -1,0 +1,56 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Small description for my-app goes here",
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "lint:hbs": "ember-template-lint .",
+    "lint:js": "eslint .",
+    "start": "ember serve",
+    "test": "ember test"
+  },
+  "devDependencies": {
+    "@ember/optional-features": "^1.1.0",
+    "@glimmer/component": "^1.0.0",
+    "babel-eslint": "^10.0.3",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.3",
+    "ember-cli": "~3.15.0-beta.3",
+    "ember-cli-app-version": "^3.2.0",
+    "ember-cli-babel": "^7.13.0",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-eslint": "^5.1.0",
+    "ember-cli-htmlbars": "^4.2.0",
+    "ember-cli-inject-live-reload": "^2.0.1",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-template-lint": "^1.0.0-beta.3",
+    "ember-cli-uglify": "^3.0.0",
+    "ember-data": "~3.15.0-beta.0",
+    "ember-export-application-global": "^2.0.1",
+    "ember-fetch": "^7.0.0",
+    "ember-load-initializers": "^2.1.1",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit": "^4.6.0",
+    "ember-resolver": "^6.0.0",
+    "ember-source": "~3.15.0",
+    "ember-welcome-page": "^4.0.0",
+    "eslint-plugin-ember": "^7.7.1",
+    "eslint-plugin-node": "^10.0.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^0.9.2"
+  },
+  "engines": {
+    "node": "8.* || >= 10.*"
+  },
+  "ember": {
+    "edition": "octane"
+  }
+}

--- a/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
@@ -4,9 +4,25 @@ exports[`dependencies-task detects dependencies 1`] = `
 "=== Dependencies - Core Libraries
 
 Dependency   Version   
-ember-source undefined 
-ember-cli    undefined 
-ember-data   undefined 
+ember-source ^3.15.0   
+ember-cli    ^3.15.0   
+ember-data   Not found 
+
+=== Dependencies - Ember Addons
+
+Dependency   Version 
+ember-source ^3.15.0 
+
+=== Dependencies - Ember CLI Addons
+
+Dependency                       Version 
+ember-cli                        ^3.15.0 
+ember-cli-blueprint-test-helpers latest  
+
+=== Dev Dependencies - Ember CLI Addons
+
+Dependency             Version 
+ember-cli-string-utils latest  
 
 "
 `;
@@ -15,17 +31,24 @@ exports[`dependencies-task detects dependencies 2`] = `
 Object {
   "dependencies": Object {
     "emberAddons": Object {
-      "dependencies": Object {},
+      "dependencies": Object {
+        "ember-source": "^3.15.0",
+      },
       "devDependencies": Object {},
     },
     "emberCliAddons": Object {
-      "dependencies": Object {},
-      "devDependencies": Object {},
+      "dependencies": Object {
+        "ember-cli": "^3.15.0",
+        "ember-cli-blueprint-test-helpers": "latest",
+      },
+      "devDependencies": Object {
+        "ember-cli-string-utils": "latest",
+      },
     },
     "emberLibraries": Object {
-      "ember-cli": undefined,
-      "ember-data": undefined,
-      "ember-source": undefined,
+      "ember-cli": "^3.15.0",
+      "ember-data": "Not found",
+      "ember-source": "^3.15.0",
     },
   },
 }

--- a/packages/plugin-ember/__tests__/__snapshots__/project-info-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/project-info-task-test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`project-info-task for Ember Addons can read project info and output to console 1`] = `
+"=== Project Info
+
+name:    checkup-app
+type:    Ember.js addon
+version: 0.0.0
+
+"
+`;
+
+exports[`project-info-task for Ember Addons can read project info as JSON 1`] = `
+Object {
+  "project-info": Object {
+    "name": "checkup-app",
+    "type": "Ember.js addon",
+    "version": "0.0.0",
+  },
+}
+`;
+
+exports[`project-info-task for Ember Applications can read project info and output to console 1`] = `
+"=== Project Info
+
+name:    checkup-app
+type:    Ember.js application
+version: 0.0.0
+
+"
+`;
+
+exports[`project-info-task for Ember Applications can read project info as JSON 1`] = `
+Object {
+  "project-info": Object {
+    "name": "checkup-app",
+    "type": "Ember.js application",
+    "version": "0.0.0",
+  },
+}
+`;

--- a/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
@@ -5,80 +5,80 @@ Object {
   "types": Array [
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/components/my-component.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/components/my-component.js",
+        "addon/components/my-component.js",
+        "lib/ember-super-button/addon/components/my-component.js",
       ],
       "total": 2,
       "type": "components",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/controllers/my-controller.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/controllers/my-controller.js",
+        "addon/controllers/my-controller.js",
+        "lib/ember-super-button/addon/controllers/my-controller.js",
       ],
       "total": 2,
       "type": "controllers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/helpers/my-helper.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/helpers/my-helper.js",
+        "addon/helpers/my-helper.js",
+        "lib/ember-super-button/addon/helpers/my-helper.js",
       ],
       "total": 2,
       "type": "helpers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/initializers/my-initializer.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/initializers/my-initializer.js",
+        "addon/initializers/my-initializer.js",
+        "lib/ember-super-button/addon/initializers/my-initializer.js",
       ],
       "total": 2,
       "type": "initializers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/instance-initializers/my-helper.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/instance-initializers/my-helper.js",
+        "addon/instance-initializers/my-helper.js",
+        "lib/ember-super-button/addon/instance-initializers/my-helper.js",
       ],
       "total": 2,
       "type": "instance-initializers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/mixins/my-mixin.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/mixins/my-mixin.js",
+        "addon/mixins/my-mixin.js",
+        "lib/ember-super-button/addon/mixins/my-mixin.js",
       ],
       "total": 2,
       "type": "mixins",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/models/my-model.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/models/my-model.js",
+        "addon/models/my-model.js",
+        "lib/ember-super-button/addon/models/my-model.js",
       ],
       "total": 2,
       "type": "models",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/routes/my-route.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/routes/my-route.js",
+        "addon/routes/my-route.js",
+        "lib/ember-super-button/addon/routes/my-route.js",
       ],
       "total": 2,
       "type": "routes",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/services/my-service.js",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/services/my-service.js",
+        "addon/services/my-service.js",
+        "lib/ember-super-button/addon/services/my-service.js",
       ],
       "total": 2,
       "type": "services",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/templates/my-component.hbs",
-        "tests/test-app/cli-checkup-app/lib/ember-super-button/addon/templates/my-component.hbs",
+        "addon/templates/my-component.hbs",
+        "lib/ember-super-button/addon/templates/my-component.hbs",
       ],
       "total": 2,
       "type": "templates",
@@ -110,70 +110,70 @@ Object {
   "types": Array [
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/components/my-component.js",
+        "addon/components/my-component.js",
       ],
       "total": 1,
       "type": "components",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/controllers/my-controller.js",
+        "addon/controllers/my-controller.js",
       ],
       "total": 1,
       "type": "controllers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/helpers/my-helper.js",
+        "addon/helpers/my-helper.js",
       ],
       "total": 1,
       "type": "helpers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/initializers/my-initializer.js",
+        "addon/initializers/my-initializer.js",
       ],
       "total": 1,
       "type": "initializers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/instance-initializers/my-helper.js",
+        "addon/instance-initializers/my-helper.js",
       ],
       "total": 1,
       "type": "instance-initializers",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/mixins/my-mixin.js",
+        "addon/mixins/my-mixin.js",
       ],
       "total": 1,
       "type": "mixins",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/models/my-model.js",
+        "addon/models/my-model.js",
       ],
       "total": 1,
       "type": "models",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/routes/my-route.js",
+        "addon/routes/my-route.js",
       ],
       "total": 1,
       "type": "routes",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/services/my-service.js",
+        "addon/services/my-service.js",
       ],
       "total": 1,
       "type": "services",
     },
     Object {
       "data": Array [
-        "tests/test-app/cli-checkup-app/addon/templates/my-component.hbs",
+        "addon/templates/my-component.hbs",
       ],
       "total": 1,
       "type": "templates",

--- a/packages/plugin-ember/__tests__/__utils__/ember-cli-fixturify-project.ts
+++ b/packages/plugin-ember/__tests__/__utils__/ember-cli-fixturify-project.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { PackageJson } from 'type-fest';
+
 const FixturifyProject = require('fixturify-project');
 const rimraf = require('rimraf');
 
@@ -52,6 +54,12 @@ export default class EmberCLIFixturifyProject extends FixturifyProject {
 
     // insert inRepoAddon into files
     Object.assign(this.files.lib, inRepoAddon.toJSON());
+  }
+
+  updatePackageJson(pkgContent: PackageJson) {
+    pkgContent.name = this.name;
+
+    this.pkg = pkgContent;
   }
 
   dispose(tempFilesToCleanupPath?: string) {

--- a/packages/plugin-ember/__tests__/dependencies-task-test.ts
+++ b/packages/plugin-ember/__tests__/dependencies-task-test.ts
@@ -8,12 +8,14 @@ describe('dependencies-task', () => {
   let fixturifyProject: EmberCLIFixturifyProject;
 
   beforeEach(function() {
-    fixturifyProject = new EmberCLIFixturifyProject('test-app', '0.0.0', project => {
+    fixturifyProject = new EmberCLIFixturifyProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-source', '^3.15.0');
       project.addDependency('ember-cli', '^3.15.0');
       project.addDevDependency('ember-cli-string-utils', 'latest');
       project.addAddon('ember-cli-blueprint-test-helpers', 'latest');
     });
+
+    fixturifyProject.writeSync();
   });
 
   afterEach(function() {
@@ -21,7 +23,7 @@ describe('dependencies-task', () => {
   });
 
   it('detects dependencies', async () => {
-    const result = await new DependenciesTask().run();
+    const result = await new DependenciesTask({ path: fixturifyProject.baseDir }).run();
     const dependencyTaskResult = <DependenciesTaskResult>result;
 
     dependencyTaskResult.toConsole();
@@ -30,7 +32,7 @@ describe('dependencies-task', () => {
   });
 
   it('detects dependencies', async () => {
-    const result = await new DependenciesTask().run();
+    const result = await new DependenciesTask({ path: fixturifyProject.baseDir }).run();
     const dependencyTaskResult = <DependenciesTaskResult>result;
 
     expect(dependencyTaskResult.toJson()).toMatchSnapshot();

--- a/packages/plugin-ember/__tests__/project-info-task-test.ts
+++ b/packages/plugin-ember/__tests__/project-info-task-test.ts
@@ -1,0 +1,76 @@
+import EmberCLIFixturifyProject from './__utils__/ember-cli-fixturify-project';
+import { ProjectInfoTask } from '../src/tasks';
+import { ProjectInfoTaskResult } from '../src/results';
+import { stdout } from './__utils__/stdout';
+
+describe('project-info-task', () => {
+  let fixturifyProject: EmberCLIFixturifyProject;
+
+  describe('for Ember Applications', () => {
+    beforeEach(() => {
+      let packageJson = require('./__fixtures__/app-package.json');
+
+      fixturifyProject = new EmberCLIFixturifyProject('checkup-app', '0.0.0', project => {
+        project.addDependency('ember-cli', '^3.15.0');
+      });
+
+      fixturifyProject.updatePackageJson(packageJson);
+
+      fixturifyProject.writeSync();
+    });
+
+    afterEach(() => {
+      fixturifyProject.dispose();
+    });
+
+    it('can read project info and output to console', async () => {
+      const result = await new ProjectInfoTask({ path: fixturifyProject.baseDir }).run();
+      const taskResult = <ProjectInfoTaskResult>result;
+
+      taskResult.toConsole();
+
+      expect(stdout()).toMatchSnapshot();
+    });
+
+    it('can read project info as JSON', async () => {
+      const result = await new ProjectInfoTask({ path: fixturifyProject.baseDir }).run();
+      const taskResult = <ProjectInfoTaskResult>result;
+
+      expect(taskResult.toJson()).toMatchSnapshot();
+    });
+  });
+
+  describe('for Ember Addons', () => {
+    beforeEach(() => {
+      let packageJson = require('./__fixtures__/addon-package.json');
+
+      fixturifyProject = new EmberCLIFixturifyProject('checkup-app', '0.0.0', project => {
+        project.addDependency('ember-cli', '^3.15.0');
+      });
+
+      fixturifyProject.updatePackageJson(packageJson);
+
+      fixturifyProject.writeSync();
+    });
+
+    afterEach(() => {
+      fixturifyProject.dispose();
+    });
+
+    it('can read project info and output to console', async () => {
+      const result = await new ProjectInfoTask({ path: fixturifyProject.baseDir }).run();
+      const taskResult = <ProjectInfoTaskResult>result;
+
+      taskResult.toConsole();
+
+      expect(stdout()).toMatchSnapshot();
+    });
+
+    it('can read project info as JSON', async () => {
+      const result = await new ProjectInfoTask({ path: fixturifyProject.baseDir }).run();
+      const taskResult = <ProjectInfoTaskResult>result;
+
+      expect(taskResult.toJson()).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/plugin-ember/__tests__/types-task-test.ts
+++ b/packages/plugin-ember/__tests__/types-task-test.ts
@@ -4,8 +4,6 @@ import { stdout } from './__utils__/stdout';
 import { TypesTask } from '../src/tasks';
 import { TypesTaskResult } from '../src/results';
 
-const FILE_PATH = 'tests/test-app';
-
 const TYPES = {
   components: {
     'my-component.js': '',
@@ -43,11 +41,11 @@ describe('types-task', () => {
   let fixturifyProject: EmberCLIFixturifyProject;
 
   beforeEach(function() {
-    fixturifyProject = new EmberCLIFixturifyProject('cli-checkup-app', '0.0.0');
+    fixturifyProject = new EmberCLIFixturifyProject('checkup-app', '0.0.0');
   });
 
   afterEach(function() {
-    fixturifyProject.dispose(FILE_PATH);
+    fixturifyProject.dispose();
   });
 
   it('returns all the types found in the app and outputs to the console', async () => {
@@ -56,9 +54,9 @@ describe('types-task', () => {
       addon: TYPES,
     });
 
-    fixturifyProject.writeSync(FILE_PATH);
+    fixturifyProject.writeSync();
 
-    const result = await new TypesTask().run();
+    const result = await new TypesTask({ path: fixturifyProject.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
     typesTaskResult.toConsole();
@@ -78,9 +76,9 @@ describe('types-task', () => {
     fixturifyProject.files.lib['ember-super-button'].addon = TYPES;
     // @ts-ignore
 
-    fixturifyProject.writeSync(FILE_PATH);
+    fixturifyProject.writeSync();
 
-    const result = await new TypesTask().run();
+    const result = await new TypesTask({ path: fixturifyProject.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
     typesTaskResult.toConsole();
@@ -94,9 +92,9 @@ describe('types-task', () => {
       addon: TYPES,
     });
 
-    fixturifyProject.writeSync(FILE_PATH);
+    fixturifyProject.writeSync();
 
-    const result = await new TypesTask().run();
+    const result = await new TypesTask({ path: fixturifyProject.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
     expect(typesTaskResult.toJson()).toMatchSnapshot();
@@ -114,9 +112,9 @@ describe('types-task', () => {
     fixturifyProject.files.lib['ember-super-button'].addon = TYPES;
     // @ts-ignore
 
-    fixturifyProject.writeSync(FILE_PATH);
+    fixturifyProject.writeSync();
 
-    const result = await new TypesTask().run();
+    const result = await new TypesTask({ path: fixturifyProject.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
     expect(typesTaskResult.toJson()).toMatchSnapshot();

--- a/packages/plugin-ember/jest.config.js
+++ b/packages/plugin-ember/jest.config.js
@@ -14,5 +14,5 @@ module.exports = {
       statements: 100,
     },
   },
-  testPathIgnorePatterns: ['/__utils__/'],
+  testPathIgnorePatterns: ['/__utils__/', '__fixtures__'],
 };

--- a/packages/plugin-ember/package.json
+++ b/packages/plugin-ember/package.json
@@ -16,6 +16,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^25.2.0",
     "ts-node": "^8",
+    "type-fest": "^0.11.0",
     "typescript": "^3.3"
   },
   "engines": {

--- a/packages/plugin-ember/src/tasks/dependencies-task.ts
+++ b/packages/plugin-ember/src/tasks/dependencies-task.ts
@@ -40,7 +40,6 @@ function emberCliAddonFilter(dependency: string) {
 
 export default class DependenciesTask extends BaseTask {
   async run(): Promise<TaskResult> {
-    debugger;
     let result: DependenciesTaskResult = new DependenciesTaskResult();
     let pkg: PackageJson = getPackageJson(this.args.path);
 

--- a/packages/plugin-ember/src/tasks/project-info-task.ts
+++ b/packages/plugin-ember/src/tasks/project-info-task.ts
@@ -1,15 +1,15 @@
-import { Task, TaskResult, getPackageJson } from '@checkup/core';
+import { BaseTask, TaskResult, getPackageJson } from '@checkup/core';
 
 import { PackageJson } from 'type-fest';
 import { ProjectInfoTaskResult } from '../results';
 import { getProjectType } from '../utils/project';
 
-export default class ProjectInfoTask implements Task {
+export default class ProjectInfoTask extends BaseTask {
   async run(): Promise<TaskResult> {
     let result: ProjectInfoTaskResult = new ProjectInfoTaskResult();
-    let pkg: PackageJson = getPackageJson();
+    let pkg: PackageJson = getPackageJson(this.args.path);
 
-    result.type = getProjectType();
+    result.type = getProjectType(this.args.path);
     result.name = pkg.name || '';
     result.version = pkg.version || '';
 

--- a/packages/plugin-ember/src/tasks/project-info-task.ts
+++ b/packages/plugin-ember/src/tasks/project-info-task.ts
@@ -9,7 +9,7 @@ export default class ProjectInfoTask extends BaseTask {
     let result: ProjectInfoTaskResult = new ProjectInfoTaskResult();
     let pkg: PackageJson = getPackageJson(this.args.path);
 
-    result.type = getProjectType(this.args.path);
+    result.type = `Ember.js ${getProjectType(this.args.path)}`;
     result.name = pkg.name || '';
     result.version = pkg.version || '';
 

--- a/packages/plugin-ember/src/tasks/types-task.ts
+++ b/packages/plugin-ember/src/tasks/types-task.ts
@@ -1,9 +1,9 @@
-import { FileSearcherTask, Task, TaskResult } from '@checkup/core';
+import { BaseTask, FileSearcherTask, TaskResult } from '@checkup/core';
 
 import { TypesTaskResult } from '../results';
 
-export default class TypesTask extends FileSearcherTask implements Task {
-  constructor() {
+export default class TypesTask extends FileSearcherTask implements BaseTask {
+  constructor(args: any) {
     const SEARCH_PATTERNS = {
       components: ['**/components/**/*.js'],
       controllers: ['**/controllers/**/*.js'],
@@ -17,7 +17,7 @@ export default class TypesTask extends FileSearcherTask implements Task {
       templates: ['**/templates/**/*.hbs'],
     };
 
-    super(SEARCH_PATTERNS);
+    super(args, SEARCH_PATTERNS);
   }
 
   async run(): Promise<TaskResult> {

--- a/packages/plugin-ember/src/utils/project.ts
+++ b/packages/plugin-ember/src/utils/project.ts
@@ -5,8 +5,8 @@ import { ProjectType } from '../types';
 import { getPackageJson } from '@checkup/core';
 
 /**
- * Gets the current type of project, either
- * @param project {IProject} The ember-cli model object, either App, Engine, or Addon.
+ * Gets the current type of project, either App, Engine, or Addon
+ *
  * @returns {ProjectType}
  */
 export function getProjectType(basePath: string): ProjectType {

--- a/packages/plugin-ember/src/utils/project.ts
+++ b/packages/plugin-ember/src/utils/project.ts
@@ -9,8 +9,8 @@ import { getPackageJson } from '@checkup/core';
  * @param project {IProject} The ember-cli model object, either App, Engine, or Addon.
  * @returns {ProjectType}
  */
-export function getProjectType(): ProjectType {
-  let pkg = getPackageJson();
+export function getProjectType(basePath: string): ProjectType {
+  let pkg = getPackageJson(basePath);
 
   if (pkg.keywords && Array.isArray(pkg.keywords) && pkg.keywords.indexOf('ember-addon') >= 0) {
     if (fs.existsSync(path.join(process.cwd(), 'addon', 'engine.js'))) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5146,6 +5146,11 @@ type-fest@^0.10.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.10.0.tgz#7f06b2b9fbfc581068d1341ffabd0349ceafc642"
   integrity sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==
 
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
 type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"


### PR DESCRIPTION
Checkup currently considers `process.cwd()` the base directory from which to run. In future cases, we want users to be able to run in a specific subdirectory. This PR adds support for a `path` argument. 

```shell
❯ checkup --help
A CLI that provides health check information about your project

USAGE
  $ checkup PATH

ARGUMENTS
  PATH  [default: .] The path referring to the root directory that Checkup will run in

OPTIONS
  -f, --force
  -h, --help       show CLI help
  -s, --silent
  -t, --task=task
  -v, --version    show CLI version
  --json
```

The path defaults to the current directory (`.`), with the ability for users to specify an alternate directory to run checkup in.

Addition: fixes broken tasks that were incorrectly testing the project's cwd instead of test fixture directories due to the lack of `path` support.