### PR TITLE
Removing `undefined` from `ReportResultData`, and adding mock results to all existing tasks

### DIFF
--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -1,4 +1,10 @@
-import { BaseTaskResult, Category, TaskMetaData, TaskResult } from '@checkup/core';
+import {
+  BaseTaskResult,
+  Category,
+  TaskMetaData,
+  TaskResult,
+  NumericalCardData,
+} from '@checkup/core';
 
 export default class MockTaskResult extends BaseTaskResult implements TaskResult {
   constructor(meta: TaskMetaData, public result: any) {
@@ -23,6 +29,6 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
   }
 
   pdf() {
-    return undefined;
+    return new NumericalCardData(this.meta, this.result, 'this is a description of your result');
   }
 }

--- a/packages/cli/__tests__/__utils__/render-partial.ts
+++ b/packages/cli/__tests__/__utils__/render-partial.ts
@@ -21,10 +21,5 @@ function getPartialDelegate(partialPath: string): HandlebarsTemplateDelegate {
 }
 
 export function renderPartialAsHtml(componentData: ReportResultData): string {
-  // TODO: remove this check once all tasks are retrofitted to return results (and undefined  is no longer a valid option for ReportResultsData)
-  if (componentData) {
-    return COMPILED_PARTIALS[componentData.componentType]({ taskResult: componentData });
-  }
-
-  return '';
+  return COMPILED_PARTIALS[componentData.componentType]({ taskResult: componentData });
 }

--- a/packages/cli/src/results/checkup-meta-task-result.ts
+++ b/packages/cli/src/results/checkup-meta-task-result.ts
@@ -1,4 +1,4 @@
-import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskResult, ui, NumericalCardData } from '@checkup/core';
 
 export default class CheckupMetaTaskResult extends BaseTaskResult implements TaskResult {
   configHash!: string;
@@ -23,6 +23,7 @@ export default class CheckupMetaTaskResult extends BaseTaskResult implements Tas
   }
 
   pdf() {
-    return undefined;
+    // TODO: add in correct data type for CheckupMetaTaskResult
+    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -1,4 +1,4 @@
-import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskResult, ui, NumericalCardData } from '@checkup/core';
 
 import { RepositoryInfo } from '../types';
 
@@ -36,6 +36,7 @@ export default class ProjectMetaTaskResult extends BaseTaskResult implements Tas
   }
 
   pdf() {
-    return undefined;
+    // TODO: add in correct data type for CheckupMetaTaskResult
+    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -67,14 +67,9 @@ export enum ReporterType {
   pdf = 'pdf',
 }
 
-export type ReportResultData =
-  | NumericalCardData
-  | TableData
-  | GradedTableData
-  | PieChartData
-  | undefined; //TODO: removed `undefined` once all tasks are retrofitted to return results
+export type ReportResultData = NumericalCardData | TableData | GradedTableData | PieChartData;
 
-export enum ReportComponentType {
+export const enum ReportComponentType {
   NumericalCard = 'numerical-card',
   Table = 'table',
   GradedTable = 'graded-table',

--- a/packages/plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -1,12 +1,18 @@
-import { BaseTaskResult, TaskMetaData, TaskResult, TemplateLintReport, ui } from '@checkup/core';
+import {
+  BaseTaskResult,
+  NumericalCardData,
+  TaskMetaData,
+  TaskResult,
+  ui,
+  TemplateLintReport,
+} from '@checkup/core';
+import { CLIEngine } from 'eslint';
+import { ESLintMigrationType, MigrationInfo, TemplateLintMigrationType } from '../types';
 import {
   ESLINT_MIGRATION_TASK_CONFIGS,
   TEMPLATE_LINT_MIGRATION_TASK_CONFIGS,
 } from '../utils/task-configs';
-import { ESLintMigrationType, MigrationInfo, TemplateLintMigrationType } from '../types';
 import { transformESLintReport, transformTemplateLintReport } from '../utils/transformers';
-
-import { CLIEngine } from 'eslint';
 
 export default class OctaneMigrationStatusTaskResult extends BaseTaskResult implements TaskResult {
   taskName: string = 'Octane Migration Status';
@@ -118,6 +124,7 @@ export default class OctaneMigrationStatusTaskResult extends BaseTaskResult impl
   }
 
   pdf() {
-    return undefined;
+    // TODO: add in correct data type for OctaneMigrationStatusTaskResult
+    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }

--- a/packages/plugin-ember/src/results/dependencies-task-result.ts
+++ b/packages/plugin-ember/src/results/dependencies-task-result.ts
@@ -1,4 +1,11 @@
-import { BaseTaskResult, TaskMetaData, TaskResult, toPairs, ui } from '@checkup/core';
+import {
+  BaseTaskResult,
+  TaskMetaData,
+  TaskResult,
+  toPairs,
+  ui,
+  NumericalCardData,
+} from '@checkup/core';
 
 import { PackageJson } from 'type-fest';
 
@@ -54,7 +61,8 @@ export default class DependenciesTaskResult extends BaseTaskResult implements Ta
   }
 
   pdf() {
-    return undefined;
+    // TODO: add in correct data type for DependenciesTaskResult
+    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 
   _writeDependencySection(header: string, dependencies: PackageJson.Dependency) {

--- a/packages/plugin-ember/src/results/ember-project-task-result.ts
+++ b/packages/plugin-ember/src/results/ember-project-task-result.ts
@@ -1,4 +1,4 @@
-import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskResult, ui, NumericalCardData } from '@checkup/core';
 
 export default class EmberProjectTaskResult extends BaseTaskResult implements TaskResult {
   type!: string;
@@ -19,6 +19,7 @@ export default class EmberProjectTaskResult extends BaseTaskResult implements Ta
   }
 
   pdf() {
-    return undefined;
+    // TODO: add in correct data type for EmberProjectTaskResult
+    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }

--- a/packages/plugin-ember/src/results/types-task-result.ts
+++ b/packages/plugin-ember/src/results/types-task-result.ts
@@ -1,4 +1,4 @@
-import { BaseTaskResult, TaskItemData, TaskResult, ui } from '@checkup/core';
+import { BaseTaskResult, TaskItemData, TaskResult, ui, NumericalCardData } from '@checkup/core';
 
 export default class TypesTaskResult extends BaseTaskResult implements TaskResult {
   types!: TaskItemData[];
@@ -19,6 +19,7 @@ export default class TypesTaskResult extends BaseTaskResult implements TaskResul
   }
 
   pdf() {
-    return undefined;
+    // TODO: add in correct data type for TypesTaskResult
+    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }


### PR DESCRIPTION
Having `undefined` as an option for `ReportResultData` was causing problems as we needed to account for `ReportResultData` being undefined, which it never will, it was just put there as an temporary measure until we retrofitted all existing tasks to return some real data. I put in another bandaid here, ensuring that each task result returns some mock data for the pdf() hook, instead of allowing it to return undefined