### PR TITLE
Add config flag to optionally pass explicit config path to cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,7 +58,7 @@ The .checkuprc file (without extension) can be in JSON or YAML format. You can a
 You can also specify an explicit path to a configuration via the command line, which will override any configurations found in any `.checkuprc.*` files
 
 ```sh-session
-$ checkup --config /some/path/to/my/config/.eslintrc
+$ checkup --config /some/path/to/my/config/.checkuprc
 ``` 
 
 The configuration object has the following properties:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,7 +44,6 @@ checkup is designed to be completely configurable via a configuration object.
 
 checkup uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find and load your configuration object. Starting from the current working directory, it looks for the following possible sources:
                                         
-- a checkup property in package.json
 - a .checkuprc file
 - a checkup.config.js file exporting a JS object
 
@@ -52,9 +51,15 @@ The search stops when one of these is found, and checkup uses that object.
 
 The .checkuprc file (without extension) can be in JSON or YAML format. You can add a filename extension to help your text editor provide syntax checking and highlighting:
 
-- checkup.json
-- checkup.yaml / .checkup.yml
-- checkup.js
+- .checkup.json
+- .checkup.yaml / .checkup.yml
+- .checkup.js
+
+You can also specify an explicit path to a configuration via the command line, which will override any configurations found in any `.checkuprc.*` files
+
+```sh-session
+$ checkup --config /some/path/to/my/config/.eslintrc
+``` 
 
 The configuration object has the following properties:
 

--- a/packages/cli/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/index-test.ts.snap
@@ -15,9 +15,8 @@ mock task3 is being run
 
 exports[`@checkup/cli normal cli output with plugins should output checkup result in JSON 1`] = `
 "{
-  \\"mockTask\\": 5,
-  \\"mockTask2\\": 10,
-  \\"mockTask3\\": 15
+  \\"mockTask\\": 15,
+  \\"mockTask2\\": 10
 }
 "
 `;

--- a/packages/cli/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/index-test.ts.snap
@@ -9,18 +9,26 @@ tasks.someTask.isEnabled expected type boolean, but got \\"foo\\""
 exports[`@checkup/cli normal cli output with plugins should output checkup result 1`] = `
 "mock task is being run
 mock task2 is being run
+mock task3 is being run
 "
 `;
 
 exports[`@checkup/cli normal cli output with plugins should output checkup result in JSON 1`] = `
 "{
   \\"mockTask\\": 5,
-  \\"mockTask2\\": 10
+  \\"mockTask2\\": 10,
+  \\"mockTask3\\": 15
 }
 "
 `;
 
 exports[`@checkup/cli normal cli output with plugins should run a single task if the task option is specified 1`] = `
 "mock task is being run
+"
+`;
+
+exports[`@checkup/cli normal cli output with plugins should use the config at the config path if provided 1`] = `
+"mock task is being run
+mock task2 is being run
 "
 `;

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -56,31 +56,29 @@ describe('@checkup/cli', () => {
             }
           }
         );
-      const anotherPlugin = new Plugin('another-plugin-mock')
-        .addTask(
-          class MockTask implements Task {
-            taskName = 'mock-task3';
-            friendlyTaskName = 'Mock Task3';
-            taskClassification = {
-              category: 0,
-              priority: 0,
-            };
+      const anotherPlugin = new Plugin('another-plugin-mock').addTask(
+        class MockTask implements Task {
+          taskName = 'mock-task3';
+          friendlyTaskName = 'Mock Task3';
+          taskClassification = {
+            category: 0,
+            priority: 0,
+          };
 
-            async run() {
-              return {
-                toJson() {
-                  return {
-                    mockTask: 15,
-                  };
-                },
-                toConsole() {
-                  process.stdout.write('mock task3 is being run\n');
-                },
-              };
-            }
+          async run() {
+            return {
+              toJson() {
+                return {
+                  mockTask: 15,
+                };
+              },
+              toConsole() {
+                process.stdout.write('mock task3 is being run\n');
+              },
+            };
           }
-        )
-        .build();
+        }
+      );
 
       project = new CheckupProject('checkup-project', '0.0.0')
         .addCheckupConfig({

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -1,5 +1,6 @@
 import { CheckupConfig, Task } from '@checkup/core';
 import { CheckupProject, Plugin, stdout } from '@checkup/test-helpers';
+import * as path from 'path';
 
 import cmd = require('../src');
 
@@ -55,13 +56,39 @@ describe('@checkup/cli', () => {
             }
           }
         );
+      const anotherPlugin = new Plugin('another-plugin-mock')
+        .addTask(
+          class MockTask implements Task {
+            taskName = 'mock-task3';
+            friendlyTaskName = 'Mock Task3';
+            taskClassification = {
+              category: 0,
+              priority: 0,
+            };
+
+            async run() {
+              return {
+                toJson() {
+                  return {
+                    mockTask: 15,
+                  };
+                },
+                toConsole() {
+                  process.stdout.write('mock task3 is being run\n');
+                },
+              };
+            }
+          }
+        )
+        .build();
 
       project = new CheckupProject('checkup-project', '0.0.0')
         .addCheckupConfig({
-          plugins: ['@checkup/plugin-mock'],
+          plugins: ['@checkup/plugin-mock', 'another-plugin-mock'],
           tasks: {},
         })
-        .addPlugin(plugin);
+        .addPlugin(plugin)
+        .addPlugin(anotherPlugin);
 
       project.writeSync();
     });
@@ -86,6 +113,18 @@ describe('@checkup/cli', () => {
       await cmd.run(['--task', 'mock-task', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
+    });
+
+    it('should use the config at the config path if provided', async () => {
+      const anotherProject = new CheckupProject('another-project').addCheckupConfig({
+        plugins: ['@checkup/plugin-mock'],
+        tasks: {},
+      });
+      anotherProject.writeSync();
+      await cmd.run(['--config', path.join(anotherProject.baseDir, '.checkuprc'), project.baseDir]);
+
+      expect(stdout()).toMatchSnapshot();
+      anotherProject.dispose();
     });
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   loadPlugins,
   ui,
   getSearchLoader,
+  getFilepathLoader,
   CheckupConfigService,
 } from '@checkup/core';
 import { getRegisteredParsers, registerParser } from './parsers';
@@ -46,6 +47,10 @@ class Checkup extends Command {
     silent: flags.boolean({ char: 's' }),
     json: flags.boolean(),
     task: flags.string({ char: 't' }),
+    config: flags.string({
+      char: 'c',
+      description: 'Use this configuration, overriding .checkuprc.* if present',
+    }),
   };
 
   async run() {
@@ -54,7 +59,10 @@ class Checkup extends Command {
     let registeredTasks: TaskList = new TaskList();
 
     try {
-      const configService = await CheckupConfigService.load(getSearchLoader(args.path));
+      const configLoader = flags.config
+        ? getFilepathLoader(flags.config)
+        : getSearchLoader(args.path);
+      const configService = await CheckupConfigService.load(configLoader);
       const checkupConfig = configService.get();
       let plugins = await loadPlugins(checkupConfig.plugins, args.path);
       this.config.plugins.push(...plugins);

--- a/packages/core/__tests__/configuration/get-filepath-loader-test.ts
+++ b/packages/core/__tests__/configuration/get-filepath-loader-test.ts
@@ -22,7 +22,7 @@ describe('get-filepath-loader', () => {
     await expect(
       getFilepathLoader(path.join(project.baseDir, '.checkuprc'))()
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"ENOENT: no such file or directory, open '${path.join(project.baseDir, '.checkuprc')}'"`
+      `"Could not find checkup configuration file at ${path.join(project.baseDir, '.checkuprc')}"`
     );
   });
 

--- a/packages/core/__tests__/configuration/get-filepath-loader-test.ts
+++ b/packages/core/__tests__/configuration/get-filepath-loader-test.ts
@@ -1,0 +1,39 @@
+import { CheckupConfigFormat, getFilepathLoader } from '../../src';
+import { CheckupProject } from '@checkup/test-helpers';
+import * as path from 'path';
+
+describe('get-filepath-loader', () => {
+  const defaultConfig = {
+    plugins: [],
+    tasks: {},
+  };
+  let project: CheckupProject;
+
+  beforeEach(() => {
+    project = new CheckupProject('test');
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  it('should throw if a config file is not found at the given filepath', async () => {
+    project.writeSync();
+    await expect(
+      getFilepathLoader(path.join(project.baseDir, '.checkuprc'))()
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"ENOENT: no such file or directory, open '${path.join(project.baseDir, '.checkuprc')}'"`
+    );
+  });
+
+  it('should return the config if found', async () => {
+    project.addCheckupConfig(defaultConfig).writeSync();
+    const config = await getFilepathLoader(path.join(project.baseDir, '.checkuprc'))();
+
+    expect(config).toStrictEqual({
+      format: CheckupConfigFormat.JSON,
+      filepath: path.join(project.baseDir, '.checkuprc'),
+      config: defaultConfig,
+    });
+  });
+});

--- a/packages/core/src/configuration/loaders/get-filepath-loader.ts
+++ b/packages/core/src/configuration/loaders/get-filepath-loader.ts
@@ -13,11 +13,19 @@ import CosmiconfigService from '../cosmiconfig-service';
 const getFilepathLoader: (filepath: string) => CheckupConfigLoader = (
   filepath: string
 ) => async () => {
-  const maybeConfig = await new CosmiconfigService().load(filepath);
+  let maybeConfig;
+  try {
+    maybeConfig = await new CosmiconfigService().load(filepath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error(`Could not find checkup configuration file at ${filepath}`);
+    }
+    throw error;
+  }
 
   if (maybeConfig === null) {
     throw new Error(
-      `Could not find a checkup configuration starting at: ${filepath}. See https://github.com/checkupjs/checkup/tree/master/packages/cli#configuration for more info on how to setup a configuration.`
+      `Could not find a checkup configuration at: ${filepath}. See https://github.com/checkupjs/checkup/tree/master/packages/cli#configuration for more info on how to setup a configuration.`
     );
   }
 

--- a/packages/core/src/configuration/loaders/get-filepath-loader.ts
+++ b/packages/core/src/configuration/loaders/get-filepath-loader.ts
@@ -1,0 +1,27 @@
+import { CheckupConfigLoader } from '../../types';
+import CosmiconfigService from '../cosmiconfig-service';
+
+/**
+ * A function to get an instance of a {@link CheckupConfigLoader} that
+ * uses {@link cosmiconfig#load} to get a {@link CheckupConfig} object
+ * at the given filepath
+ *
+ * @param {string} filepath - the file path to the config file
+ * @returns {CheckupConfigLoader} - a loader that loads the config at the given
+ * filepath
+ */
+const getFilepathLoader: (filepath: string) => CheckupConfigLoader = (
+  filepath: string
+) => async () => {
+  const maybeConfig = await new CosmiconfigService().load(filepath);
+
+  if (maybeConfig === null) {
+    throw new Error(
+      `Could not find a checkup configuration starting at: ${filepath}. See https://github.com/checkupjs/checkup/tree/master/packages/cli#configuration for more info on how to setup a configuration.`
+    );
+  }
+
+  return maybeConfig;
+};
+
+export default getFilepathLoader;

--- a/packages/core/src/configuration/loaders/get-search-loader.ts
+++ b/packages/core/src/configuration/loaders/get-search-loader.ts
@@ -4,6 +4,7 @@ import CosmiconfigService from '../cosmiconfig-service';
 /**
  * A function to get an instance of a {@link CheckupConfigLoader} that
  * uses {@link cosmiconfig#search} to get a {@link CheckupConfig} object
+ *
  * @param {string} basePath - the base path to start the config search in
  * @returns {CheckupConfigLoader} - a loader that searches the given basePath for
  * a config

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { loadPlugins } from './loaders/plugin-loader';
 export { getPackageJson } from './utils/get-package-json';
 export { default as CheckupConfigService } from './configuration/checkup-config-service';
 export { default as getSearchLoader } from './configuration/loaders/get-search-loader';
+export { default as getFilepathLoader } from './configuration/loaders/get-filepath-loader';
 export { ui } from './utils/ui';
 export { toPairs } from './utils/data-transformers';
 


### PR DESCRIPTION
Add --config flag to checkup cli that allows users to optionally pass in
an explcit path to the config file to be loaded.