### PR TITLE
Adds @checkup/parser-eslint plugin package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "husky": "^4.2.1",
+    "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
     "prettier": "^1.19.1",
     "wsrun": "^5.2.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,11 +9,8 @@
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
     "@checkup/core": "0.0.0",
+    "@checkup/parser-eslint": "0.0.0",
     "@checkup/plugin-ember": "0.0.0",
-    "@glimmer/reference": "^0.47.0",
-    "@glimmer/runtime": "^0.47.9",
-    "@glimmer/syntax": "^0.47.9",
-    "@glimmer/validator": "^0.47.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,6 +65,7 @@ class Checkup extends Command {
     await this.config.runHook('register-parsers', {
       registerParser,
     });
+    console.log(getRegisteredParsers());
     await this.config.runHook('register-tasks', {
       parsers: getRegisteredParsers(),
       registerTask,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,7 +65,7 @@ class Checkup extends Command {
     await this.config.runHook('register-parsers', {
       registerParser,
     });
-    console.log(getRegisteredParsers());
+
     await this.config.runHook('register-tasks', {
       parsers: getRegisteredParsers(),
       registerTask,

--- a/packages/cli/src/parsers.ts
+++ b/packages/cli/src/parsers.ts
@@ -1,7 +1,4 @@
-type ParserName = string;
-interface Parser {
-  parse(): () => void;
-}
+import { Parser, ParserName } from '@checkup/core';
 
 let registeredParsers: Map<ParserName, Parser> = new Map<ParserName, Parser>();
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from 'type-fest';
 import { RuntimeCheckupConfig, RuntimeTaskConfig } from './runtime-types';
 import * as t from 'io-ts';
 
@@ -7,6 +8,11 @@ export interface HooksConfig {
 
 export type CheckupConfig = t.TypeOf<typeof RuntimeCheckupConfig>;
 export type TaskConfig = t.TypeOf<typeof RuntimeTaskConfig>;
+export type ParserName = string;
+
+export interface Parser {
+  execute(paths: string[]): JsonObject;
+}
 
 export type TaskName = string;
 

--- a/packages/parser-eslint/package.json
+++ b/packages/parser-eslint/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@checkup/parser-eslint",
+  "description": "ESLint parser for @checkup/cli",
+  "version": "0.0.0",
+  "author": "Steve Calvert <steve.calvert@gmail.com>",
+  "bugs": "https://github.com/checkupjs/checkup/issues",
+  "dependencies": {
+    "@checkup/core": "0.0.0",
+    "eslint": "^6.8.0"
+  },
+  "devDependencies": {
+    "ts-node": "^8",
+    "type-fest": "^0.11.0",
+    "typescript": "^3.8"
+  },
+  "engines": {
+    "node": "10.* || >= 12.*"
+  },
+  "files": [
+    "/lib"
+  ],
+  "homepage": "https://github.com/checkupjs/checkup",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "repository": "https://github.com/checkupjs/checkup",
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "yarn build -w",
+    "clean": "rm -rf lib/*",
+    "test": "jest --passWithNoTests"
+  },
+  "types": "lib/index.d.ts",
+  "oclif": {
+    "hooks": {
+      "init": "./lib/hooks/init/register-parser"
+    }
+  }
+}

--- a/packages/parser-eslint/package.json
+++ b/packages/parser-eslint/package.json
@@ -6,7 +6,10 @@
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
     "@checkup/core": "0.0.0",
-    "eslint": "^6.8.0"
+    "@oclif/command": "^1",
+    "@oclif/config": "^1",
+    "eslint": "^6.8.0",
+    "tslib": "^1"
   },
   "devDependencies": {
     "ts-node": "^8",
@@ -17,11 +20,23 @@
     "node": "10.* || >= 12.*"
   },
   "files": [
-    "/lib"
+    "/lib",
+    "/oclif.manifest.json",
+    "/yarn.lock"
   ],
   "homepage": "https://github.com/checkupjs/checkup",
+  "keywords": [
+    "oclif-plugin"
+  ],
   "license": "MIT",
-  "main": "lib/index.js",
+  "oclif": {
+    "devPlugins": [
+      "@oclif/plugin-help"
+    ],
+    "hooks": {
+      "register-parsers": "./lib/hooks/register-parsers"
+    }
+  },
   "repository": "https://github.com/checkupjs/checkup",
   "scripts": {
     "build": "tsc",
@@ -29,10 +44,5 @@
     "clean": "rm -rf lib/*",
     "test": "jest --passWithNoTests"
   },
-  "types": "lib/index.d.ts",
-  "oclif": {
-    "hooks": {
-      "init": "./lib/hooks/init/register-parser"
-    }
-  }
+  "types": "lib/index.d.ts"
 }

--- a/packages/parser-eslint/src/eslint-parser.ts
+++ b/packages/parser-eslint/src/eslint-parser.ts
@@ -10,7 +10,7 @@ export default class ESLintParser implements Parser {
     this.engine = new CLIEngine({
       baseConfig: {
         // I assume this will be some sort of eslint-config-checkup
-        extends: ['eslint-config-shared'],
+        extends: ['eslint:recommended'],
       },
       useEslintrc: false,
     });

--- a/packages/parser-eslint/src/eslint-parser.ts
+++ b/packages/parser-eslint/src/eslint-parser.ts
@@ -1,0 +1,25 @@
+import { JsonObject } from 'type-fest';
+import { Parser } from '@checkup/core';
+
+const CLIEngine = require('eslint').CLIEngine;
+
+export default class ESLintParser implements Parser {
+  engine: typeof CLIEngine;
+
+  constructor() {
+    this.engine = new CLIEngine({
+      baseConfig: {
+        // I assume this will be some sort of eslint-config-checkup
+        extends: ['eslint-config-shared'],
+      },
+      useEslintrc: false,
+    });
+  }
+
+  execute(paths: string[]): JsonObject {
+    const report = this.engine.executeOnFiles(paths);
+    const formatter = this.engine.getFormatter('json');
+
+    return formatter(report.results);
+  }
+}

--- a/packages/parser-eslint/src/hooks/register-parsers.ts
+++ b/packages/parser-eslint/src/hooks/register-parsers.ts
@@ -2,7 +2,6 @@ import ESLintParser from '../eslint-parser';
 import { Hook } from '@oclif/config';
 
 const hook: Hook<'register-parsers'> = async function({ registerParser }: any) {
-  process.stdout.write('in here registering parsers');
   registerParser('eslint', new ESLintParser());
 };
 

--- a/packages/parser-eslint/src/hooks/register-parsers.ts
+++ b/packages/parser-eslint/src/hooks/register-parsers.ts
@@ -1,0 +1,8 @@
+import ESLintParser from '../eslint-parser';
+import { Hook } from '@oclif/config';
+
+const hook: Hook<'register-parsers'> = async function({ registerParser }: any) {
+  registerParser('eslint', new ESLintParser());
+};
+
+export default hook;

--- a/packages/parser-eslint/src/hooks/register-parsers.ts
+++ b/packages/parser-eslint/src/hooks/register-parsers.ts
@@ -2,6 +2,7 @@ import ESLintParser from '../eslint-parser';
 import { Hook } from '@oclif/config';
 
 const hook: Hook<'register-parsers'> = async function({ registerParser }: any) {
+  process.stdout.write('in here registering parsers');
   registerParser('eslint', new ESLintParser());
 };
 

--- a/packages/parser-eslint/src/index.ts
+++ b/packages/parser-eslint/src/index.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/parser-eslint/tsconfig.json
+++ b/packages/parser-eslint/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["jest", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "@checkup/core": ["../core/lib/index.d.ts"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,15 +167,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@glimmer/encoder@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.47.9.tgz#76b8844b70aa2948a14306edfd189ab9c3c49ac1"
-  integrity sha512-A3ldCfWzXVuU4vF2R0nFKppBZ90zgjsC8DS41Z5O4tdL1aJZ1WhyF/DaJI7YNqnh2gn+1pFAUTkZgMgEADV59w==
-  dependencies:
-    "@glimmer/interfaces" "^0.47.9"
-    "@glimmer/vm" "^0.47.9"
-
-"@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
+"@glimmer/env@0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
@@ -185,45 +177,6 @@
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.47.9.tgz#4c50b5343815045318bba38915f780ae39f14590"
   integrity sha512-xne80DHkPC70u08LKV9g0+PboAmIw0A+vDXjJXMrDoRcNzCR4dXR6nvKD/Een+wbwwBaRawCIn45Rnk5+Dyvrg==
   dependencies:
-    "@simple-dom/interface" "^1.4.0"
-
-"@glimmer/low-level@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.47.9.tgz#ef5e3aaaa659e3d94fa452688f869a2a38524285"
-  integrity sha512-BUQeUxx8mDlNNwVFz3SFIOs0eysl9OX89suUrZROZ/emg37RZFbo/6cRi7v5ZCEknX2vCBJ0tzEbWXGEiPoysQ==
-
-"@glimmer/program@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.47.9.tgz#8ffa8a43c36d985d5d6949672b69bee1f3d6e9a6"
-  integrity sha512-y3aShRCnVDhdq8I/uNokQ00QNn89hRSKLjhnh8s0stk7sGBJrzuas2DTSQOVkKEuz96SAIqBQD+xpMJjf3mF4A==
-  dependencies:
-    "@glimmer/encoder" "^0.47.9"
-    "@glimmer/interfaces" "^0.47.9"
-    "@glimmer/util" "^0.47.9"
-
-"@glimmer/reference@^0.47.0", "@glimmer/reference@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.47.9.tgz#f95c06a8dd08eddc16f1f5ccc9071ecb544be37b"
-  integrity sha512-IXn995T0maaKKSEcTTnRhEvjV24nnf2FG1cEKw0V2/tjvef+pn3zJqgUACqUF0c1BMDWTepw4ES70TEVq9F4jQ==
-  dependencies:
-    "@glimmer/env" "^0.1.7"
-    "@glimmer/util" "^0.47.9"
-    "@glimmer/validator" "^0.47.9"
-
-"@glimmer/runtime@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.47.9.tgz#35c9d6820086d4fe9e2e810553b103d7c70d55e5"
-  integrity sha512-j6jecBLhVEwEtlU44WqC7GeNUU5sfLGJHK0CYhlYa+kd4BUOphWRrQ+NCKOjkehgbYlXA0PGuGVPZ9mB0ACbJg==
-  dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.47.9"
-    "@glimmer/low-level" "^0.47.9"
-    "@glimmer/program" "^0.47.9"
-    "@glimmer/reference" "^0.47.9"
-    "@glimmer/util" "^0.47.9"
-    "@glimmer/validator" "^0.47.9"
-    "@glimmer/vm" "^0.47.9"
-    "@glimmer/wire-format" "^0.47.9"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/syntax@^0.47.9":
@@ -243,29 +196,6 @@
   dependencies:
     "@glimmer/env" "0.1.7"
     "@simple-dom/interface" "^1.4.0"
-
-"@glimmer/validator@^0.47.0", "@glimmer/validator@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.47.9.tgz#bed80157b9fd800c03f654616921b41dbfa14b9d"
-  integrity sha512-AW7Nud5AQd6bM0c+qzyT4slovHTE+evysS9znsfYCkhTyHqbjTipBviif9czPovTV5A5Xjv5gvy62iyPxl2/Rw==
-  dependencies:
-    "@glimmer/env" "^0.1.7"
-
-"@glimmer/vm@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.47.9.tgz#05029b7ef31104bf32cfc5cb53ae1f0d5d8c7ea6"
-  integrity sha512-VGfSSDjAx7Thsz1HTTUs3eNS/l9Xiaqhq3Z4rxui8a9GeUf2eOkpS1eUTWt9vjNTHJM+pNt1EohAvuaPWd/AGw==
-  dependencies:
-    "@glimmer/interfaces" "^0.47.9"
-    "@glimmer/util" "^0.47.9"
-
-"@glimmer/wire-format@^0.47.9":
-  version "0.47.9"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.47.9.tgz#93f685bb6ce43af888ec85fd473880532a677983"
-  integrity sha512-zO5cFxPb8+kYdkDzKp4q7dOghWnQKR/K67TQuJmPDE0MJh22HJSclWqgDH3FiSYz7O4IQ3GMVOxsvKAuIDOXBA==
-  dependencies:
-    "@glimmer/interfaces" "^0.47.9"
-    "@glimmer/util" "^0.47.9"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
@@ -2600,7 +2530,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^4.2.1:
+husky@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.3.tgz#3b18d2ee5febe99e27f2983500202daffbc3151e"
   integrity sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==


### PR DESCRIPTION
Adds `@checkup/parser-eslint` with `register-parsers` hook implementation. This hook registers the `eslint` parser, which is a bare-bones implementation of what we need for parsing eslint files.