### PR TITLE
Fixing reportOutputPath to create directory if doesn't exist

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
     "build:watch": "yarn build -w",
     "clean": "rm -rf lib/*",
     "prepack": "yarn build && oclif-dev readme",
-    "test": "jest",
+    "test": "jest --runInBand",
     "version": "oclif-dev readme && git add README.md",
     "copystatic": "cp -a ./src/static ./lib/static"
   },

--- a/packages/cli/src/helpers/pdf.ts
+++ b/packages/cli/src/helpers/pdf.ts
@@ -29,6 +29,10 @@ export async function generateReport(
 
   fs.writeFileSync(htmlTmpPath, reportHTML);
 
+  if (!fs.existsSync(resultOutputPath)) {
+    fs.mkdirSync(resultOutputPath, { recursive: true });
+  }
+
   let outputFilePath = path.resolve(
     path.join(
       resultOutputPath,


### PR DESCRIPTION
Fixes a bug in the PDF reporter where it errors if the `reportOutputPath` directory isn't created before trying to write the PDF to it.