### PR TITLE
Add TaskMetaData to tasks

### DIFF
--- a/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
@@ -2,13 +2,15 @@
 
 exports[`TaskList runTask will run a task by taskName 1`] = `
 Object {
-  "meta": Object {
-    "friendlyTaskName": "Mock Task",
-    "taskClassification": Object {
-      "category": "core",
-      "priority": "high",
+  "meta": MockTask {
+    "meta": Object {
+      "friendlyTaskName": "Mock Task",
+      "taskClassification": Object {
+        "category": "core",
+        "priority": "high",
+      },
+      "taskName": "mock-task",
     },
-    "taskName": "mock-task",
   },
   "result": "mock task is being run",
 }
@@ -16,13 +18,15 @@ Object {
 
 exports[`TaskList runTasks will run all registered tasks 1`] = `
 Object {
-  "meta": Object {
-    "friendlyTaskName": "Mock Task",
-    "taskClassification": Object {
-      "category": "core",
-      "priority": "high",
+  "meta": MockTask {
+    "meta": Object {
+      "friendlyTaskName": "Mock Task",
+      "taskClassification": Object {
+        "category": "core",
+        "priority": "high",
+      },
+      "taskName": "mock-task",
     },
-    "taskName": "mock-task",
   },
   "result": "mock task is being run",
 }
@@ -30,13 +34,15 @@ Object {
 
 exports[`TaskList runTasks will run all registered tasks 2`] = `
 Object {
-  "meta": Object {
-    "friendlyTaskName": "Another Mock Task",
-    "taskClassification": Object {
-      "category": "core",
-      "priority": "low",
+  "meta": AnotherMockTask {
+    "meta": Object {
+      "friendlyTaskName": "Another Mock Task",
+      "taskClassification": Object {
+        "category": "core",
+        "priority": "low",
+      },
+      "taskName": "another-mock-task",
     },
-    "taskName": "another-mock-task",
   },
   "result": "another mock task is being run",
 }

--- a/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
@@ -2,15 +2,13 @@
 
 exports[`TaskList runTask will run a task by taskName 1`] = `
 Object {
-  "meta": MockTask {
-    "meta": Object {
-      "friendlyTaskName": "Mock Task",
-      "taskClassification": Object {
-        "category": "core",
-        "priority": "high",
-      },
-      "taskName": "mock-task",
+  "meta": Object {
+    "friendlyTaskName": "Mock Task",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "high",
     },
+    "taskName": "mock-task",
   },
   "result": "mock task is being run",
 }
@@ -18,15 +16,13 @@ Object {
 
 exports[`TaskList runTasks will run all registered tasks 1`] = `
 Object {
-  "meta": MockTask {
-    "meta": Object {
-      "friendlyTaskName": "Mock Task",
-      "taskClassification": Object {
-        "category": "core",
-        "priority": "high",
-      },
-      "taskName": "mock-task",
+  "meta": Object {
+    "friendlyTaskName": "Mock Task",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "high",
     },
+    "taskName": "mock-task",
   },
   "result": "mock task is being run",
 }
@@ -34,15 +30,13 @@ Object {
 
 exports[`TaskList runTasks will run all registered tasks 2`] = `
 Object {
-  "meta": AnotherMockTask {
-    "meta": Object {
-      "friendlyTaskName": "Another Mock Task",
-      "taskClassification": Object {
-        "category": "core",
-        "priority": "low",
-      },
-      "taskName": "another-mock-task",
+  "meta": Object {
+    "friendlyTaskName": "Another Mock Task",
+    "taskClassification": Object {
+      "category": "core",
+      "priority": "low",
     },
+    "taskName": "another-mock-task",
   },
   "result": "another mock task is being run",
 }

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -1,8 +1,8 @@
-import { BaseTaskResult, Task, TaskResult } from '@checkup/core';
+import { BaseTaskResult, TaskMetaData, TaskResult } from '@checkup/core';
 
 export default class MockTaskResult extends BaseTaskResult implements TaskResult {
-  constructor(task: Task, public result: string) {
-    super(task);
+  constructor(meta: TaskMetaData, public result: string) {
+    super(meta);
   }
 
   stdout() {

--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -14,11 +14,13 @@ describe('@checkup/cli', () => {
       const plugin = new Plugin('@checkup/plugin-mock')
         .addTask(
           class MockTask implements Task {
-            taskName = 'mock-task';
-            friendlyTaskName = 'Mock Task';
-            taskClassification = {
-              category: Category.Core,
-              priority: Priority.High,
+            meta = {
+              taskName: 'mock-task',
+              friendlyTaskName: 'Mock Task',
+              taskClassification: {
+                category: Category.Core,
+                priority: Priority.High,
+              },
             };
 
             async run() {
@@ -47,11 +49,13 @@ describe('@checkup/cli', () => {
         )
         .addTask(
           class MockTask2 implements Task {
-            taskName = 'mock-task2';
-            friendlyTaskName = 'Mock Task 2';
-            taskClassification = {
-              category: Category.Core,
-              priority: Priority.High,
+            meta = {
+              taskName: 'mock-task2',
+              friendlyTaskName: 'Mock Task 2',
+              taskClassification: {
+                category: Category.Core,
+                priority: Priority.High,
+              },
             };
 
             async run() {
@@ -80,11 +84,13 @@ describe('@checkup/cli', () => {
         );
       const anotherPlugin = new Plugin('another-plugin-mock').addTask(
         class MockTask implements Task {
-          taskName = 'mock-task3';
-          friendlyTaskName = 'Mock Task3';
-          taskClassification = {
-            category: Category.Core,
-            priority: Priority.High,
+          meta = {
+            taskName: 'mock-task3',
+            friendlyTaskName: 'Mock Task3',
+            taskClassification: {
+              category: Category.Core,
+              priority: Priority.High,
+            },
           };
 
           async run() {

--- a/packages/cli/__tests__/priority-map-test.ts
+++ b/packages/cli/__tests__/priority-map-test.ts
@@ -14,7 +14,7 @@ class MockTask implements Task {
   };
 
   async run(): Promise<TaskResult> {
-    return new MockTaskResult(this, 'mock task is being run');
+    return new MockTaskResult(this.meta, 'mock task is being run');
   }
 }
 

--- a/packages/cli/__tests__/priority-map-test.ts
+++ b/packages/cli/__tests__/priority-map-test.ts
@@ -1,14 +1,16 @@
-import { Category, Priority, Task, TaskClassification, TaskName, TaskResult } from '@checkup/core';
+import { Category, Priority, Task, TaskResult } from '@checkup/core';
 
 import MockTaskResult from './__utils__/mock-task-result';
 import PriorityMap from '../src/priority-map';
 
 class MockTask implements Task {
-  taskName: TaskName = 'mock-task';
-  friendlyTaskName: TaskName = 'Mock Task';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.High,
+  meta = {
+    taskName: 'mock-task',
+    friendlyTaskName: 'Mock Task',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.High,
+    },
   };
 
   async run(): Promise<TaskResult> {

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -14,7 +14,7 @@ class MockTask implements Task {
   };
 
   async run(): Promise<TaskResult> {
-    return new MockTaskResult(this, 'mock task is being run');
+    return new MockTaskResult(this.meta, 'mock task is being run');
   }
 }
 
@@ -29,7 +29,7 @@ class AnotherMockTask implements Task {
   };
 
   async run(): Promise<TaskResult> {
-    return new MockTaskResult(this, 'another mock task is being run');
+    return new MockTaskResult(this.meta, 'another mock task is being run');
   }
 }
 

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -1,14 +1,16 @@
-import { Category, Priority, Task, TaskClassification, TaskName, TaskResult } from '@checkup/core';
+import { Category, Priority, Task, TaskResult } from '@checkup/core';
 
 import MockTaskResult from './__utils__/mock-task-result';
 import TaskList from '../src/task-list';
 
 class MockTask implements Task {
-  taskName: TaskName = 'mock-task';
-  friendlyTaskName: TaskName = 'Mock Task';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.High,
+  meta = {
+    taskName: 'mock-task',
+    friendlyTaskName: 'Mock Task',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.High,
+    },
   };
 
   async run(): Promise<TaskResult> {
@@ -17,11 +19,13 @@ class MockTask implements Task {
 }
 
 class AnotherMockTask implements Task {
-  taskName: TaskName = 'another-mock-task';
-  friendlyTaskName: TaskName = 'Another Mock Task';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.Low,
+  meta = {
+    taskName: 'another-mock-task',
+    friendlyTaskName: 'Another Mock Task',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.Low,
+    },
   };
 
   async run(): Promise<TaskResult> {

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -33,8 +33,8 @@ export default class TaskList {
    * @param taskClassification
    */
   registerTask(task: Task) {
-    let priorityMap = this._categories.get(task.taskClassification.category);
-    priorityMap!.setTaskByPriority(task.taskClassification.priority, task.taskName, task);
+    let priorityMap = this._categories.get(task.meta.taskClassification.category);
+    priorityMap!.setTaskByPriority(task.meta.taskClassification.priority, task.meta.taskName, task);
   }
 
   /**

--- a/packages/core/src/base-task-result.ts
+++ b/packages/core/src/base-task-result.ts
@@ -1,13 +1,9 @@
-import { Task, TaskMetaData } from './types';
+import { TaskMetaData } from './types';
 
 export default abstract class BaseTaskResult {
   meta: TaskMetaData;
 
-  constructor(task: Task) {
-    this.meta = {
-      taskName: task.taskName,
-      friendlyTaskName: task.friendlyTaskName,
-      taskClassification: task.taskClassification,
-    };
+  constructor(meta: TaskMetaData) {
+    this.meta = meta;
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -30,9 +30,7 @@ export type TaskClassification = {
 };
 
 export interface Task {
-  taskName: TaskName;
-  friendlyTaskName: TaskName;
-  taskClassification: TaskClassification;
+  meta: TaskMetaData;
 
   run: () => Promise<TaskResult>;
 }

--- a/packages/plugin-default/src/tasks/project-info-task.ts
+++ b/packages/plugin-default/src/tasks/project-info-task.ts
@@ -3,8 +3,7 @@ import {
   Category,
   Priority,
   Task,
-  TaskClassification,
-  TaskName,
+  TaskMetaData,
   TaskResult,
   getPackageJson,
 } from '@checkup/core';
@@ -13,15 +12,17 @@ import ProjectInfoTaskResult from '../results/project-info-task-result';
 import { getRepositoryInfo } from '../utils/repository';
 
 export default class ProjectInfoTask extends BaseTask implements Task {
-  taskName: TaskName = 'project-info';
-  friendlyTaskName: TaskName = 'Project Information';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.High,
+  meta: TaskMetaData = {
+    taskName: 'project-info',
+    friendlyTaskName: 'Project Information',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.High,
+    },
   };
 
   async run(): Promise<TaskResult> {
-    let result: ProjectInfoTaskResult = new ProjectInfoTaskResult(this);
+    let result: ProjectInfoTaskResult = new ProjectInfoTaskResult(this.meta);
     let package_ = getPackageJson(this.args.path);
 
     result.name = package_.name || '';

--- a/packages/plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -8,7 +8,7 @@ describe('octane-migration-status-task-result', () => {
     test('simple console output', async () => {
       let sampleOctaneReport = require('../__fixtures__/sample-octane-eslint-report.json');
       let task = new OctaneMigrationStatusTask({});
-      let taskResult = new OctaneMigrationStatusTaskResult(task, sampleOctaneReport);
+      let taskResult = new OctaneMigrationStatusTaskResult(task.meta, sampleOctaneReport);
 
       taskResult.stdout();
 
@@ -20,7 +20,7 @@ describe('octane-migration-status-task-result', () => {
     test('it should have basic JSON results', () => {
       let sampleOctaneReport = require('../__fixtures__/sample-octane-eslint-report.json');
       let task = new OctaneMigrationStatusTask({});
-      let taskResult = new OctaneMigrationStatusTaskResult(task, sampleOctaneReport);
+      let taskResult = new OctaneMigrationStatusTaskResult(task.meta, sampleOctaneReport);
 
       let jsonResults = taskResult.json();
       let { totalViolations, migrationTasks } = jsonResults.result;
@@ -34,7 +34,7 @@ describe('octane-migration-status-task-result', () => {
     test('it should output detailed completion data', () => {
       let sampleOctaneReport = require('../__fixtures__/sample-octane-eslint-report.json');
       let task = new OctaneMigrationStatusTask({});
-      let taskResult = new OctaneMigrationStatusTaskResult(task, sampleOctaneReport);
+      let taskResult = new OctaneMigrationStatusTaskResult(task.meta, sampleOctaneReport);
 
       let jsonResults = taskResult.json();
       let { migrationTasks } = jsonResults.result;

--- a/packages/plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -1,4 +1,4 @@
-import { BaseTaskResult, Task, TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskMetaData, TaskResult, ui } from '@checkup/core';
 
 import { CLIEngine } from 'eslint';
 
@@ -104,8 +104,8 @@ function getMigrationInfo(
 export default class OctaneMigrationStatusTaskResult extends BaseTaskResult implements TaskResult {
   taskName: string = 'Octane Migration Status';
 
-  constructor(task: Task, public report: CLIEngine.LintReport) {
-    super(task);
+  constructor(meta: TaskMetaData, public report: CLIEngine.LintReport) {
+    super(meta);
   }
 
   stdout() {

--- a/packages/plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -1,14 +1,16 @@
-import { BaseTask, Category, Priority, Task, TaskClassification, TaskName } from '@checkup/core';
+import { BaseTask, Category, Priority, Task } from '@checkup/core';
 
 import { CLIEngine } from 'eslint';
 import { OctaneMigrationStatusTaskResult } from '../results';
 
 export default class OctaneMigrationStatusTask extends BaseTask implements Task {
-  taskName: TaskName = 'octane-migration-status';
-  friendlyTaskName: TaskName = 'Ember Octane Migration Status';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.Medium,
+  meta = {
+    taskName: 'octane-migration-status',
+    friendlyTaskName: 'Ember Octane Migration Status',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.Medium,
+    },
   };
 
   public report!: CLIEngine.LintReport;
@@ -52,7 +54,7 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
 
   async run(): Promise<OctaneMigrationStatusTaskResult> {
     this.report = this.esLintEngine.executeOnFiles([`${this.rootPath}/+(app|addon)/**/*.js`]);
-    let result = new OctaneMigrationStatusTaskResult(this, this.report);
+    let result = new OctaneMigrationStatusTaskResult(this.meta, this.report);
 
     return result;
   }

--- a/packages/plugin-ember/src/results/dependencies-task-result.ts
+++ b/packages/plugin-ember/src/results/dependencies-task-result.ts
@@ -1,4 +1,4 @@
-import { BaseTaskResult, Task, TaskResult, toPairs, ui } from '@checkup/core';
+import { BaseTaskResult, TaskMetaData, TaskResult, toPairs, ui } from '@checkup/core';
 
 import { PackageJson } from 'type-fest';
 
@@ -7,8 +7,8 @@ export default class DependenciesTaskResult extends BaseTaskResult implements Ta
   emberAddons!: Record<string, PackageJson.Dependency>;
   emberCliAddons!: Record<string, PackageJson.Dependency>;
 
-  constructor(task: Task) {
-    super(task);
+  constructor(meta: TaskMetaData) {
+    super(meta);
     this.emberLibraries = {};
   }
 

--- a/packages/plugin-ember/src/tasks/dependencies-task.ts
+++ b/packages/plugin-ember/src/tasks/dependencies-task.ts
@@ -1,12 +1,4 @@
-import {
-  BaseTask,
-  Category,
-  Priority,
-  Task,
-  TaskClassification,
-  TaskResult,
-  getPackageJson,
-} from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskResult, getPackageJson } from '@checkup/core';
 
 import { DependenciesTaskResult } from '../results';
 import { PackageJson } from 'type-fest';
@@ -65,15 +57,17 @@ function emberCliAddonFilter(dependency: string) {
 }
 
 export default class DependenciesTask extends BaseTask implements Task {
-  taskName: string = 'dependencies';
-  friendlyTaskName: string = 'Project Dependencies';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.Medium,
+  meta = {
+    taskName: 'dependencies',
+    friendlyTaskName: 'Project Dependencies',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.Medium,
+    },
   };
 
   async run(): Promise<TaskResult> {
-    let result: DependenciesTaskResult = new DependenciesTaskResult(this);
+    let result: DependenciesTaskResult = new DependenciesTaskResult(this.meta);
     let packageJson = getPackageJson(this.args.path);
 
     result.emberLibraries['ember-source'] = findDependency(packageJson, 'ember-source');

--- a/packages/plugin-ember/src/tasks/ember-project-task.ts
+++ b/packages/plugin-ember/src/tasks/ember-project-task.ts
@@ -1,26 +1,20 @@
-import {
-  BaseTask,
-  Category,
-  Priority,
-  Task,
-  TaskClassification,
-  TaskName,
-  TaskResult,
-} from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskResult } from '@checkup/core';
 
 import { EmberProjectTaskResult } from '../results';
 import { getProjectType } from '../utils/project';
 
 export default class EmberProjectTask extends BaseTask implements Task {
-  taskName: TaskName = 'ember-project';
-  friendlyTaskName: TaskName = 'Ember Project';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.Medium,
+  meta = {
+    taskName: 'ember-project',
+    friendlyTaskName: 'Ember Project',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.Medium,
+    },
   };
 
   async run(): Promise<TaskResult> {
-    let result: EmberProjectTaskResult = new EmberProjectTaskResult(this);
+    let result: EmberProjectTaskResult = new EmberProjectTaskResult(this.meta);
 
     result.type = `Ember.js ${getProjectType(this.args.path)}`;
 

--- a/packages/plugin-ember/src/tasks/types-task.ts
+++ b/packages/plugin-ember/src/tasks/types-task.ts
@@ -1,12 +1,4 @@
-import {
-  Category,
-  FileSearcherTask,
-  Priority,
-  Task,
-  TaskClassification,
-  TaskName,
-  TaskResult,
-} from '@checkup/core';
+import { Category, FileSearcherTask, Priority, Task, TaskResult } from '@checkup/core';
 
 import { TypesTaskResult } from '../results';
 
@@ -24,11 +16,13 @@ const SEARCH_PATTERNS = {
 };
 
 export default class TypesTask extends FileSearcherTask implements Task {
-  taskName: TaskName = 'types';
-  friendlyTaskName: TaskName = 'Project Types';
-  taskClassification: TaskClassification = {
-    category: Category.Core,
-    priority: Priority.Medium,
+  meta = {
+    taskName: 'types',
+    friendlyTaskName: 'Project Types',
+    taskClassification: {
+      category: Category.Core,
+      priority: Priority.Medium,
+    },
   };
 
   constructor(cliArguments: any) {
@@ -36,7 +30,7 @@ export default class TypesTask extends FileSearcherTask implements Task {
   }
 
   async run(): Promise<TaskResult> {
-    let result = new TypesTaskResult(this);
+    let result = new TypesTaskResult(this.meta);
     result.types = await this.searcher.search();
 
     return result;


### PR DESCRIPTION
Cleanup. Encapsulates `taskName`, `friendlyTaskName`, and `taskClassification` in a `meta` property, similar to what is used in `BaseTaskResult`. Now, between tasks and task results, there's a standardized property, `meta`, which houses the meta data for a particular task.