### PR TITLE
Adding --no-cache for jest tests to address test caching issues

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -50,7 +50,7 @@ exports[`plugin generator generates plugin with custom options 1`] = `
     \\"clean\\": \\"rm -rf lib\\",
     \\"postpack\\": \\"rm -f oclif.manifest.json\\",
     \\"prepack\\": \\"rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme\\",
-    \\"test\\": \\"jest\\",
+    \\"test\\": \\"jest --no-cache\\",
     \\"version\\": \\"oclif-dev readme && git add README.md\\"
   },
   \\"types\\": \\"lib/index.d.ts\\",
@@ -201,7 +201,7 @@ exports[`plugin generator generates plugin with defaults 1`] = `
     \\"clean\\": \\"rm -rf lib\\",
     \\"postpack\\": \\"rm -f oclif.manifest.json\\",
     \\"prepack\\": \\"rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme\\",
-    \\"test\\": \\"jest\\",
+    \\"test\\": \\"jest --no-cache\\",
     \\"version\\": \\"oclif-dev readme && git add README.md\\"
   },
   \\"types\\": \\"lib/index.d.ts\\",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
     "build:watch": "yarn build -w",
     "clean": "rm -rf lib",
     "prepack": "yarn build && oclif-dev readme",
-    "test": "jest --runInBand",
+    "test": "jest --runInBand --no-cache",
     "version": "oclif-dev readme && git add README.md",
     "copystatic": "cp -a ./src/static ./lib/static"
   },

--- a/packages/cli/templates/src/plugin/package.json.ejs
+++ b/packages/cli/templates/src/plugin/package.json.ejs
@@ -47,7 +47,7 @@
     "clean": "rm -rf lib",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "jest",
+    "test": "jest --no-cache",
     "version": "oclif-dev readme && git add README.md"
   },
   "types": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "build": "yarn clean && tsc",
     "build:watch": "yarn build -w",
     "clean": "rm -rf lib",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests --no-cache"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/parser-eslint/package.json
+++ b/packages/parser-eslint/package.json
@@ -41,7 +41,7 @@
     "build": "yarn clean && tsc",
     "build:watch": "yarn build -w",
     "clean": "rm -rf lib",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests --no-cache"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/plugin-ember-octane/package.json
+++ b/packages/plugin-ember-octane/package.json
@@ -53,7 +53,7 @@
     "clean": "rm -rf lib",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "jest",
+    "test": "jest --no-cache",
     "test:debug": "yarn clean && yarn build && node --inspect-brk=1337 node_modules/.bin/jest",
     "version": "oclif-dev readme && git add README.md"
   },

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -28,7 +28,7 @@
     "build": "yarn clean && tsc && yarn copystatic",
     "build:watch": "yarn build -w",
     "clean": "rm -rf lib",
-    "test": "jest --passWithNoTests",
+    "test": "jest --passWithNoTests --no-cache",
     "copystatic": "cp -a ./src/static ./lib/static"
   },
   "types": "lib/index.d.ts"


### PR DESCRIPTION
This is a path to address the sporadic TS caching issues within tests. Ultimately, we would like to leverage TS directly and avoid the use of ts-jest.