### PR TITLE
Increasing test timeout for test in @checkup/cli

### DIFF
--- a/packages/cli/__tests__/index-test.ts
+++ b/packages/cli/__tests__/index-test.ts
@@ -140,7 +140,7 @@ describe('@checkup/cli', () => {
       await cmd.run(['run', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
-    });
+    }, 15000);
 
     it('should output checkup result in JSON', async () => {
       await cmd.run(['run', '--reporter', 'json', project.baseDir]);


### PR DESCRIPTION
In the "macOS-latest, 10" build, tests have been failing due to timeouts. Generally, after rerunning the tests, they pass.
It is mostly failing on the test that runs the checkup command. Increasing timeout for that test