### PR TITLE
Fixing hooks config paths to point to lib vs src

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -39,7 +39,7 @@ exports[`plugin generator generates plugin with custom options 1`] = `
       \\"@oclif/plugin-help\\"
     ],
     \\"hooks\\": {
-      \\"register-tasks\\": \\"./src/hooks/register-tasks\\"
+      \\"register-tasks\\": \\"./lib/hooks/register-tasks\\"
     }
   },
   \\"repository\\": \\"http://github.com/scalvert/plugin-custom\\",
@@ -189,7 +189,7 @@ exports[`plugin generator generates plugin with defaults 1`] = `
       \\"@oclif/plugin-help\\"
     ],
     \\"hooks\\": {
-      \\"register-tasks\\": \\"./src/hooks/register-tasks\\"
+      \\"register-tasks\\": \\"./lib/hooks/register-tasks\\"
     }
   },
   \\"repository\\": \\"\\",

--- a/packages/cli/templates/src/plugin/package.json.ejs
+++ b/packages/cli/templates/src/plugin/package.json.ejs
@@ -36,7 +36,7 @@
       "@oclif/plugin-help"
     ],
     "hooks": {
-      "register-tasks": "./src/hooks/register-tasks"
+      "register-tasks": "./lib/hooks/register-tasks"
     }
   },
   "repository": "<%- repository %>",

--- a/packages/plugin-ember-octane/package.json
+++ b/packages/plugin-ember-octane/package.json
@@ -44,7 +44,7 @@
       "@oclif/plugin-help"
     ],
     "hooks": {
-      "register-tasks": "./src/hooks/register-tasks"
+      "register-tasks": "./lib/hooks/register-tasks"
     }
   },
   "publishConfig": {

--- a/packages/plugin-ember/package.json
+++ b/packages/plugin-ember/package.json
@@ -40,7 +40,7 @@
       "@oclif/plugin-help"
     ],
     "hooks": {
-      "register-tasks": "./src/hooks/register-tasks"
+      "register-tasks": "./lib/hooks/register-tasks"
     }
   },
   "publishConfig": {

--- a/packages/test-helpers/src/plugin.ts
+++ b/packages/test-helpers/src/plugin.ts
@@ -39,7 +39,7 @@ export default class Plugin {
       pluginProject.pkg.keywords.push('oclif-plugin');
       pluginProject.pkg.oclif = {
         hooks: {
-          'register-tasks': './src/hooks/register-tasks',
+          'register-tasks': './lib/hooks/register-tasks',
         },
       };
       pluginProject.pkg.files = [];

--- a/packages/test-helpers/src/plugin.ts
+++ b/packages/test-helpers/src/plugin.ts
@@ -43,7 +43,7 @@ export default class Plugin {
         },
       };
       pluginProject.pkg.files = [];
-      pluginProject.files.src = {
+      pluginProject.files.lib = {
         hooks: {
           'register-tasks.js': template({
             classes: [...this.tasks].map(task => task.toString()),


### PR DESCRIPTION
@lbdm44 found a bug in the published packages where the hooks paths were misconfigured (used `src` vs. `lib`). This PR fixes that.