### PR TITLE
Fixing checkup-meta-task's use of shorthash

### DIFF
--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -48,7 +48,7 @@ describe('project-info-task', () => {
 
       expect(stdout()).toMatchInlineSnapshot(`
         "=== Checkup Configuration
-        configHash: Z8RYA1
+        configHash: ae3266e319bdfb51db83810a2f4dd161
         version:    0.0.1
 
         "
@@ -76,7 +76,7 @@ describe('project-info-task', () => {
           },
           "result": Object {
             "checkup": Object {
-              "configHash": "Z8RYA1",
+              "configHash": "ae3266e319bdfb51db83810a2f4dd161",
               "version": "0.0.1",
             },
           },
@@ -100,7 +100,7 @@ describe('project-info-task', () => {
 
       expect(stdout()).toMatchInlineSnapshot(`
         "=== Checkup Configuration
-        configHash: ZbvPrF
+        configHash: 07e8f7d8731ffbb323ad86f8f2f62460
         version:    0.0.1
 
         "
@@ -131,7 +131,7 @@ describe('project-info-task', () => {
           },
           "result": Object {
             "checkup": Object {
-              "configHash": "ZbvPrF",
+              "configHash": "07e8f7d8731ffbb323ad86f8f2f62460",
               "version": "0.0.1",
             },
           },

--- a/packages/cli/src/tasks/checkup-meta-task.ts
+++ b/packages/cli/src/tasks/checkup-meta-task.ts
@@ -1,4 +1,4 @@
-import * as shorthash from 'shorthash';
+import * as crypto from 'crypto';
 import * as stringify from 'json-stable-stringify';
 
 import {
@@ -18,7 +18,10 @@ const { version } = require('../../package.json');
 function getConfigHash(checkupConfig: CheckupConfig) {
   let configAsJson = stringify(checkupConfig);
 
-  return shorthash.unique(configAsJson);
+  return crypto
+    .createHash('md5')
+    .update(configAsJson)
+    .digest('hex');
 }
 
 export default class CheckupMetaTask extends BaseTask implements Task {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,5 +9,5 @@
       "@checkup/core": ["../core/lib/index.d.ts"]
     }
   },
-  "include": ["src/**/*", "types/**/*"]
+  "include": ["src/**/*"]
 }

--- a/packages/cli/types/shorthash.d.ts
+++ b/packages/cli/types/shorthash.d.ts
@@ -1,1 +1,0 @@
-declare module 'shorthash';


### PR DESCRIPTION
Fixes a bug when running checkup in dev mode - `ts-node` wasn't correctly reading the local `d.ts` files, and caused a build error when invoking a linked checkup. This PR removes the use of that module in favor of built-ins.