### PR TITLE
Removing Core category. Adding Recommendations and renaming Migration

### DIFF
--- a/packages/cli/__tests__/__snapshots__/pdf-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/pdf-test.ts.snap
@@ -26,6 +26,7 @@ exports[`generateHTML returns correct HTML string 1`] = `
         </div>
       </div>
 
+
 </body>
 </html>
 "

--- a/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Mock Task",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "high",
     },
     "taskName": "mock-task",
@@ -19,7 +19,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Mock Task",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "high",
     },
     "taskName": "mock-task",
@@ -33,7 +33,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Another Mock Task",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "low",
     },
     "taskName": "another-mock-task",

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -51,7 +51,7 @@ exports[`@checkup/cli normal cli output with plugins should output checkup resul
         \\"taskName\\": \\"mock-task\\",
         \\"friendlyTaskName\\": \\"Mock Task\\",
         \\"taskClassification\\": {
-          \\"category\\": \\"core\\",
+          \\"category\\": \\"insights\\",
           \\"priority\\": \\"high\\"
         }
       },
@@ -64,7 +64,7 @@ exports[`@checkup/cli normal cli output with plugins should output checkup resul
         \\"taskName\\": \\"mock-task2\\",
         \\"friendlyTaskName\\": \\"Mock Task 2\\",
         \\"taskClassification\\": {
-          \\"category\\": \\"core\\",
+          \\"category\\": \\"insights\\",
           \\"priority\\": \\"high\\"
         }
       },
@@ -77,7 +77,7 @@ exports[`@checkup/cli normal cli output with plugins should output checkup resul
         \\"taskName\\": \\"mock-task3\\",
         \\"friendlyTaskName\\": \\"Mock Task 3\\",
         \\"taskClassification\\": {
-          \\"category\\": \\"core\\",
+          \\"category\\": \\"insights\\",
           \\"priority\\": \\"high\\"
         }
       },

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -20,7 +20,7 @@ describe('@checkup/cli', () => {
               taskName: 'mock-task',
               friendlyTaskName: 'Mock Task',
               taskClassification: {
-                category: Category.Core,
+                category: Category.Insights,
                 priority: Priority.High,
               },
             };
@@ -33,7 +33,7 @@ describe('@checkup/cli', () => {
                       taskName: 'mock-task',
                       friendlyTaskName: 'Mock Task',
                       taskClassification: {
-                        category: Category.Core,
+                        category: Category.Insights,
                         priority: Priority.High,
                       },
                     },
@@ -58,7 +58,7 @@ describe('@checkup/cli', () => {
               taskName: 'mock-task2',
               friendlyTaskName: 'Mock Task 2',
               taskClassification: {
-                category: Category.Core,
+                category: Category.Insights,
                 priority: Priority.High,
               },
             };
@@ -71,7 +71,7 @@ describe('@checkup/cli', () => {
                       taskName: 'mock-task2',
                       friendlyTaskName: 'Mock Task 2',
                       taskClassification: {
-                        category: Category.Core,
+                        category: Category.Insights,
                         priority: Priority.High,
                       },
                     },
@@ -96,7 +96,7 @@ describe('@checkup/cli', () => {
             taskName: 'mock-task3',
             friendlyTaskName: 'Mock Task3',
             taskClassification: {
-              category: Category.Core,
+              category: Category.Insights,
               priority: Priority.High,
             },
           };
@@ -109,7 +109,7 @@ describe('@checkup/cli', () => {
                     taskName: 'mock-task3',
                     friendlyTaskName: 'Mock Task 3',
                     taskClassification: {
-                      category: Category.Core,
+                      category: Category.Insights,
                       priority: Priority.High,
                     },
                   },

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -9,7 +9,7 @@ export default class MyFooTask extends BaseTask {
     taskName: 'my-foo',
     friendlyTaskName: 'My Foo',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     },
   };
@@ -100,7 +100,7 @@ export default class MyFooTask extends BaseTask implements Task {
     taskName: 'my-foo',
     friendlyTaskName: 'My Foo',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     },
   };
@@ -195,7 +195,7 @@ export default class MyFooTask extends BaseTask implements Task {
     taskName: 'my-foo',
     friendlyTaskName: 'My Foo',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     },
   };
@@ -290,7 +290,7 @@ export default class MyFooTask extends BaseTask implements Task {
     taskName: 'my-foo',
     friendlyTaskName: 'My Foo',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.High,
     },
   };
@@ -385,7 +385,7 @@ export default class MyFooTask extends BaseTask implements Task {
     taskName: 'my-foo',
     friendlyTaskName: 'My Foo',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     },
   };
@@ -467,7 +467,7 @@ export default class MyBarTask extends BaseTask implements Task {
     taskName: 'my-bar',
     friendlyTaskName: 'My Bar',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     },
   };

--- a/packages/cli/__tests__/generators/generate-task-test.ts
+++ b/packages/cli/__tests__/generators/generate-task-test.ts
@@ -90,7 +90,7 @@ describe('task generator', () => {
         name: 'my-foo',
       })
       .withPrompts({
-        category: 'Core',
+        category: 'Insights',
       });
 
     assertTaskFiles('my-foo', dir);

--- a/packages/cli/__tests__/pdf-test.ts
+++ b/packages/cli/__tests__/pdf-test.ts
@@ -1,17 +1,18 @@
-import { NumericalCardData, Category, Priority, TaskMetaData } from '@checkup/core';
+import { Category, NumericalCardData, Priority, TaskMetaData } from '@checkup/core';
+
 import { generateHTML } from '../src/helpers/pdf';
 
 const meta: TaskMetaData = {
   taskName: 'mock-task',
   friendlyTaskName: 'Mock Task',
   taskClassification: {
-    category: Category.Migration,
+    category: Category.Migrations,
     priority: Priority.Medium,
   },
 };
 
 const mergedResults: any = {
-  [Category.Migration]: {
+  [Category.Migrations]: {
     [Priority.High]: [],
     [Priority.Medium]: [new NumericalCardData(meta, 100, 'bad patterns in your app')],
     [Priority.Low]: [],

--- a/packages/cli/__tests__/priority-map-test.ts
+++ b/packages/cli/__tests__/priority-map-test.ts
@@ -8,7 +8,7 @@ class MockTask implements Task {
     taskName: 'mock-task',
     friendlyTaskName: 'Mock Task',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.High,
     },
   };

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -34,14 +34,14 @@ describe('_transformResults', () => {
       createMockTaskResult(
         'mock-meta-task-7',
         'Mock Meta Task 7',
-        Category.Migration,
+        Category.Migrations,
         Priority.High,
         {}
       ),
       createMockTaskResult(
         'mock-meta-task-3',
         'Mock Meta Task 3',
-        Category.Core,
+        Category.Insights,
         Priority.High,
         {}
       ),
@@ -55,14 +55,14 @@ describe('_transformResults', () => {
       createMockTaskResult(
         'mock-meta-task-8',
         'Mock Meta Task 8',
-        Category.Migration,
+        Category.Migrations,
         Priority.Low,
         {}
       ),
       createMockTaskResult(
         'mock-meta-task-4',
         'Mock Meta Task 4',
-        Category.Core,
+        Category.Insights,
         Priority.Medium,
         {}
       ),
@@ -100,7 +100,7 @@ describe('_transformResults', () => {
             "meta": Object {
               "friendlyTaskName": "Mock Meta Task 7",
               "taskClassification": Object {
-                "category": "migration",
+                "category": "migrations",
                 "priority": "high",
               },
               "taskName": "mock-meta-task-7",
@@ -111,7 +111,7 @@ describe('_transformResults', () => {
             "meta": Object {
               "friendlyTaskName": "Mock Meta Task 3",
               "taskClassification": Object {
-                "category": "core",
+                "category": "insights",
                 "priority": "high",
               },
               "taskName": "mock-meta-task-3",
@@ -133,7 +133,7 @@ describe('_transformResults', () => {
             "meta": Object {
               "friendlyTaskName": "Mock Meta Task 8",
               "taskClassification": Object {
-                "category": "migration",
+                "category": "migrations",
                 "priority": "low",
               },
               "taskName": "mock-meta-task-8",
@@ -144,7 +144,7 @@ describe('_transformResults', () => {
             "meta": Object {
               "friendlyTaskName": "Mock Meta Task 4",
               "taskClassification": Object {
-                "category": "core",
+                "category": "insights",
                 "priority": "medium",
               },
               "taskName": "mock-meta-task-4",

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -8,7 +8,7 @@ class MockTask implements Task {
     taskName: 'mock-task',
     friendlyTaskName: 'Mock Task',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.High,
     },
   };
@@ -23,7 +23,7 @@ class AnotherMockTask implements Task {
     taskName: 'another-mock-task',
     friendlyTaskName: 'Another Mock Task',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     },
   };
@@ -46,7 +46,7 @@ describe('TaskList', () => {
 
     taskList.registerTask(new MockTask());
 
-    expect(taskList.categories.get(Category.Core)!.size).toEqual(1);
+    expect(taskList.categories.get(Category.Insights)!.size).toEqual(1);
   });
 
   it('runTask will run a task by taskName', async () => {

--- a/packages/cli/src/generators/task.ts
+++ b/packages/cli/src/generators/task.ts
@@ -60,7 +60,7 @@ export default class TaskGenerator extends Generator {
 
     const defaults = {
       typescript: true,
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Low,
     };
 
@@ -79,11 +79,12 @@ export default class TaskGenerator extends Generator {
           name: 'category',
           message: 'Select a task category',
           choices: [
-            { name: 'core', value: 'Core' },
-            { name: 'migration', value: 'Migration' },
+            { name: 'meta', value: 'Meta' },
             { name: 'insights', value: 'Insights' },
+            { name: 'migrations', value: 'Migrations' },
+            { name: 'recommendations', value: 'Recommendations' },
           ],
-          default: 'Core',
+          default: 'Insights',
         },
         {
           type: 'list',

--- a/packages/cli/src/static/report-template.hbs
+++ b/packages/cli/src/static/report-template.hbs
@@ -11,7 +11,7 @@
 <body class="min-h-screen bg-gray-100">
   <h1>Checkup report</h1>
 
-  {{#each core as |priority|}}
+  {{#each insights as |priority|}}
     {{#each priority as |taskResult|}}
       <div>
         {{> (lookup . 'componentType') taskResult=taskResult}}
@@ -27,7 +27,15 @@
     {{/each}}
   {{/each}}
 
-  {{#each migration as |priority|}}
+  {{#each migrations as |priority|}}
+    {{#each priority as |taskResult|}}
+      <div>
+        {{> (lookup . 'componentType') taskResult=taskResult}}
+      </div>
+    {{/each}}
+  {{/each}}
+
+  {{#each recommendations as |priority|}}
     {{#each priority as |taskResult|}}
       <div>
         {{> (lookup . 'componentType') taskResult=taskResult}}

--- a/packages/core/src/base-task-result.ts
+++ b/packages/core/src/base-task-result.ts
@@ -2,9 +2,9 @@ import { Category, TaskMetaData } from './types';
 
 const CATEGORY_SORT_MAP = {
   [Category.Meta]: 4,
-  [Category.Core]: 3,
-  [Category.Insights]: 2,
-  [Category.Migration]: 1,
+  [Category.Insights]: 3,
+  [Category.Migrations]: 2,
+  [Category.Recommendations]: 1,
 };
 
 export default abstract class BaseTaskResult {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -18,9 +18,9 @@ export interface Parser {
 
 export const enum Category {
   Meta = 'meta',
-  Core = 'core',
-  Migration = 'migration',
   Insights = 'insights',
+  Migrations = 'migrations',
+  Recommendations = 'recommendations',
 }
 
 export const enum Priority {

--- a/packages/plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
+++ b/packages/plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Ember Octane Migration Status",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "medium",
     },
     "taskName": "octane-migration-status",

--- a/packages/plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -1,15 +1,17 @@
-import { CLIEngine } from 'eslint';
 import * as globby from 'globby';
+
 import { BaseTask, Category, Priority, Task } from '@checkup/core';
-import { getESLintEngine } from '../linters/es-lint';
-import { getTemplateLinter } from '../linters/ember-template-lint';
 import { OCTANE_ES_LINT_CONFIG, OCTANE_TEMPLATE_LINT_CONFIG } from '../utils/lint-configs';
-import { OctaneMigrationStatusTaskResult } from '../results';
 import {
   TemplateLintMessage,
   TemplateLintReport,
   TemplateLintResult,
 } from '../types/ember-template-lint';
+
+import { CLIEngine } from 'eslint';
+import { OctaneMigrationStatusTaskResult } from '../results';
+import { getESLintEngine } from '../linters/es-lint';
+import { getTemplateLinter } from '../linters/ember-template-lint';
 
 const fs = require('fs');
 const TemplateLinter = require('ember-template-lint');
@@ -20,7 +22,7 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
     taskName: 'octane-migration-status',
     friendlyTaskName: 'Ember Octane Migration Status',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Medium,
     },
   };

--- a/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
@@ -33,7 +33,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Project Dependencies",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "medium",
     },
     "taskName": "dependencies",

--- a/packages/plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
@@ -13,7 +13,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Ember Project",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "medium",
     },
     "taskName": "ember-project",
@@ -37,7 +37,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Ember Project",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "medium",
     },
     "taskName": "ember-project",

--- a/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Project Types",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "medium",
     },
     "taskName": "types",
@@ -120,7 +120,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Project Types",
     "taskClassification": Object {
-      "category": "core",
+      "category": "insights",
       "priority": "medium",
     },
     "taskName": "types",

--- a/packages/plugin-ember/src/tasks/dependencies-task.ts
+++ b/packages/plugin-ember/src/tasks/dependencies-task.ts
@@ -61,7 +61,7 @@ export default class DependenciesTask extends BaseTask implements Task {
     taskName: 'dependencies',
     friendlyTaskName: 'Project Dependencies',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Medium,
     },
   };

--- a/packages/plugin-ember/src/tasks/ember-project-task.ts
+++ b/packages/plugin-ember/src/tasks/ember-project-task.ts
@@ -8,7 +8,7 @@ export default class EmberProjectTask extends BaseTask implements Task {
     taskName: 'ember-project',
     friendlyTaskName: 'Ember Project',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Medium,
     },
   };

--- a/packages/plugin-ember/src/tasks/types-task.ts
+++ b/packages/plugin-ember/src/tasks/types-task.ts
@@ -20,7 +20,7 @@ export default class TypesTask extends FileSearcherTask implements Task {
     taskName: 'types',
     friendlyTaskName: 'Project Types',
     taskClassification: {
-      category: Category.Core,
+      category: Category.Insights,
       priority: Priority.Medium,
     },
   };


### PR DESCRIPTION
Cleanup of `Category` enum.

- remove `Core`
- change `Core` tasks to Insights
- add `Recommended` category (to be used for future tasks)