### PR TITLE
Refactoring task registration to simplify

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "packages/**/*.ts": [
       "yarn lint"
     ]
+  },
+  "volta": {
+    "node": "10.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,5 @@
     "packages/**/*.ts": [
       "yarn lint"
     ]
-  },
-  "volta": {
-    "node": "10.19.0"
   }
 }

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -11,6 +11,13 @@ describe('@checkup/cli', () => {
     beforeEach(function() {
       const plugin = new Plugin.PluginBuilder('@checkup/plugin-mock')
         .addTask('MockTask', {
+          taskName: 'mock-task',
+          friendlyTaskName: 'Mock Task',
+          taskClassification: {
+            category: 0,
+            priority: 0,
+          },
+
           async run() {
             return Promise.resolve({
               toJson() {
@@ -25,6 +32,13 @@ describe('@checkup/cli', () => {
           },
         })
         .addTask('MockTask2', {
+          taskName: 'mock-task2',
+          friendlyTaskName: 'Mock Task 2',
+          taskClassification: {
+            category: 0,
+            priority: 0,
+          },
+
           async run() {
             return Promise.resolve({
               toJson() {
@@ -39,6 +53,7 @@ describe('@checkup/cli', () => {
           },
         })
         .build();
+
       project = new CheckupProject('checkup-project', '0.0.0')
         .addCheckupConfig({
           plugins: ['@checkup/plugin-mock'],
@@ -66,7 +81,7 @@ describe('@checkup/cli', () => {
     });
 
     it('should run a single task if the task option is specified', async () => {
-      await cmd.run(['--task', 'MockTask', project.baseDir]);
+      await cmd.run(['--task', 'mock-task', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });

--- a/packages/cli/__tests__/priority-map-test.ts
+++ b/packages/cli/__tests__/priority-map-test.ts
@@ -1,8 +1,15 @@
-import { BaseTask, Priority } from '@checkup/core';
+import { BaseTask, Category, Priority, TaskClassification, TaskName } from '@checkup/core';
 
 import PriorityMap from '../src/priority-map';
 
 class MockTask extends BaseTask {
+  taskName: TaskName = 'mock-task';
+  friendlyTaskName: TaskName = 'Mock Task';
+  taskClassification: TaskClassification = {
+    category: Category.Core,
+    priority: Priority.High,
+  };
+
   run() {
     return Promise.resolve({
       toJson() {

--- a/packages/cli/__tests__/priority-map-test.ts
+++ b/packages/cli/__tests__/priority-map-test.ts
@@ -1,8 +1,8 @@
-import { BaseTask, Category, Priority, TaskClassification, TaskName } from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskClassification, TaskName } from '@checkup/core';
 
 import PriorityMap from '../src/priority-map';
 
-class MockTask extends BaseTask {
+class MockTask extends BaseTask implements Task {
   taskName: TaskName = 'mock-task';
   friendlyTaskName: TaskName = 'Mock Task';
   taskClassification: TaskClassification = {

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -1,8 +1,15 @@
-import { BaseTask, Category, Priority } from '@checkup/core';
+import { BaseTask, Category, Priority, TaskClassification, TaskName } from '@checkup/core';
 
 import TaskList from '../src/task-list';
 
 class MockTask extends BaseTask {
+  taskName: TaskName = 'mock-task';
+  friendlyTaskName: TaskName = 'Mock Task';
+  taskClassification: TaskClassification = {
+    category: Category.Core,
+    priority: Priority.High,
+  };
+
   run() {
     return Promise.resolve({
       toJson() {
@@ -18,6 +25,13 @@ class MockTask extends BaseTask {
 }
 
 class AnotherMockTask extends BaseTask {
+  taskName: TaskName = 'another-mock-task';
+  friendlyTaskName: TaskName = 'Another Mock Task';
+  taskClassification: TaskClassification = {
+    category: Category.Core,
+    priority: Priority.Low,
+  };
+
   run() {
     return Promise.resolve({
       toJson() {
@@ -43,10 +57,7 @@ describe('TaskList', () => {
   it('registerTask adds a task to the TaskList', () => {
     let taskList = new TaskList();
 
-    taskList.registerTask('mock-task', new MockTask({}), {
-      category: Category.Core,
-      priority: Priority.High,
-    });
+    taskList.registerTask(new MockTask({}));
 
     expect(taskList.categories.get(Category.Core)!.size).toEqual(1);
   });
@@ -54,10 +65,7 @@ describe('TaskList', () => {
   it('runTask will run a task by taskName', async () => {
     let taskList = new TaskList();
 
-    taskList.registerTask('mock-task', new MockTask({}), {
-      category: Category.Core,
-      priority: Priority.High,
-    });
+    taskList.registerTask(new MockTask({}));
 
     let result = await taskList.runTask('mock-task');
 
@@ -69,14 +77,8 @@ describe('TaskList', () => {
   it('runTasks will run all registered tasks', async () => {
     let taskList = new TaskList();
 
-    taskList.registerTask('mock-task', new MockTask({}), {
-      category: Category.Core,
-      priority: Priority.High,
-    });
-    taskList.registerTask('another-mock-task', new AnotherMockTask({}), {
-      category: Category.Core,
-      priority: Priority.High,
-    });
+    taskList.registerTask(new MockTask({}));
+    taskList.registerTask(new AnotherMockTask({}));
 
     let result = await taskList.runTasks();
 

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -1,8 +1,8 @@
-import { BaseTask, Category, Priority, TaskClassification, TaskName } from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskClassification, TaskName } from '@checkup/core';
 
 import TaskList from '../src/task-list';
 
-class MockTask extends BaseTask {
+class MockTask extends BaseTask implements Task {
   taskName: TaskName = 'mock-task';
   friendlyTaskName: TaskName = 'Mock Task';
   taskClassification: TaskClassification = {
@@ -24,7 +24,7 @@ class MockTask extends BaseTask {
   }
 }
 
-class AnotherMockTask extends BaseTask {
+class AnotherMockTask extends BaseTask implements Task {
   taskName: TaskName = 'another-mock-task';
   friendlyTaskName: TaskName = 'Another Mock Task';
   taskClassification: TaskClassification = {

--- a/packages/cli/src/priority-map.ts
+++ b/packages/cli/src/priority-map.ts
@@ -39,7 +39,11 @@ export default class PriorityMap {
     return this.maps.get(priority)!;
   }
 
-  *[Symbol.iterator]() {
+  [Symbol.iterator](): Generator<[TaskName, Task]> {
+    return this.entries();
+  }
+
+  *entries(): Generator<[TaskName, Task]> {
     for (let [, map] of this.maps) {
       for (let [taskName, task] of map) {
         yield [taskName, task];
@@ -47,31 +51,19 @@ export default class PriorityMap {
     }
   }
 
-  entries() {
-    return this.entriesIterator();
-  }
-
-  values() {
-    return this.valuesIterator();
-  }
-
-  get size() {
-    return [...this.maps.values()].reduce((total, currentMap) => (total += currentMap.size), 0);
-  }
-
-  *entriesIterator() {
-    for (let [, map] of this.maps) {
-      for (let [priority, tasks] of map) {
-        yield [priority, tasks];
-      }
-    }
-  }
-
-  *valuesIterator() {
+  *values(): Generator<Task> {
     for (let [, map] of this.maps) {
       for (let [, task] of map) {
         yield task;
       }
     }
+  }
+
+  get size() {
+    return (
+      this.maps.get(Priority.High)!.size +
+      this.maps.get(Priority.Medium)!.size +
+      this.maps.get(Priority.Low)!.size
+    );
   }
 }

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -1,6 +1,6 @@
 import * as pMap from 'p-map';
 
-import { Category, Task, TaskClassification, TaskName, TaskResult } from '@checkup/core';
+import { Category, Task, TaskName, TaskResult } from '@checkup/core';
 
 import PriorityMap from './priority-map';
 
@@ -32,9 +32,9 @@ export default class TaskList {
    * @param task {Task}
    * @param taskClassification
    */
-  registerTask(taskName: TaskName, task: Task, taskClassification: TaskClassification) {
-    let priorityMap = this._categories.get(taskClassification.category);
-    priorityMap!.setTaskByPriority(taskClassification.priority, taskName, task);
+  registerTask(task: Task) {
+    let priorityMap = this._categories.get(task.taskClassification.category);
+    priorityMap!.setTaskByPriority(task.taskClassification.priority, task.taskName, task);
   }
 
   /**

--- a/packages/core/src/base-task-result.ts
+++ b/packages/core/src/base-task-result.ts
@@ -1,0 +1,12 @@
+import { Task, TaskMetaData } from './types';
+
+export default abstract class BaseTaskResult {
+  meta: TaskMetaData;
+
+  constructor(task: Task) {
+    this.meta = {
+      taskName: task.taskName,
+      friendlyTaskName: task.friendlyTaskName,
+    };
+  }
+}

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -1,8 +1,9 @@
-import { Task, TaskName, TaskResult } from './types';
+import { Task, TaskClassification, TaskName, TaskResult } from './types';
 
 export default abstract class BaseTask implements Task {
-  static taskName: TaskName;
-  static friendlyTaskName: TaskName;
+  abstract taskName: TaskName;
+  abstract friendlyTaskName: TaskName;
+  abstract taskClassification: TaskClassification;
 
   args: any;
 

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -1,15 +1,7 @@
-import { Task, TaskClassification, TaskName, TaskResult } from './types';
-
-export default abstract class BaseTask implements Task {
-  abstract taskName: TaskName;
-  abstract friendlyTaskName: TaskName;
-  abstract taskClassification: TaskClassification;
-
+export default abstract class BaseTask {
   args: any;
 
   constructor(cliArguments: any) {
     this.args = cliArguments;
   }
-
-  abstract run(): Promise<TaskResult>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { default as BaseTask } from './base-task';
+export { default as BaseTaskResult } from './base-task-result';
 export { default as FileSearcherTask } from './file-searcher-task';
 export { default as FileSearcher } from './searchers/file-searcher';
 export { loadPlugins } from './loaders/plugin-loader';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -31,12 +31,21 @@ export type TaskClassification = {
 };
 
 export interface Task {
+  taskName: TaskName;
+  friendlyTaskName: TaskName;
+  taskClassification: TaskClassification;
+
   run: () => Promise<TaskResult>;
 }
 
 export interface TaskResult {
   toConsole: () => void;
   toJson: () => {};
+}
+
+export interface TaskMetaData {
+  taskName: TaskName;
+  friendlyTaskName: TaskName;
 }
 
 export interface TaskItemData {

--- a/packages/plugin-default/src/hooks/register-tasks.ts
+++ b/packages/plugin-default/src/hooks/register-tasks.ts
@@ -2,11 +2,7 @@ import { Hook } from '@oclif/config';
 import { ProjectInfoTask } from '../tasks';
 
 const hook: Hook<'register-tasks'> = async function({ cliArguments, tasks }: any) {
-  tasks.registerTask(
-    ProjectInfoTask.taskName,
-    new ProjectInfoTask(cliArguments),
-    ProjectInfoTask.taskClassification
-  );
+  tasks.registerTask(new ProjectInfoTask(cliArguments));
 };
 
 export default hook;

--- a/packages/plugin-default/src/results/project-info-task-result.ts
+++ b/packages/plugin-default/src/results/project-info-task-result.ts
@@ -1,15 +1,14 @@
-import { TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
-import ProjectInfoTask from '../tasks/project-info-task';
 import { RepositoryInfo } from '../types';
 
-export default class ProjectInfoTaskResult implements TaskResult {
+export default class ProjectInfoTaskResult extends BaseTaskResult implements TaskResult {
   name!: string;
   version!: string;
   repository!: RepositoryInfo;
 
   toConsole() {
-    ui.styledHeader(ProjectInfoTask.friendlyTaskName);
+    ui.styledHeader(this.meta.friendlyTaskName);
     ui.blankLine();
     ui.styledObject({
       name: this.name,
@@ -29,7 +28,7 @@ export default class ProjectInfoTaskResult implements TaskResult {
 
   toJson() {
     return {
-      [ProjectInfoTask.taskName]: {
+      [this.meta.taskName]: {
         name: this.name,
         version: this.version,
         repository: this.repository,

--- a/packages/plugin-default/src/tasks/project-info-task.ts
+++ b/packages/plugin-default/src/tasks/project-info-task.ts
@@ -12,15 +12,15 @@ import ProjectInfoTaskResult from '../results/project-info-task-result';
 import { getRepositoryInfo } from '../utils/repository';
 
 export default class ProjectInfoTask extends BaseTask {
-  static taskName: TaskName = 'project-info';
-  static friendlyTaskName: TaskName = 'Project Information';
-  static taskClassification: TaskClassification = {
+  taskName: TaskName = 'project-info';
+  friendlyTaskName: TaskName = 'Project Information';
+  taskClassification: TaskClassification = {
     category: Category.Core,
     priority: Priority.High,
   };
 
   async run(): Promise<TaskResult> {
-    let result: ProjectInfoTaskResult = new ProjectInfoTaskResult();
+    let result: ProjectInfoTaskResult = new ProjectInfoTaskResult(this);
     let package_ = getPackageJson(this.args.path);
 
     result.name = package_.name || '';

--- a/packages/plugin-default/src/tasks/project-info-task.ts
+++ b/packages/plugin-default/src/tasks/project-info-task.ts
@@ -2,6 +2,7 @@ import {
   BaseTask,
   Category,
   Priority,
+  Task,
   TaskClassification,
   TaskName,
   TaskResult,
@@ -11,7 +12,7 @@ import {
 import ProjectInfoTaskResult from '../results/project-info-task-result';
 import { getRepositoryInfo } from '../utils/repository';
 
-export default class ProjectInfoTask extends BaseTask {
+export default class ProjectInfoTask extends BaseTask implements Task {
   taskName: TaskName = 'project-info';
   friendlyTaskName: TaskName = 'Project Information';
   taskClassification: TaskClassification = {

--- a/packages/plugin-ember/src/hooks/register-tasks.ts
+++ b/packages/plugin-ember/src/hooks/register-tasks.ts
@@ -4,17 +4,9 @@ import { Hook } from '@oclif/config';
 
 // TODO: Determine correct type for options
 const hook: Hook<'register-tasks'> = async function({ cliArguments, tasks }: any) {
-  tasks.registerTask(
-    EmberProjectTask.taskName,
-    new EmberProjectTask(cliArguments),
-    EmberProjectTask.taskClassification
-  );
-  tasks.registerTask(
-    DependenciesTask.taskName,
-    new DependenciesTask(cliArguments),
-    DependenciesTask.taskClassification
-  );
-  tasks.registerTask(TypesTask.taskName, new TypesTask(cliArguments), TypesTask.taskClassification);
+  tasks.registerTask(new EmberProjectTask(cliArguments));
+  tasks.registerTask(new DependenciesTask(cliArguments));
+  tasks.registerTask(new TypesTask(cliArguments));
 };
 
 export default hook;

--- a/packages/plugin-ember/src/results/dependencies-task-result.ts
+++ b/packages/plugin-ember/src/results/dependencies-task-result.ts
@@ -1,14 +1,14 @@
-import { TaskResult, toPairs, ui } from '@checkup/core';
+import { BaseTaskResult, Task, TaskResult, toPairs, ui } from '@checkup/core';
 
-import { DependenciesTask } from '../tasks';
 import { PackageJson } from 'type-fest';
 
-export default class DependenciesTaskResult implements TaskResult {
+export default class DependenciesTaskResult extends BaseTaskResult implements TaskResult {
   emberLibraries!: PackageJson.Dependency;
   emberAddons!: Record<string, PackageJson.Dependency>;
   emberCliAddons!: Record<string, PackageJson.Dependency>;
 
-  constructor() {
+  constructor(task: Task) {
+    super(task);
     this.emberLibraries = {};
   }
 
@@ -25,7 +25,7 @@ export default class DependenciesTaskResult implements TaskResult {
     if (!this.hasDependencies) {
       return;
     }
-    ui.styledHeader(DependenciesTask.friendlyTaskName);
+    ui.styledHeader(this.meta.friendlyTaskName);
     this._writeDependencySection('Dependencies - Core Libraries', this.emberLibraries);
     this._writeDependencySection('Dependencies - Ember Addons', this.emberAddons.dependencies);
     this._writeDependencySection(
@@ -44,7 +44,7 @@ export default class DependenciesTaskResult implements TaskResult {
 
   toJson() {
     return {
-      [DependenciesTask.taskName]: {
+      [this.meta.taskName]: {
         emberLibraries: this.emberLibraries,
         emberAddons: this.emberAddons,
         emberCliAddons: this.emberCliAddons,

--- a/packages/plugin-ember/src/results/ember-project-task-result.ts
+++ b/packages/plugin-ember/src/results/ember-project-task-result.ts
@@ -1,14 +1,12 @@
-import { TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
-import { EmberProjectTask } from '../tasks';
-
-export default class EmberProjectTaskResult implements TaskResult {
+export default class EmberProjectTaskResult extends BaseTaskResult implements TaskResult {
   type!: string;
   name!: string;
   version!: string;
 
   toConsole() {
-    ui.styledHeader(EmberProjectTask.friendlyTaskName);
+    ui.styledHeader(this.meta.friendlyTaskName);
     ui.blankLine();
     ui.styledObject({
       type: this.type,
@@ -18,7 +16,7 @@ export default class EmberProjectTaskResult implements TaskResult {
 
   toJson() {
     return {
-      [EmberProjectTask.taskName]: { type: this.type },
+      [this.meta.taskName]: { type: this.type },
     };
   }
 }

--- a/packages/plugin-ember/src/results/types-task-result.ts
+++ b/packages/plugin-ember/src/results/types-task-result.ts
@@ -1,8 +1,6 @@
-import { TaskItemData, TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskItemData, TaskResult, ui } from '@checkup/core';
 
-import { TypesTask } from '../tasks';
-
-export default class TypesTaskResult implements TaskResult {
+export default class TypesTaskResult extends BaseTaskResult implements TaskResult {
   types!: TaskItemData[];
 
   findByType(typeName: string): TaskItemData | undefined {
@@ -10,13 +8,13 @@ export default class TypesTaskResult implements TaskResult {
   }
 
   toConsole() {
-    ui.styledHeader(TypesTask.friendlyTaskName);
+    ui.styledHeader(this.meta.friendlyTaskName);
     ui.blankLine();
     ui.table(this.types, { type: {}, total: {} });
     ui.blankLine();
   }
 
   toJson() {
-    return { [TypesTask.taskName]: this.types };
+    return { [this.meta.taskName]: this.types };
   }
 }

--- a/packages/plugin-ember/src/tasks/dependencies-task.ts
+++ b/packages/plugin-ember/src/tasks/dependencies-task.ts
@@ -13,6 +13,7 @@ import { PackageJson } from 'type-fest';
 /**
  * @param packageJson
  * @param key
+ * @returns {string}
  */
 function findDependency(packageJson: PackageJson, key: string): string {
   return (
@@ -25,6 +26,7 @@ function findDependency(packageJson: PackageJson, key: string): string {
 /**
  * @param dependencies
  * @param filter
+ * @returns Record<string, string>
  */
 function findDependencies(
   dependencies: PackageJson.Dependency | undefined,
@@ -47,6 +49,7 @@ function findDependencies(
 
 /**
  * @param dependency
+ * @returns {boolean}
  */
 function emberAddonFilter(dependency: string) {
   return dependency.startsWith('ember-') && !dependency.startsWith('ember-cli');
@@ -54,21 +57,22 @@ function emberAddonFilter(dependency: string) {
 
 /**
  * @param dependency
+ * @returns {boolean}
  */
 function emberCliAddonFilter(dependency: string) {
   return dependency.startsWith('ember-cli');
 }
 
 export default class DependenciesTask extends BaseTask {
-  static taskName: string = 'dependencies';
-  static friendlyTaskName: string = 'Project Dependencies';
-  static taskClassification: TaskClassification = {
+  taskName: string = 'dependencies';
+  friendlyTaskName: string = 'Project Dependencies';
+  taskClassification: TaskClassification = {
     category: Category.Core,
     priority: Priority.Medium,
   };
 
   async run(): Promise<TaskResult> {
-    let result: DependenciesTaskResult = new DependenciesTaskResult();
+    let result: DependenciesTaskResult = new DependenciesTaskResult(this);
     let packageJson = getPackageJson(this.args.path);
 
     result.emberLibraries['ember-source'] = findDependency(packageJson, 'ember-source');

--- a/packages/plugin-ember/src/tasks/dependencies-task.ts
+++ b/packages/plugin-ember/src/tasks/dependencies-task.ts
@@ -2,6 +2,7 @@ import {
   BaseTask,
   Category,
   Priority,
+  Task,
   TaskClassification,
   TaskResult,
   getPackageJson,
@@ -63,7 +64,7 @@ function emberCliAddonFilter(dependency: string) {
   return dependency.startsWith('ember-cli');
 }
 
-export default class DependenciesTask extends BaseTask {
+export default class DependenciesTask extends BaseTask implements Task {
   taskName: string = 'dependencies';
   friendlyTaskName: string = 'Project Dependencies';
   taskClassification: TaskClassification = {

--- a/packages/plugin-ember/src/tasks/ember-project-task.ts
+++ b/packages/plugin-ember/src/tasks/ember-project-task.ts
@@ -11,15 +11,15 @@ import { EmberProjectTaskResult } from '../results';
 import { getProjectType } from '../utils/project';
 
 export default class EmberProjectTask extends BaseTask {
-  static taskName: TaskName = 'ember-project';
-  static friendlyTaskName: TaskName = 'Ember Project';
-  static taskClassification: TaskClassification = {
+  taskName: TaskName = 'ember-project';
+  friendlyTaskName: TaskName = 'Ember Project';
+  taskClassification: TaskClassification = {
     category: Category.Core,
     priority: Priority.Medium,
   };
 
   async run(): Promise<TaskResult> {
-    let result: EmberProjectTaskResult = new EmberProjectTaskResult();
+    let result: EmberProjectTaskResult = new EmberProjectTaskResult(this);
 
     result.type = `Ember.js ${getProjectType(this.args.path)}`;
 

--- a/packages/plugin-ember/src/tasks/ember-project-task.ts
+++ b/packages/plugin-ember/src/tasks/ember-project-task.ts
@@ -2,6 +2,7 @@ import {
   BaseTask,
   Category,
   Priority,
+  Task,
   TaskClassification,
   TaskName,
   TaskResult,
@@ -10,7 +11,7 @@ import {
 import { EmberProjectTaskResult } from '../results';
 import { getProjectType } from '../utils/project';
 
-export default class EmberProjectTask extends BaseTask {
+export default class EmberProjectTask extends BaseTask implements Task {
   taskName: TaskName = 'ember-project';
   friendlyTaskName: TaskName = 'Ember Project';
   taskClassification: TaskClassification = {

--- a/packages/plugin-ember/src/tasks/types-task.ts
+++ b/packages/plugin-ember/src/tasks/types-task.ts
@@ -24,9 +24,9 @@ const SEARCH_PATTERNS = {
 };
 
 export default class TypesTask extends FileSearcherTask implements BaseTask {
-  static taskName: TaskName = 'types';
-  static friendlyTaskName: TaskName = 'Project Types';
-  static taskClassification: TaskClassification = {
+  taskName: TaskName = 'types';
+  friendlyTaskName: TaskName = 'Project Types';
+  taskClassification: TaskClassification = {
     category: Category.Core,
     priority: Priority.Medium,
   };
@@ -36,7 +36,7 @@ export default class TypesTask extends FileSearcherTask implements BaseTask {
   }
 
   async run(): Promise<TaskResult> {
-    let result = new TypesTaskResult();
+    let result = new TypesTaskResult(this);
     result.types = await this.searcher.search();
 
     return result;

--- a/packages/plugin-ember/src/tasks/types-task.ts
+++ b/packages/plugin-ember/src/tasks/types-task.ts
@@ -1,8 +1,8 @@
 import {
-  BaseTask,
   Category,
   FileSearcherTask,
   Priority,
+  Task,
   TaskClassification,
   TaskName,
   TaskResult,
@@ -23,7 +23,7 @@ const SEARCH_PATTERNS = {
   templates: ['**/templates/**/*.hbs'],
 };
 
-export default class TypesTask extends FileSearcherTask implements BaseTask {
+export default class TypesTask extends FileSearcherTask implements Task {
   taskName: TaskName = 'types';
   friendlyTaskName: TaskName = 'Project Types';
   taskClassification: TaskClassification = {

--- a/packages/test-helpers/src/plugin.ts
+++ b/packages/test-helpers/src/plugin.ts
@@ -55,16 +55,17 @@ export default class Plugin {
             .map(
               ([taskName, task]) =>
                 `class ${taskName} {
+                  taskName = '${task.taskName}';
+                  friendlyTaskName = '${task.friendlyTaskName}';
+                  taskClassification = ${JSON.stringify(task.taskClassification, null, 2)};
+
                   ${task.run.toString()}
                 }`
             )
             .join('\n\n')}
             const hook = async function ({ cliArguments, tasks }) {
               ${[...this.tasks.keys()]
-                .map(
-                  taskName =>
-                    `tasks.registerTask('${taskName}', new ${taskName}(cliArguments), { category: 0, priority: 0 });`
-                )
+                .map(taskName => `tasks.registerTask(new ${taskName}(cliArguments));`)
                 .join('\n')}
             }
             exports.default = hook;

--- a/packages/test-helpers/src/plugin.ts
+++ b/packages/test-helpers/src/plugin.ts
@@ -55,9 +55,11 @@ export default class Plugin {
             .map(
               ([taskName, task]) =>
                 `class ${taskName} {
-                  taskName = '${task.taskName}';
-                  friendlyTaskName = '${task.friendlyTaskName}';
-                  taskClassification = ${JSON.stringify(task.taskClassification, null, 2)};
+                  constructor() {
+                    this.taskName = '${task.taskName}';
+                    this.friendlyTaskName = '${task.friendlyTaskName}';
+                    this.taskClassification = ${JSON.stringify(task.taskClassification, null, 2)};
+                  }
 
                   ${task.run.toString()}
                 }`


### PR DESCRIPTION
This PR removes the multiple params passed in to `registerTask` when registering tasks via hooks. 