### PR TITLE
Add Validation to Checkup Config

### DIFF
--- a/packages/cli/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/index-test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`@checkup/cli cli error cases should error if the config is malformed 1`] = `
+"Checkup configuration is malformed:
+plugins expected type Array<string>, but got undefined
+tasks.someTask.isEnabled expected type boolean, but got \\"foo\\""
+`;
+
 exports[`@checkup/cli normal cli output with plugins should output checkup result 1`] = `
 "mock task is being run
 mock task2 is being run

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -1,5 +1,6 @@
-import { stdout, CheckupProject, Plugin } from '@checkup/test-helpers';
+import { CheckupProject, Plugin, stdout } from '@checkup/test-helpers';
 import cmd = require('../src');
+import { CheckupConfig } from '@checkup/core';
 
 describe('@checkup/cli', () => {
   describe('normal cli output with plugins', () => {
@@ -90,6 +91,22 @@ describe('@checkup/cli', () => {
       await expect(cmd.run([project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Cannot find module '@checkup/unknown-plugin' from '${project.baseDir}'"`
       );
+
+      project.dispose();
+    });
+
+    it('should error if the config is malformed', async () => {
+      const project = new CheckupProject('checkup-project', '0.0.0').addCheckupConfig(({
+        plugins: undefined,
+        tasks: {
+          someTask: {
+            isEnabled: 'foo',
+          },
+        },
+      } as unknown) as CheckupConfig);
+      project.writeSync();
+
+      await expect(cmd.run([project.baseDir])).rejects.toThrowErrorMatchingSnapshot();
 
       project.dispose();
     });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,9 @@
   "author": "Steve Calvert <steve.calvert@gmail.com>",
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
+    "resolve": "^1.15.1",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
     "resolve": "^1.15.1"
   },
   "devDependencies": {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,13 +1,12 @@
+import { RuntimeCheckupConfig, RuntimeTaskConfig } from './runtime-types';
+import * as t from 'io-ts';
+
 export interface HooksConfig {
   registerTask(taskName: string, task: TaskConstructor): void;
 }
 
-export interface TaskConfig {}
-
-export interface CheckupConfig {
-  plugins: string[];
-  tasks: Record<string, TaskConfig>;
-}
+export type CheckupConfig = t.TypeOf<typeof RuntimeCheckupConfig>;
+export type TaskConfig = t.TypeOf<typeof RuntimeTaskConfig>;
 
 export type TaskName = string;
 

--- a/packages/core/src/types/runtime-types.ts
+++ b/packages/core/src/types/runtime-types.ts
@@ -1,0 +1,10 @@
+import * as t from 'io-ts';
+
+export const RuntimeTaskConfig = t.type({
+  isEnabled: t.boolean,
+});
+
+export const RuntimeCheckupConfig = t.type({
+  plugins: t.array(t.string),
+  tasks: t.record(t.string, RuntimeTaskConfig),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,6 +2269,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+fp-ts@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.5.3.tgz#7f09cc7f3e09623c6ade303d98a2cccdb2cc861f"
+  integrity sha512-lQd+hahLd8cygNoXbEHDjH/cbF6XVWlEPb8h5GXXlozjCSDxWgclvkpOoTRfBA0P+r69l9VvW1nEsSGIJRQpWw==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -2700,6 +2705,11 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+io-ts@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.1.2.tgz#8ea4439c902c3d15cda343900bed7ee5a9977f42"
+  integrity sha512-whVRGaNBZSrkPrg1y+sSy/kv/fDjweQPP1UCLhKwJUHWGD6rFgbZ44FBF98JlY/FFzTA0MkhGeHWZ/aFhF42eA==
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Use io-ts to wrap CheckupConfig types so they can be accessed during
runtime and used to validate the configuration found via cosmiconfig