### PR TITLE
internal(infra): Utilize workspaces run for build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/core",
+    "packages/test-helpers",
+    "packages/plugin-ember",
+    "packages/cli"
   ],
   "scripts": {
-    "build": "yarn workspace @checkup/core build && yarn workspace @checkup/test-helpers build && yarn workspace @checkup/plugin-ember build && yarn workspace @checkup/cli build",
-    "build:watch": "yarn workspace @checkup/core build -w && yarn workspace @checkup/plugin-ember build -w && yarn workspace @checkup/cli build -w",
+    "build": "yarn workspaces run build",
+    "build:watch": "yarn workspaces run build:watch",
     "test": "yarn workspaces run test",
     "lint": "eslint . --cache --ext .ts"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "yarn workspaces run build",
     "build:watch": "yarn workspaces run build:watch",
+    "clean": "yarn workspaces run clean",
     "test": "yarn workspaces run test",
     "lint": "eslint . --cache --ext .ts"
   },

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   "private": true,
   "workspaces": [
     "packages/core",
-    "packages/test-helpers",
-    "packages/plugin-ember",
-    "packages/cli"
+    "packages/*"
   ],
   "scripts": {
     "build": "yarn workspaces run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "yarn build -w",
+    "clean": "rm -rf lib/*",
     "prepack": "yarn build && oclif-dev readme",
     "test": "jest",
     "version": "oclif-dev readme && git add README.md"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "yarn build -w",
+    "clean": "rm -rf lib/*",
     "test": "jest --passWithNoTests"
   },
   "types": "lib/index.d.ts"

--- a/packages/plugin-ember/package.json
+++ b/packages/plugin-ember/package.json
@@ -45,6 +45,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "yarn build -w",
+    "clean": "rm -rf lib/*",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest",

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "yarn build -w",
+    "clean": "rm -rf lib/*",
     "test": "jest --passWithNoTests"
   },
   "types": "lib/index.d.ts"


### PR DESCRIPTION
Utilize `yarn workspaces run` for build command so we don't need to keep on updating our build command as our workspaces grow.

Create `clean` commands for each package.