### PR TITLE
PDF reporter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,14 +5,13 @@
     "ecmaVersion": 2017,
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "filenames", "jest", "jsdoc", "prettier"],
+  "plugins": ["@typescript-eslint", "filenames", "jest", "prettier"],
   "extends": [
     "eslint:recommended",
     "prettier",
     "prettier/@typescript-eslint",
     "plugin:jest/recommended",
     "plugin:jest/style",
-    "plugin:jsdoc/recommended",
     "plugin:unicorn/recommended"
   ],
   "env": {
@@ -24,7 +23,8 @@
     "prettier/prettier": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "no-global-assign": ["error", { "exceptions": ["console"] }]
+    "no-global-assign": ["error", { "exceptions": ["console"] }],
+    "unicorn/prevent-abbreviations": "off"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-jest": "^23.8.2",
-    "eslint-plugin-jsdoc": "^22.0.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-unicorn": "^16.1.1",

--- a/packages/cli/__tests__/__fixtures__/report.html
+++ b/packages/cli/__tests__/__fixtures__/report.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkup Report</title>
+  </head>
+  <body>
+    Basic Checkup Report
+  </body>
+</html>

--- a/packages/cli/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/index-test.ts.snap
@@ -15,8 +15,51 @@ mock task3 is being run
 
 exports[`@checkup/cli normal cli output with plugins should output checkup result in JSON 1`] = `
 "{
-  \\"mockTask\\": 15,
-  \\"mockTask2\\": 10
+  \\"core\\": {
+    \\"high\\": [
+      {
+        \\"meta\\": {
+          \\"taskName\\": \\"mock-task\\",
+          \\"friendlyTaskName\\": \\"Mock Task\\",
+          \\"taskClassification\\": {
+            \\"category\\": \\"core\\",
+            \\"priority\\": \\"high\\"
+          }
+        },
+        \\"result\\": {
+          \\"mockTask1\\": 5
+        }
+      },
+      {
+        \\"meta\\": {
+          \\"taskName\\": \\"mock-task2\\",
+          \\"friendlyTaskName\\": \\"Mock Task 2\\",
+          \\"taskClassification\\": {
+            \\"category\\": \\"core\\",
+            \\"priority\\": \\"high\\"
+          }
+        },
+        \\"result\\": {
+          \\"mockTask2\\": 10
+        }
+      },
+      {
+        \\"meta\\": {
+          \\"taskName\\": \\"mock-task3\\",
+          \\"friendlyTaskName\\": \\"Mock Task 3\\",
+          \\"taskClassification\\": {
+            \\"category\\": \\"core\\",
+            \\"priority\\": \\"high\\"
+          }
+        },
+        \\"result\\": {
+          \\"mockTask2\\": 10
+        }
+      }
+    ],
+    \\"medium\\": [],
+    \\"low\\": []
+  }
 }
 "
 `;

--- a/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TaskList runTask will run a task by taskName 1`] = `
+Object {
+  "meta": Object {
+    "friendlyTaskName": "Mock Task",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "high",
+    },
+    "taskName": "mock-task",
+  },
+  "result": "mock task is being run",
+}
+`;
+
+exports[`TaskList runTasks will run all registered tasks 1`] = `
+Object {
+  "meta": Object {
+    "friendlyTaskName": "Mock Task",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "high",
+    },
+    "taskName": "mock-task",
+  },
+  "result": "mock task is being run",
+}
+`;
+
+exports[`TaskList runTasks will run all registered tasks 2`] = `
+Object {
+  "meta": Object {
+    "friendlyTaskName": "Another Mock Task",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "low",
+    },
+    "taskName": "another-mock-task",
+  },
+  "result": "another mock task is being run",
+}
+`;

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -1,0 +1,18 @@
+import { BaseTaskResult, Task, TaskResult } from '@checkup/core';
+
+export default class MockTaskResult extends BaseTaskResult implements TaskResult {
+  constructor(task: Task, public result: string) {
+    super(task);
+  }
+
+  stdout() {
+    process.stdout.write(`Result for ${this.meta.taskName}`);
+  }
+
+  json() {
+    return {
+      meta: this.meta,
+      result: this.result,
+    };
+  }
+}

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -150,7 +150,7 @@ describe('@checkup/cli', () => {
       expect(fs.existsSync(outputPath)).toEqual(true);
 
       fs.unlinkSync(outputPath);
-    }, 10000);
+    }, 15000);
 
     it('should output a PDF in a custom directory if the pdf reporter and reporterOutputPath options are provided', async () => {
       let tmp = createTmpDir();
@@ -165,7 +165,7 @@ describe('@checkup/cli', () => {
       expect(fs.existsSync(outputPath)).toEqual(true);
 
       fs.unlinkSync(outputPath);
-    }, 10000);
+    }, 15000);
 
     it('should run a single task if the task option is specified', async () => {
       await cmd.run(['--task', 'mock-task', project.baseDir]);

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -1,6 +1,8 @@
-import { CheckupConfig, Task } from '@checkup/core';
-import { CheckupProject, Plugin, stdout } from '@checkup/test-helpers';
+import * as fs from 'fs';
 import * as path from 'path';
+
+import { Category, CheckupConfig, Priority, Task } from '@checkup/core';
+import { CheckupProject, Plugin, createTmpDir, stdout } from '@checkup/test-helpers';
 
 import cmd = require('../src');
 
@@ -15,18 +17,28 @@ describe('@checkup/cli', () => {
             taskName = 'mock-task';
             friendlyTaskName = 'Mock Task';
             taskClassification = {
-              category: 0,
-              priority: 0,
+              category: Category.Core,
+              priority: Priority.High,
             };
 
             async run() {
               return {
-                toJson() {
+                json() {
                   return {
-                    mockTask: 5,
+                    meta: {
+                      taskName: 'mock-task',
+                      friendlyTaskName: 'Mock Task',
+                      taskClassification: {
+                        category: Category.Core,
+                        priority: Priority.High,
+                      },
+                    },
+                    result: {
+                      mockTask1: 5,
+                    },
                   };
                 },
-                toConsole() {
+                stdout() {
                   process.stdout.write('mock task is being run\n');
                 },
               };
@@ -38,18 +50,28 @@ describe('@checkup/cli', () => {
             taskName = 'mock-task2';
             friendlyTaskName = 'Mock Task 2';
             taskClassification = {
-              category: 0,
-              priority: 0,
+              category: Category.Core,
+              priority: Priority.High,
             };
 
             async run() {
               return {
-                toJson() {
+                json() {
                   return {
-                    mockTask2: 10,
+                    meta: {
+                      taskName: 'mock-task2',
+                      friendlyTaskName: 'Mock Task 2',
+                      taskClassification: {
+                        category: Category.Core,
+                        priority: Priority.High,
+                      },
+                    },
+                    result: {
+                      mockTask2: 10,
+                    },
                   };
                 },
-                toConsole() {
+                stdout() {
                   process.stdout.write('mock task2 is being run\n');
                 },
               };
@@ -61,18 +83,28 @@ describe('@checkup/cli', () => {
           taskName = 'mock-task3';
           friendlyTaskName = 'Mock Task3';
           taskClassification = {
-            category: 0,
-            priority: 0,
+            category: Category.Core,
+            priority: Priority.High,
           };
 
           async run() {
             return {
-              toJson() {
+              json() {
                 return {
-                  mockTask: 15,
+                  meta: {
+                    taskName: 'mock-task3',
+                    friendlyTaskName: 'Mock Task 3',
+                    taskClassification: {
+                      category: Category.Core,
+                      priority: Priority.High,
+                    },
+                  },
+                  result: {
+                    mockTask2: 10,
+                  },
                 };
               },
-              toConsole() {
+              stdout() {
                 process.stdout.write('mock task3 is being run\n');
               },
             };
@@ -102,10 +134,38 @@ describe('@checkup/cli', () => {
     });
 
     it('should output checkup result in JSON', async () => {
-      await cmd.run(['--json', project.baseDir]);
+      await cmd.run(['--reporter', 'json', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });
+
+    it('should output a PDF in the current directory if the pdf reporter option is provided', async () => {
+      await cmd.run(['--reporter', 'pdf', project.baseDir]);
+
+      let outputPath = stdout().trim();
+
+      expect(outputPath).toMatch(
+        /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.pdf/
+      );
+      expect(fs.existsSync(outputPath)).toEqual(true);
+
+      fs.unlinkSync(outputPath);
+    }, 10000);
+
+    it('should output a PDF in a custom directory if the pdf reporter and reporterOutputPath options are provided', async () => {
+      let tmp = createTmpDir();
+
+      await cmd.run(['--reporter', 'pdf', `--reportOutputPath`, tmp, project.baseDir]);
+
+      let outputPath = stdout().trim();
+
+      expect(outputPath).toMatch(
+        /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.pdf/
+      );
+      expect(fs.existsSync(outputPath)).toEqual(true);
+
+      fs.unlinkSync(outputPath);
+    }, 10000);
 
     it('should run a single task if the task option is specified', async () => {
       await cmd.run(['--task', 'mock-task', project.baseDir]);

--- a/packages/cli/__tests__/print-to-pdf-test.ts
+++ b/packages/cli/__tests__/print-to-pdf-test.ts
@@ -1,0 +1,17 @@
+import { join, resolve } from 'path';
+
+import { createTmpDir } from '@checkup/test-helpers';
+import { existsSync } from 'fs';
+import { pathToFileURL } from 'url';
+import { printToPDF } from '../src/helpers/print-to-pdf';
+
+describe('print-to-pdf', () => {
+  it('prints dummy file to PDF', async () => {
+    let tmp = createTmpDir();
+    let outputFilePath = join(tmp, 'tmp-report.pdf');
+    let htmlPath = resolve('./__fixtures__/report.html');
+    await printToPDF(pathToFileURL(htmlPath).toString(), outputFilePath);
+
+    expect(existsSync(outputFilePath)).toEqual(true);
+  });
+});

--- a/packages/cli/__tests__/priority-map-test.ts
+++ b/packages/cli/__tests__/priority-map-test.ts
@@ -1,5 +1,6 @@
-import { Category, Priority, Task, TaskClassification, TaskName } from '@checkup/core';
+import { Category, Priority, Task, TaskClassification, TaskName, TaskResult } from '@checkup/core';
 
+import MockTaskResult from './__utils__/mock-task-result';
 import PriorityMap from '../src/priority-map';
 
 class MockTask implements Task {
@@ -10,17 +11,8 @@ class MockTask implements Task {
     priority: Priority.High,
   };
 
-  async run() {
-    return {
-      toJson() {
-        return {
-          mockTask: 'You mock me',
-        };
-      },
-      toConsole() {
-        process.stdout.write('mock task is being run\n');
-      },
-    };
+  async run(): Promise<TaskResult> {
+    return new MockTaskResult(this, 'mock task is being run');
   }
 }
 

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -1,5 +1,6 @@
-import { Category, Priority, Task, TaskClassification, TaskName } from '@checkup/core';
+import { Category, Priority, Task, TaskClassification, TaskName, TaskResult } from '@checkup/core';
 
+import MockTaskResult from './__utils__/mock-task-result';
 import TaskList from '../src/task-list';
 
 class MockTask implements Task {
@@ -10,17 +11,8 @@ class MockTask implements Task {
     priority: Priority.High,
   };
 
-  run() {
-    return Promise.resolve({
-      toJson() {
-        return {
-          mockTask: 'You mock me',
-        };
-      },
-      toConsole() {
-        process.stdout.write('mock task is being run\n');
-      },
-    });
+  async run(): Promise<TaskResult> {
+    return new MockTaskResult(this, 'mock task is being run');
   }
 }
 
@@ -32,17 +24,8 @@ class AnotherMockTask implements Task {
     priority: Priority.Low,
   };
 
-  run() {
-    return Promise.resolve({
-      toJson() {
-        return {
-          anotherMockTask: 'You mock me, yet again',
-        };
-      },
-      toConsole() {
-        process.stdout.write('another mock task is being run\n');
-      },
-    });
+  async run(): Promise<TaskResult> {
+    return new MockTaskResult(this, 'another mock task is being run');
   }
 }
 
@@ -69,9 +52,7 @@ describe('TaskList', () => {
 
     let result = await taskList.runTask('mock-task');
 
-    expect(result.toJson()).toStrictEqual({
-      mockTask: 'You mock me',
-    });
+    expect(result.json()).toMatchSnapshot();
   });
 
   it('runTasks will run all registered tasks', async () => {
@@ -82,11 +63,7 @@ describe('TaskList', () => {
 
     let result = await taskList.runTasks();
 
-    expect(result[0].toJson()).toStrictEqual({
-      mockTask: 'You mock me',
-    });
-    expect(result[1].toJson()).toStrictEqual({
-      anotherMockTask: 'You mock me, yet again',
-    });
+    expect(result[0].json()).toMatchSnapshot();
+    expect(result[1].json()).toMatchSnapshot();
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,10 +15,14 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
+    "chrome-debugging-client": "^1.2.0",
     "cli-ux": "^5.4.4",
+    "date-and-time": "^0.12.0",
+    "devtools-protocol": "^0.0.746878",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.0",
     "p-map": "^4.0.0",
+    "tmp": "^0.1.0",
     "tslib": "^1"
   },
   "devDependencies": {
@@ -27,9 +31,11 @@
     "@oclif/dev-cli": "^1",
     "@oclif/test": "^1",
     "@types/chai": "^4",
+    "@types/date-and-time": "^0.6.0",
     "@types/fs-extra": "^8.1.0",
     "@types/jest": "^25.1.3",
     "@types/node": "^13",
+    "@types/tmp": "^0.1.0",
     "chai": "^4.2.0",
     "jest": "^25.1.0",
     "stdout-stderr": "^0.1.13",
@@ -56,12 +62,13 @@
   },
   "repository": "https://github.com/checkupjs/checkup",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && yarn copystatic",
     "build:watch": "yarn build -w",
     "clean": "rm -rf lib/*",
     "prepack": "yarn build && oclif-dev readme",
     "test": "jest",
-    "version": "oclif-dev readme && git add README.md"
+    "version": "oclif-dev readme && git add README.md",
+    "copystatic": "cp -a ./src/static ./lib/static"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/cli/src/helpers/pdf.ts
+++ b/packages/cli/src/helpers/pdf.ts
@@ -1,0 +1,42 @@
+import * as Handlebars from 'handlebars';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { JsonObject } from 'type-fest';
+import { pathToFileURL } from 'url';
+import { printToPDF } from './print-to-pdf';
+import { readFileSync } from 'fs-extra';
+
+import tmp = require('tmp');
+
+const date = require('date-and-time');
+const REPORT_PATH = path.join(__dirname, '../static/report-template.hbs');
+
+let REPORT_TEMPLATE_RAW = readFileSync(REPORT_PATH, 'utf8');
+/**
+ * @param jsonResult
+ * @param results
+ */
+export async function generateReport(
+  resultOutputPath: string,
+  jsonResult: JsonObject
+): Promise<string> {
+  const template = Handlebars.compile(REPORT_TEMPLATE_RAW);
+  let tmpDir = fs.realpathSync(tmp.dirSync({ unsafeCleanup: true }).name);
+  let htmlTmpPath = path.resolve(path.join(tmpDir, 'tmp-report.html'));
+
+  let reportHTML = template(jsonResult);
+
+  fs.writeFileSync(htmlTmpPath, reportHTML);
+
+  let outputFilePath = path.resolve(
+    path.join(
+      resultOutputPath,
+      `checkup-report-${date.format(new Date(), 'YYYY-MM-DD-HH-mm-ss')}.pdf`
+    )
+  );
+
+  await printToPDF(pathToFileURL(htmlTmpPath).toString(), outputFilePath);
+
+  return outputFilePath;
+}

--- a/packages/cli/src/helpers/print-to-pdf.ts
+++ b/packages/cli/src/helpers/print-to-pdf.ts
@@ -1,0 +1,30 @@
+import { spawnChrome } from 'chrome-debugging-client';
+import { writeFileSync } from 'fs-extra';
+
+/**
+ * Spawn a chrome process and visit the given url. Wait until page load event is fired
+ * and then create PDF.
+ *
+ * @param url - URL of page for chrome to visit
+ * @param outputPath - Output pdf to this file
+ */
+export async function printToPDF(url: string, outputPath: string) {
+  const chrome = spawnChrome({ headless: true });
+  try {
+    const browser = chrome.connection;
+    const { targetId } = await browser.send('Target.createTarget', {
+      url: 'about:blank',
+    });
+    const page = await browser.attachToTarget(targetId);
+
+    await page.send('Page.enable');
+    await Promise.all([page.until('Page.loadEventFired'), page.send('Page.navigate', { url })]);
+    const { data } = await page.send('Page.printToPDF', {});
+
+    writeFileSync(outputPath, Buffer.from(data, 'base64'));
+
+    await chrome.close();
+  } finally {
+    await chrome.dispose();
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,28 +1,41 @@
 import * as path from 'path';
 
-import { Command, flags } from '@oclif/command';
-
 import {
+  Category,
+  CheckupConfigService,
+  Priority,
   TaskResult,
+  getFilepathLoader,
   getPackageJson,
+  getSearchLoader,
   loadPlugins,
   ui,
-  getSearchLoader,
-  getFilepathLoader,
-  CheckupConfigService,
 } from '@checkup/core';
+import { Command, flags } from '@oclif/command';
 import { getRegisteredParsers, registerParser } from './parsers';
 
 import TaskList from './task-list';
+import { generateReport } from './helpers/pdf';
 
-/**
- * @param taskResults
- */
+enum ReporterType {
+  stdout = 'stdout',
+  json = 'json',
+  pdf = 'pdf',
+}
+
 function mergeTaskResults(taskResults: TaskResult[]) {
-  let mergedResults = {};
+  let mergedResults: any = {
+    [Category.Core]: {
+      [Priority.High]: [],
+      [Priority.Medium]: [],
+      [Priority.Low]: [],
+    },
+  };
 
   taskResults.forEach(taskResult => {
-    mergedResults = Object.assign(mergedResults, taskResult.toJson());
+    let json = taskResult.json();
+    let { category, priority } = json.meta.taskClassification;
+    mergedResults[category][priority].push(json);
   });
 
   return mergedResults;
@@ -45,7 +58,15 @@ class Checkup extends Command {
     help: flags.help({ char: 'h' }),
     force: flags.boolean({ char: 'f' }),
     silent: flags.boolean({ char: 's' }),
-    json: flags.boolean(),
+    reporter: flags.string({
+      char: 'r',
+      options: [...Object.values(ReporterType)],
+      default: 'stdout',
+    }),
+    reportOutputPath: flags.string({
+      char: 'o',
+      default: '.',
+    }),
     task: flags.string({ char: 't' }),
     config: flags.string({
       char: 'c',
@@ -53,62 +74,87 @@ class Checkup extends Command {
     }),
   };
 
+  tasks: TaskList = new TaskList();
+  taskResults: TaskResult[] = [];
+
   async run() {
     let { args, flags } = this.parse(Checkup);
-    let taskResults: TaskResult[];
-    let registeredTasks: TaskList = new TaskList();
 
+    ui.action.start('Checking up on your project');
+
+    await this.loadConfig(flags.config, args.path);
+
+    this.validatePackageJson(args.path);
+
+    await this.runHooks(args);
+
+    if (flags.task !== undefined) {
+      this.taskResults = [await this.tasks.runTask(flags.task)];
+    } else {
+      this.taskResults = await this.tasks.runTasks();
+    }
+
+    await this.outputResults(flags);
+
+    ui.action.stop();
+  }
+
+  private async loadConfig(configFlag: any, pathArgument: string) {
     try {
-      const configLoader = flags.config
-        ? getFilepathLoader(flags.config)
-        : getSearchLoader(args.path);
+      const configLoader = configFlag
+        ? getFilepathLoader(configFlag)
+        : getSearchLoader(pathArgument);
       const configService = await CheckupConfigService.load(configLoader);
       const checkupConfig = configService.get();
-      let plugins = await loadPlugins(checkupConfig.plugins, args.path);
+      let plugins = await loadPlugins(checkupConfig.plugins, pathArgument);
       this.config.plugins.push(...plugins);
     } catch (error) {
       this.error(error);
     }
+  }
 
+  private validatePackageJson(pathArgument: string) {
     try {
-      getPackageJson(args.path);
+      getPackageJson(pathArgument);
     } catch (error) {
       this.error(
         `The ${path.resolve(
-          args.path
+          pathArgument
         )} directory found through the 'path' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`,
         error
       );
     }
+  }
 
+  private async runHooks(cliArguments: any) {
     await this.config.runHook('register-parsers', {
       registerParser,
     });
 
     await this.config.runHook('register-tasks', {
-      cliArguments: args,
+      cliArguments: cliArguments,
       cliFlags: flags,
       parsers: getRegisteredParsers(),
-      tasks: registeredTasks,
+      tasks: this.tasks,
     });
+  }
 
-    if (flags.task !== undefined) {
-      taskResults = [await registeredTasks.runTask(flags.task)];
-    } else {
-      taskResults = await registeredTasks.runTasks();
-    }
-
-    ui.action.start('Checking up on your project');
-
+  private async outputResults(flags: any) {
     if (!flags.silent) {
-      if (flags.json) {
-        ui.styledJSON(mergeTaskResults(taskResults));
+      if (flags.reporter !== ReporterType.stdout) {
+        let resultJson = mergeTaskResults(this.taskResults);
+
+        if (flags.reporter === ReporterType.json) {
+          ui.styledJSON(resultJson);
+        } else {
+          let reportPath = await generateReport(flags.reportOutputPath, resultJson);
+
+          ui.log(reportPath);
+        }
       } else {
-        taskResults.forEach(taskResult => taskResult.toConsole());
+        this.taskResults.forEach(taskResult => taskResult.stdout());
       }
     }
-
-    ui.action.stop();
   }
 }
 

--- a/packages/cli/src/static/report-template.hbs
+++ b/packages/cli/src/static/report-template.hbs
@@ -1,0 +1,18 @@
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Checkup report</title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  Checkup report
+
+  {{#each core as |priority|}}
+      {{#each priority as |taskResult|}}
+        {{taskResult.meta.taskName}}
+      {{/each}}
+    {{/each}}
+</body>
+</html>

--- a/packages/core/src/base-task-result.ts
+++ b/packages/core/src/base-task-result.ts
@@ -7,6 +7,7 @@ export default abstract class BaseTaskResult {
     this.meta = {
       taskName: task.taskName,
       friendlyTaskName: task.friendlyTaskName,
+      taskClassification: task.taskClassification,
     };
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,6 +1,7 @@
+import * as t from 'io-ts';
+
 import { JsonObject, PromiseValue } from 'type-fest';
 import { RuntimeCheckupConfig, RuntimeTaskConfig } from './runtime-types';
-import * as t from 'io-ts';
 
 export type CheckupConfig = t.TypeOf<typeof RuntimeCheckupConfig>;
 export type TaskConfig = t.TypeOf<typeof RuntimeTaskConfig>;
@@ -11,15 +12,15 @@ export interface Parser {
 }
 
 export const enum Category {
-  Core,
-  Migration,
-  Insights,
+  Core = 'core',
+  Migration = 'migration',
+  Insights = 'insights',
 }
 
 export const enum Priority {
-  High,
-  Medium,
-  Low,
+  High = 'high',
+  Medium = 'medium',
+  Low = 'low',
 }
 
 export type TaskName = string;
@@ -36,14 +37,20 @@ export interface Task {
   run: () => Promise<TaskResult>;
 }
 
+export type JsonTaskResult = {
+  meta: TaskMetaData;
+  result: {};
+};
+
 export interface TaskResult {
-  toConsole: () => void;
-  toJson: () => {};
+  stdout: () => void;
+  json: () => JsonTaskResult;
 }
 
 export interface TaskMetaData {
   taskName: TaskName;
   friendlyTaskName: TaskName;
+  taskClassification: TaskClassification;
 }
 
 export interface TaskItemData {

--- a/packages/plugin-default/__tests__/__snapshots__/project-info-task-test.ts.snap
+++ b/packages/plugin-default/__tests__/__snapshots__/project-info-task-test.ts.snap
@@ -17,7 +17,15 @@ Total files:   0
 
 exports[`project-info-task for Projects can read project info as JSON 1`] = `
 Object {
-  "project-info": Object {
+  "meta": Object {
+    "friendlyTaskName": "Project Information",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "high",
+    },
+    "taskName": "project-info",
+  },
+  "result": Object {
     "name": "checkup-app",
     "repository": Object {
       "activeDays": "0 days",

--- a/packages/plugin-default/__tests__/project-info-task-test.ts
+++ b/packages/plugin-default/__tests__/project-info-task-test.ts
@@ -23,7 +23,7 @@ describe('project-info-task', () => {
       const result = await new ProjectInfoTask({ path: checkupProject.baseDir }).run();
       const taskResult = <ProjectInfoTaskResult>result;
 
-      taskResult.toConsole();
+      taskResult.stdout();
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -32,7 +32,7 @@ describe('project-info-task', () => {
       const result = await new ProjectInfoTask({ path: checkupProject.baseDir }).run();
       const taskResult = <ProjectInfoTaskResult>result;
 
-      expect(taskResult.toJson()).toMatchSnapshot();
+      expect(taskResult.json()).toMatchSnapshot();
     });
   });
 });

--- a/packages/plugin-default/src/results/project-info-task-result.ts
+++ b/packages/plugin-default/src/results/project-info-task-result.ts
@@ -7,7 +7,7 @@ export default class ProjectInfoTaskResult extends BaseTaskResult implements Tas
   version!: string;
   repository!: RepositoryInfo;
 
-  toConsole() {
+  stdout() {
     ui.styledHeader(this.meta.friendlyTaskName);
     ui.blankLine();
     ui.styledObject({
@@ -26,9 +26,10 @@ export default class ProjectInfoTaskResult extends BaseTaskResult implements Tas
     ui.blankLine();
   }
 
-  toJson() {
+  json() {
     return {
-      [this.meta.taskName]: {
+      meta: this.meta,
+      result: {
         name: this.name,
         version: this.version,
         repository: this.repository,

--- a/packages/plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -1,14 +1,16 @@
-import { stdout } from '@checkup/test-helpers';
-import { OctaneMigrationStatusTaskResult } from '../../src/results';
 import { MigrationType } from '../../src/results/octane-migration-status-task-result';
+import { OctaneMigrationStatusTask } from '../../src/tasks';
+import { OctaneMigrationStatusTaskResult } from '../../src/results';
+import { stdout } from '@checkup/test-helpers';
 
 describe('octane-migration-status-task-result', () => {
   describe('console output', () => {
     test('simple console output', async () => {
       let sampleOctaneReport = require('../__fixtures__/sample-octane-eslint-report.json');
-      let taskResult = new OctaneMigrationStatusTaskResult(sampleOctaneReport);
+      let task = new OctaneMigrationStatusTask({});
+      let taskResult = new OctaneMigrationStatusTaskResult(task, sampleOctaneReport);
 
-      taskResult.toConsole();
+      taskResult.stdout();
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -17,10 +19,11 @@ describe('octane-migration-status-task-result', () => {
   describe('JSON output', () => {
     test('it should have basic JSON results', () => {
       let sampleOctaneReport = require('../__fixtures__/sample-octane-eslint-report.json');
-      let taskResult = new OctaneMigrationStatusTaskResult(sampleOctaneReport);
+      let task = new OctaneMigrationStatusTask({});
+      let taskResult = new OctaneMigrationStatusTaskResult(task, sampleOctaneReport);
 
-      let jsonResults = taskResult.toJson();
-      let { totalViolations, migrationTasks } = jsonResults;
+      let jsonResults = taskResult.json();
+      let { totalViolations, migrationTasks } = jsonResults.result;
       let nativeClassesMigrationInfo = migrationTasks[MigrationType.NativeClasses];
 
       expect(totalViolations).toBe(17);
@@ -30,10 +33,11 @@ describe('octane-migration-status-task-result', () => {
 
     test('it should output detailed completion data', () => {
       let sampleOctaneReport = require('../__fixtures__/sample-octane-eslint-report.json');
-      let taskResult = new OctaneMigrationStatusTaskResult(sampleOctaneReport);
+      let task = new OctaneMigrationStatusTask({});
+      let taskResult = new OctaneMigrationStatusTaskResult(task, sampleOctaneReport);
 
-      let jsonResults = taskResult.toJson();
-      let { migrationTasks } = jsonResults;
+      let jsonResults = taskResult.json();
+      let { migrationTasks } = jsonResults.result;
       let nativeClassesMigrationInfo = migrationTasks[MigrationType.NativeClasses];
 
       expect(nativeClassesMigrationInfo).toBeDefined();

--- a/packages/plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -1,5 +1,6 @@
+import { BaseTaskResult, Task, TaskResult, ui } from '@checkup/core';
+
 import { CLIEngine } from 'eslint';
-import { TaskResult, ui } from '@checkup/core';
 
 // classic-decorator-hooks                  -
 // classic-decorator-no-classic-methods     -
@@ -100,12 +101,14 @@ function getMigrationInfo(
   };
 }
 
-export default class OctaneMigrationStatusTaskResult implements TaskResult {
+export default class OctaneMigrationStatusTaskResult extends BaseTaskResult implements TaskResult {
   taskName: string = 'Octane Migration Status';
 
-  constructor(public report: CLIEngine.LintReport) {}
+  constructor(task: Task, public report: CLIEngine.LintReport) {
+    super(task);
+  }
 
-  toConsole() {
+  stdout() {
     ui.styledHeader(this.taskName);
     ui.blankLine();
     ui.styledObject({
@@ -114,7 +117,7 @@ export default class OctaneMigrationStatusTaskResult implements TaskResult {
     ui.blankLine();
   }
 
-  toJson() {
+  json() {
     let nativeClassMigrationInfo = getMigrationInfo(
       MIGRATION_RULE_CONFIGS[MigrationType.NativeClasses],
       this.report
@@ -136,12 +139,15 @@ export default class OctaneMigrationStatusTaskResult implements TaskResult {
     );
 
     return {
-      totalViolations: this.report.errorCount,
-      migrationTasks: {
-        [MigrationType.NativeClasses]: nativeClassMigrationInfo,
-        [MigrationType.TaglessComponents]: taglessComponentMigrationInfo,
-        [MigrationType.GlimmerComponents]: glimmerComponentsMigrationinfo,
-        [MigrationType.TrackedProperties]: trackedPropertiesMigrationInfo,
+      meta: this.meta,
+      result: {
+        totalViolations: this.report.errorCount,
+        migrationTasks: {
+          [MigrationType.NativeClasses]: nativeClassMigrationInfo,
+          [MigrationType.TaglessComponents]: taglessComponentMigrationInfo,
+          [MigrationType.GlimmerComponents]: glimmerComponentsMigrationinfo,
+          [MigrationType.TrackedProperties]: trackedPropertiesMigrationInfo,
+        },
       },
     };
   }

--- a/packages/plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -1,4 +1,5 @@
 import { BaseTask, Category, Priority, Task, TaskClassification, TaskName } from '@checkup/core';
+
 import { CLIEngine } from 'eslint';
 import { OctaneMigrationStatusTaskResult } from '../results';
 
@@ -51,7 +52,7 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
 
   async run(): Promise<OctaneMigrationStatusTaskResult> {
     this.report = this.esLintEngine.executeOnFiles([`${this.rootPath}/+(app|addon)/**/*.js`]);
-    let result = new OctaneMigrationStatusTaskResult(this.report);
+    let result = new OctaneMigrationStatusTaskResult(this, this.report);
 
     return result;
   }

--- a/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
@@ -30,7 +30,15 @@ ember-cli-string-utils latest
 
 exports[`dependencies-task detects Ember dependencies as JSON 1`] = `
 Object {
-  "dependencies": Object {
+  "meta": Object {
+    "friendlyTaskName": "Project Dependencies",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "medium",
+    },
+    "taskName": "dependencies",
+  },
+  "result": Object {
     "emberAddons": Object {
       "dependencies": Object {
         "ember-source": "^3.15.0",

--- a/packages/plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
@@ -10,7 +10,15 @@ type: Ember.js addon
 
 exports[`project-info-task for Ember Addons can read project info as JSON 1`] = `
 Object {
-  "ember-project": Object {
+  "meta": Object {
+    "friendlyTaskName": "Ember Project",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "medium",
+    },
+    "taskName": "ember-project",
+  },
+  "result": Object {
     "type": "Ember.js addon",
   },
 }
@@ -26,7 +34,15 @@ type: Ember.js application
 
 exports[`project-info-task for Ember Applications can read project info as JSON 1`] = `
 Object {
-  "ember-project": Object {
+  "meta": Object {
+    "friendlyTaskName": "Ember Project",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "medium",
+    },
+    "taskName": "ember-project",
+  },
+  "result": Object {
     "type": "Ember.js application",
   },
 }

--- a/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
@@ -2,88 +2,98 @@
 
 exports[`types-task returns all the types (including nested) found in the app and outputs to JSON 1`] = `
 Object {
-  "types": Array [
-    Object {
-      "data": Array [
-        "addon/components/my-component.js",
-        "lib/ember-super-button/addon/components/my-component.js",
-      ],
-      "total": 2,
-      "type": "components",
+  "meta": Object {
+    "friendlyTaskName": "Project Types",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "medium",
     },
-    Object {
-      "data": Array [
-        "addon/controllers/my-controller.js",
-        "lib/ember-super-button/addon/controllers/my-controller.js",
-      ],
-      "total": 2,
-      "type": "controllers",
-    },
-    Object {
-      "data": Array [
-        "addon/helpers/my-helper.js",
-        "lib/ember-super-button/addon/helpers/my-helper.js",
-      ],
-      "total": 2,
-      "type": "helpers",
-    },
-    Object {
-      "data": Array [
-        "addon/initializers/my-initializer.js",
-        "lib/ember-super-button/addon/initializers/my-initializer.js",
-      ],
-      "total": 2,
-      "type": "initializers",
-    },
-    Object {
-      "data": Array [
-        "addon/instance-initializers/my-helper.js",
-        "lib/ember-super-button/addon/instance-initializers/my-helper.js",
-      ],
-      "total": 2,
-      "type": "instance-initializers",
-    },
-    Object {
-      "data": Array [
-        "addon/mixins/my-mixin.js",
-        "lib/ember-super-button/addon/mixins/my-mixin.js",
-      ],
-      "total": 2,
-      "type": "mixins",
-    },
-    Object {
-      "data": Array [
-        "addon/models/my-model.js",
-        "lib/ember-super-button/addon/models/my-model.js",
-      ],
-      "total": 2,
-      "type": "models",
-    },
-    Object {
-      "data": Array [
-        "addon/routes/my-route.js",
-        "lib/ember-super-button/addon/routes/my-route.js",
-      ],
-      "total": 2,
-      "type": "routes",
-    },
-    Object {
-      "data": Array [
-        "addon/services/my-service.js",
-        "lib/ember-super-button/addon/services/my-service.js",
-      ],
-      "total": 2,
-      "type": "services",
-    },
-    Object {
-      "data": Array [
-        "addon/templates/my-component.hbs",
-        "lib/ember-super-button/addon/templates/my-component.hbs",
-      ],
-      "total": 2,
-      "type": "templates",
-    },
-  ],
+    "taskName": "types",
+  },
+  "result": Object {
+    "types": Array [
+      Object {
+        "data": Array [
+          "addon/components/my-component.js",
+          "lib/ember-super-button/addon/components/my-component.js",
+        ],
+        "total": 2,
+        "type": "components",
+      },
+      Object {
+        "data": Array [
+          "addon/controllers/my-controller.js",
+          "lib/ember-super-button/addon/controllers/my-controller.js",
+        ],
+        "total": 2,
+        "type": "controllers",
+      },
+      Object {
+        "data": Array [
+          "addon/helpers/my-helper.js",
+          "lib/ember-super-button/addon/helpers/my-helper.js",
+        ],
+        "total": 2,
+        "type": "helpers",
+      },
+      Object {
+        "data": Array [
+          "addon/initializers/my-initializer.js",
+          "lib/ember-super-button/addon/initializers/my-initializer.js",
+        ],
+        "total": 2,
+        "type": "initializers",
+      },
+      Object {
+        "data": Array [
+          "addon/instance-initializers/my-helper.js",
+          "lib/ember-super-button/addon/instance-initializers/my-helper.js",
+        ],
+        "total": 2,
+        "type": "instance-initializers",
+      },
+      Object {
+        "data": Array [
+          "addon/mixins/my-mixin.js",
+          "lib/ember-super-button/addon/mixins/my-mixin.js",
+        ],
+        "total": 2,
+        "type": "mixins",
+      },
+      Object {
+        "data": Array [
+          "addon/models/my-model.js",
+          "lib/ember-super-button/addon/models/my-model.js",
+        ],
+        "total": 2,
+        "type": "models",
+      },
+      Object {
+        "data": Array [
+          "addon/routes/my-route.js",
+          "lib/ember-super-button/addon/routes/my-route.js",
+        ],
+        "total": 2,
+        "type": "routes",
+      },
+      Object {
+        "data": Array [
+          "addon/services/my-service.js",
+          "lib/ember-super-button/addon/services/my-service.js",
+        ],
+        "total": 2,
+        "type": "services",
+      },
+      Object {
+        "data": Array [
+          "addon/templates/my-component.hbs",
+          "lib/ember-super-button/addon/templates/my-component.hbs",
+        ],
+        "total": 2,
+        "type": "templates",
+      },
+    ],
+  },
 }
 `;
 
@@ -107,78 +117,88 @@ templates             2
 
 exports[`types-task returns all the types found in the app and outputs to JSON 1`] = `
 Object {
-  "types": Array [
-    Object {
-      "data": Array [
-        "addon/components/my-component.js",
-      ],
-      "total": 1,
-      "type": "components",
+  "meta": Object {
+    "friendlyTaskName": "Project Types",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "medium",
     },
-    Object {
-      "data": Array [
-        "addon/controllers/my-controller.js",
-      ],
-      "total": 1,
-      "type": "controllers",
-    },
-    Object {
-      "data": Array [
-        "addon/helpers/my-helper.js",
-      ],
-      "total": 1,
-      "type": "helpers",
-    },
-    Object {
-      "data": Array [
-        "addon/initializers/my-initializer.js",
-      ],
-      "total": 1,
-      "type": "initializers",
-    },
-    Object {
-      "data": Array [
-        "addon/instance-initializers/my-helper.js",
-      ],
-      "total": 1,
-      "type": "instance-initializers",
-    },
-    Object {
-      "data": Array [
-        "addon/mixins/my-mixin.js",
-      ],
-      "total": 1,
-      "type": "mixins",
-    },
-    Object {
-      "data": Array [
-        "addon/models/my-model.js",
-      ],
-      "total": 1,
-      "type": "models",
-    },
-    Object {
-      "data": Array [
-        "addon/routes/my-route.js",
-      ],
-      "total": 1,
-      "type": "routes",
-    },
-    Object {
-      "data": Array [
-        "addon/services/my-service.js",
-      ],
-      "total": 1,
-      "type": "services",
-    },
-    Object {
-      "data": Array [
-        "addon/templates/my-component.hbs",
-      ],
-      "total": 1,
-      "type": "templates",
-    },
-  ],
+    "taskName": "types",
+  },
+  "result": Object {
+    "types": Array [
+      Object {
+        "data": Array [
+          "addon/components/my-component.js",
+        ],
+        "total": 1,
+        "type": "components",
+      },
+      Object {
+        "data": Array [
+          "addon/controllers/my-controller.js",
+        ],
+        "total": 1,
+        "type": "controllers",
+      },
+      Object {
+        "data": Array [
+          "addon/helpers/my-helper.js",
+        ],
+        "total": 1,
+        "type": "helpers",
+      },
+      Object {
+        "data": Array [
+          "addon/initializers/my-initializer.js",
+        ],
+        "total": 1,
+        "type": "initializers",
+      },
+      Object {
+        "data": Array [
+          "addon/instance-initializers/my-helper.js",
+        ],
+        "total": 1,
+        "type": "instance-initializers",
+      },
+      Object {
+        "data": Array [
+          "addon/mixins/my-mixin.js",
+        ],
+        "total": 1,
+        "type": "mixins",
+      },
+      Object {
+        "data": Array [
+          "addon/models/my-model.js",
+        ],
+        "total": 1,
+        "type": "models",
+      },
+      Object {
+        "data": Array [
+          "addon/routes/my-route.js",
+        ],
+        "total": 1,
+        "type": "routes",
+      },
+      Object {
+        "data": Array [
+          "addon/services/my-service.js",
+        ],
+        "total": 1,
+        "type": "services",
+      },
+      Object {
+        "data": Array [
+          "addon/templates/my-component.hbs",
+        ],
+        "total": 1,
+        "type": "templates",
+      },
+    ],
+  },
 }
 `;
 

--- a/packages/plugin-ember/__tests__/dependencies-task-test.ts
+++ b/packages/plugin-ember/__tests__/dependencies-task-test.ts
@@ -25,7 +25,7 @@ describe('dependencies-task', () => {
     const result = await new DependenciesTask({ path: emberProject.baseDir }).run();
     const dependencyTaskResult = <DependenciesTaskResult>result;
 
-    dependencyTaskResult.toConsole();
+    dependencyTaskResult.stdout();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -34,6 +34,6 @@ describe('dependencies-task', () => {
     const result = await new DependenciesTask({ path: emberProject.baseDir }).run();
     const dependencyTaskResult = <DependenciesTaskResult>result;
 
-    expect(dependencyTaskResult.toJson()).toMatchSnapshot();
+    expect(dependencyTaskResult.json()).toMatchSnapshot();
   });
 });

--- a/packages/plugin-ember/__tests__/ember-project-task-test.ts
+++ b/packages/plugin-ember/__tests__/ember-project-task-test.ts
@@ -26,7 +26,7 @@ describe('project-info-task', () => {
       const result = await new EmberProjectTask({ path: emberProject.baseDir }).run();
       const taskResult = <EmberProjectTaskResult>result;
 
-      taskResult.toConsole();
+      taskResult.stdout();
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -35,7 +35,7 @@ describe('project-info-task', () => {
       const result = await new EmberProjectTask({ path: emberProject.baseDir }).run();
       const taskResult = <EmberProjectTaskResult>result;
 
-      expect(taskResult.toJson()).toMatchSnapshot();
+      expect(taskResult.json()).toMatchSnapshot();
     });
   });
 
@@ -60,7 +60,7 @@ describe('project-info-task', () => {
       const result = await new EmberProjectTask({ path: emberProject.baseDir }).run();
       const taskResult = <EmberProjectTaskResult>result;
 
-      taskResult.toConsole();
+      taskResult.stdout();
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -69,7 +69,7 @@ describe('project-info-task', () => {
       const result = await new EmberProjectTask({ path: emberProject.baseDir }).run();
       const taskResult = <EmberProjectTaskResult>result;
 
-      expect(taskResult.toJson()).toMatchSnapshot();
+      expect(taskResult.json()).toMatchSnapshot();
     });
   });
 });

--- a/packages/plugin-ember/__tests__/types-task-test.ts
+++ b/packages/plugin-ember/__tests__/types-task-test.ts
@@ -58,7 +58,7 @@ describe('types-task', () => {
     const result = await new TypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
-    typesTaskResult.toConsole();
+    typesTaskResult.stdout();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -80,7 +80,7 @@ describe('types-task', () => {
     const result = await new TypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
-    typesTaskResult.toConsole();
+    typesTaskResult.stdout();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -96,7 +96,7 @@ describe('types-task', () => {
     const result = await new TypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
-    expect(typesTaskResult.toJson()).toMatchSnapshot();
+    expect(typesTaskResult.json()).toMatchSnapshot();
   });
 
   it('returns all the types (including nested) found in the app and outputs to JSON', async () => {
@@ -116,6 +116,6 @@ describe('types-task', () => {
     const result = await new TypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
-    expect(typesTaskResult.toJson()).toMatchSnapshot();
+    expect(typesTaskResult.json()).toMatchSnapshot();
   });
 });

--- a/packages/plugin-ember/src/results/dependencies-task-result.ts
+++ b/packages/plugin-ember/src/results/dependencies-task-result.ts
@@ -21,7 +21,7 @@ export default class DependenciesTaskResult extends BaseTaskResult implements Ta
     );
   }
 
-  toConsole() {
+  stdout() {
     if (!this.hasDependencies) {
       return;
     }
@@ -42,9 +42,10 @@ export default class DependenciesTaskResult extends BaseTaskResult implements Ta
     );
   }
 
-  toJson() {
+  json() {
     return {
-      [this.meta.taskName]: {
+      meta: this.meta,
+      result: {
         emberLibraries: this.emberLibraries,
         emberAddons: this.emberAddons,
         emberCliAddons: this.emberCliAddons,

--- a/packages/plugin-ember/src/results/ember-project-task-result.ts
+++ b/packages/plugin-ember/src/results/ember-project-task-result.ts
@@ -5,7 +5,7 @@ export default class EmberProjectTaskResult extends BaseTaskResult implements Ta
   name!: string;
   version!: string;
 
-  toConsole() {
+  stdout() {
     ui.styledHeader(this.meta.friendlyTaskName);
     ui.blankLine();
     ui.styledObject({
@@ -14,9 +14,7 @@ export default class EmberProjectTaskResult extends BaseTaskResult implements Ta
     ui.blankLine();
   }
 
-  toJson() {
-    return {
-      [this.meta.taskName]: { type: this.type },
-    };
+  json() {
+    return { meta: this.meta, result: { type: this.type } };
   }
 }

--- a/packages/plugin-ember/src/results/types-task-result.ts
+++ b/packages/plugin-ember/src/results/types-task-result.ts
@@ -7,14 +7,14 @@ export default class TypesTaskResult extends BaseTaskResult implements TaskResul
     return this.types.find(type => type.type === typeName);
   }
 
-  toConsole() {
+  stdout() {
     ui.styledHeader(this.meta.friendlyTaskName);
     ui.blankLine();
     ui.table(this.types, { type: {}, total: {} });
     ui.blankLine();
   }
 
-  toJson() {
-    return { [this.meta.taskName]: this.types };
+  json() {
+    return { meta: this.meta, result: { types: this.types } };
   }
 }

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -8,12 +8,14 @@
     "@checkup/core": "0.0.0",
     "fixturify-project": "^2.1.0",
     "handlebars": "^4.7.3",
-    "stdout-stderr": "^0.1.13"
+    "stdout-stderr": "^0.1.13",
+    "tmp": "^0.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4",
     "@types/jest": "^25.1.3",
     "@types/node": "^13",
+    "@types/tmp": "^0.1.0",
     "chai": "^4.2.0",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -1,4 +1,5 @@
 export { stdout } from './stdout';
+export { createTmpDir } from './tmp-dir';
 export { default as CheckupProject } from './checkup-fixturify-project';
 export { default as EmberProject } from './ember-cli-fixturify-project';
 export { default as Plugin } from './plugin';

--- a/packages/test-helpers/src/tmp-dir.ts
+++ b/packages/test-helpers/src/tmp-dir.ts
@@ -1,0 +1,7 @@
+import { realpathSync } from 'fs';
+
+import tmp = require('tmp');
+
+export function createTmpDir() {
+  return realpathSync(tmp.dirSync({ unsafeCleanup: true }).name);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,63 @@
   dependencies:
     type-detect "4.0.8"
 
+"@tracerbench/find-chrome@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/find-chrome/-/find-chrome-1.2.0.tgz#6a71f080ffff8d69d817df127650a0ec226c27aa"
+  integrity sha512-es9tJkxj5ZGndlyhLe5YuXdvXT8WqXo6gOZk2ssfJmIhRw/aUnJruYzFk3K8qH/be+pjOwQX1vsGI1gK76dP/g==
+  dependencies:
+    chrome-launcher "^0.12.0"
+
+"@tracerbench/message-transport@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/message-transport/-/message-transport-1.2.0.tgz#f75d56ad0d2f1ea38946e8d79934ec7bd20e9dc7"
+  integrity sha512-OealxVa0jVyNVInjfhAwvr6z8/hIUtfFAn0DP30NoWAo37tbwl3p9pgfyMWmix2kmFmIKBpcMcJpBjzbd6wfCA==
+
+"@tracerbench/protocol-connection@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/protocol-connection/-/protocol-connection-1.2.0.tgz#0c736fce2f900e76e863286311a51c810cccfc73"
+  integrity sha512-84nVBs4BfzZ41I0Yv2Ca2H8lclw5/lr83Ra9mcHy9WCc9V23WF6cB/9tsK4+7yvovN0N0KpJWAluf+TkQMZOUA==
+  dependencies:
+    "@tracerbench/message-transport" "^1.2.0"
+    "@tracerbench/protocol-transport" "^1.2.0"
+    race-cancellation "^0.4.1"
+
+"@tracerbench/protocol-transport@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/protocol-transport/-/protocol-transport-1.2.0.tgz#4d54824118f2a0d8c1b74f7b6f53816507d20d2f"
+  integrity sha512-FePY6aKm4w2UR/LUzFYhheT5SV9AWTl+Xqk4c9oq27pa4erfwXgbM8osCnAP4C3MCxn4UPxnwI7oOzLU/4PwLQ==
+  dependencies:
+    "@tracerbench/message-transport" "^1.2.0"
+    race-cancellation "^0.4.1"
+
+"@tracerbench/spawn-chrome@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/spawn-chrome/-/spawn-chrome-1.2.0.tgz#be133e1579c62454c3b3da42ad1cb8cd2fde6ee3"
+  integrity sha512-ht4StGdwAMNlBXu9uOQsVM64mOrNHPrAtdRZh/vwVlP+H71iQpXFzcbSYrDsRZvSlMNrj5CyWeaFBUlQNJmn5g==
+  dependencies:
+    "@tracerbench/find-chrome" "^1.2.0"
+    "@tracerbench/spawn" "^1.2.0"
+    tmp "^0.1.0"
+
+"@tracerbench/spawn@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/spawn/-/spawn-1.2.0.tgz#28783283229ad65ca68f5d28ce377b41e9d286af"
+  integrity sha512-nuupj9/OcrLnkPKgtXw9iKgPuJ4nSHpYjQ5quCRo5xi9o01X9ZRVBu+Fgcms+4XmL3iFyvaTfXUrkaL4c7ASyA==
+  dependencies:
+    "@tracerbench/message-transport" "^1.2.0"
+    debug "^4.1.1"
+    execa "^3.3.0"
+    race-cancellation "^0.4.1"
+
+"@tracerbench/websocket-message-transport@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tracerbench/websocket-message-transport/-/websocket-message-transport-1.2.0.tgz#4b17734549d44896fc416187353ab650b1a9dfed"
+  integrity sha512-6/a/dWQoPrAlX2NmEhjxFk9TsyrmggDuL2KO/E9+KwPZcXwlH3rJ9N2hBg2FlXYyfoTghoRpElMZiGdHO3PSGQ==
+  dependencies:
+    "@tracerbench/message-transport" "^1.2.0"
+    race-cancellation "^0.4.1"
+    ws "^7.1.2"
+
 "@types/babel__core@^7.1.0":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.6.tgz#16ff42a5ae203c9af1c6e190ed1f30f83207b610"
@@ -514,6 +571,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/date-and-time@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/date-and-time/-/date-and-time-0.6.0.tgz#3e7fa319dd5e07affc96a9247d40aab31f62a6c5"
+  integrity sha512-gCNLSTK8SnHqNQo1MIy4fwhsufZU5zFXsJzmTdjvRsp6Xpb28G2ODFNSoZNSsf2kB9J0hPSzHCEaQqYusIwUqQ==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -646,6 +708,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/tmp@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
+  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1183,6 +1250,31 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chrome-debugging-client@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/chrome-debugging-client/-/chrome-debugging-client-1.2.0.tgz#23efc68b75b57c2b8cbdbdb99997cae01f0a31ea"
+  integrity sha512-GtC79nrKEUSZqwlzdFl1ULgYMqJmRcoI9pwLITDzQCzFHuvSDw3IFbAsMAnzSYyKo5AXa6C2uddkxG2oocu+xg==
+  dependencies:
+    "@tracerbench/find-chrome" "^1.2.0"
+    "@tracerbench/message-transport" "^1.2.0"
+    "@tracerbench/protocol-connection" "^1.2.0"
+    "@tracerbench/spawn" "^1.2.0"
+    "@tracerbench/spawn-chrome" "^1.2.0"
+    "@tracerbench/websocket-message-transport" "^1.2.0"
+    debug "^4.1.1"
+    race-cancellation "^0.4.1"
+
+chrome-launcher@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.12.0.tgz#08db81ef0f7b283c331df2c350e780c38bd0ce3a"
+  integrity sha512-rBUP4tvWToiileDi3UR0SbWKoUoDCYTRmVND2sdoBL1xANBgVz8V9h1yQluj3MEQaBJg0fRw7hW82uOPrJus7A==
+  dependencies:
+    "@types/node" "*"
+    is-wsl "^2.1.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "0.5.1"
+    rimraf "^2.6.1"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -1369,11 +1461,6 @@ commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-comment-parser@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.7.2.tgz#baf6d99b42038678b81096f15b630d18142f4b8a"
-  integrity sha512-4Rjb1FnxtOcv9qsfuaNuVsmmVn4ooVoBHzYfyKteiXwIU84PClyGA5jASoFMwPV93+FPh9spwueXauxFJZkGAg==
-
 compare-versions@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
@@ -1475,12 +1562,17 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-and-time@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.12.0.tgz#6d30c91c47fa72edadd628b71ec2ac46909b9267"
+  integrity sha512-n2RJIAp93AucgF/U/Rz5WRS2Hjg5Z+QxscaaMCi6pVZT1JpJKRH+C08vyH/lRR1kxNXnPxgo3lWfd+jCb/UcuQ==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@^2.2.0, debug@^2.3.3:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -1564,6 +1656,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+devtools-protocol@^0.0.746878:
+  version "0.0.746878"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.746878.tgz#c2fa3261f93b5f5957dd7c11557945cd464ed326"
+  integrity sha512-DkIGCpIdtgQnDaIp6ptrT1JwePQMn9Eo946JAOcIzV36POeV0VTA5Dcb4hO2B6C9+lBY63nsvg2qttVKJlxLzw==
 
 diff-sequences@^25.1.0:
   version "25.1.0"
@@ -1747,19 +1844,6 @@ eslint-plugin-jest@^23.8.2:
   integrity sha512-xwbnvOsotSV27MtAe7s8uGWOori0nUsrXh2f1EnpmXua8sDfY6VZhHAhHg2sqK7HBNycRQExF074XSZ7DvfoFg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
-
-eslint-plugin-jsdoc@^22.0.0:
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-22.0.0.tgz#371f1dbf4f61ee6e11c23fa1ea3275962f1bceaf"
-  integrity sha512-dLqUtIL6tvOoV+9IDdP3FqOnQ/sxklzs4hxZa91kt0TGI2o1fSqIuc6wa71oWtWKEyvaQj7m6CnzQxcBC9CEsg==
-  dependencies:
-    comment-parser "^0.7.2"
-    debug "^4.1.1"
-    jsdoctypeparser "^6.1.0"
-    lodash "^4.17.15"
-    regextras "^0.7.0"
-    semver "^6.3.0"
-    spdx-expression-parse "^3.0.0"
 
 eslint-plugin-node@^11.0.0:
   version "11.0.0"
@@ -1950,7 +2034,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^3.2.0, execa@^3.4.0:
+execa@^3.2.0, execa@^3.3.0, execa@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
   integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
@@ -2897,7 +2981,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.1.1:
+is-wsl@^2.1.0, is-wsl@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
@@ -3348,11 +3432,6 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdoctypeparser@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz#acfb936c26300d98f1405cb03e20b06748e512a8"
-  integrity sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==
-
 jsdom@^15.1.1:
   version "15.2.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
@@ -3487,6 +3566,14 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lighthouse-logger@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz#b76d56935e9c137e86a04741f6bb9b2776e886ca"
+  integrity sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==
+  dependencies:
+    debug "^2.6.8"
+    marky "^1.2.0"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -3726,6 +3813,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marky@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.1.tgz#a3fcf82ffd357756b8b8affec9fdbf3a30dc1b02"
+  integrity sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==
+
 matcher-collection@^2.0.0, matcher-collection@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-2.0.1.tgz#90be1a4cf58d6f2949864f65bb3b0f3e41303b29"
@@ -3832,7 +3924,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.x, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.x, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -4383,6 +4475,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+race-cancellation@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/race-cancellation/-/race-cancellation-0.4.1.tgz#bd1c69bf5b836b56645a4b5b78fb9b973c46eb45"
+  integrity sha512-TF1vf4q/a5mwER9DoIuniE/qNIRM3Begyoe+21VUKgsyQAT4iIfSqlK7aG4Of1J1wzeATqVwbDP0dwX9GhaGcw==
+
 react-is@^16.12.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
@@ -4457,11 +4554,6 @@ regexpp@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
   integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
-
-regextras@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/regextras/-/regextras-0.7.0.tgz#2298bef8cfb92b1b7e3b9b12aa8f69547b7d71e4"
-  integrity sha512-ds+fL+Vhl918gbAUb0k2gVKbTZLsg84Re3DI6p85Et0U0tYME3hyW4nMK8Px4dtDaBA2qNjvG5uWyW7eK5gfmw==
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -4607,7 +4699,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.3:
+rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -5646,7 +5738,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^7.0.0:
+ws@^7.0.0, ws@^7.1.2:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.1.tgz#03ed52423cd744084b2cf42ed197c8b65a936b8e"
   integrity sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==


### PR DESCRIPTION
This PR gets the basic structure for the PDF reporter working. It changes a few things:

1. The `--json` flag has been replaced with `--reporter`, with the options `stdout`, `json`, or `pdf`
2. The JSON output from a result is more constrained now, and contains both the task's `meta` and a `result` property.
3. The JSON results are aggregated now by `category`, then by `priority`. 

TODO:

- [x] Tests