### PR TITLE
Fixing `task` flag

### DIFF
--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -101,11 +101,6 @@ Age:           0 days
 Total commits: 0
 Total files:   0
 
-=== Checkup Configuration
-configHash: 47def66968059c89c59bb41f477c180c
-version:    0.0.0
-
-mock task is being run
 "
 `;
 

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -197,7 +197,7 @@ describe('@checkup/cli', () => {
     );
 
     it('should run a single task if the task option is specified', async () => {
-      await cmd.run(['run', '--task', 'mock-task', project.baseDir]);
+      await cmd.run(['run', '--task', 'project', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -49,6 +49,38 @@ describe('TaskList', () => {
     expect(taskList.categories.get(Category.Insights)!.size).toEqual(1);
   });
 
+  it('hasTask returns false if no task exists with that name', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new MockTask());
+
+    expect(taskList.hasTask('foo')).toEqual(false);
+  });
+
+  it('hasTask returns true if task exists with that name', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new MockTask());
+
+    expect(taskList.hasTask('mock-task')).toEqual(true);
+  });
+
+  it('findTask returns undefined if no task exists with that name', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new MockTask());
+
+    expect(taskList.findTask('foo')).toBeUndefined();
+  });
+
+  it('findTask returns task instance if task exists with that name', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new MockTask());
+
+    expect(taskList.findTask('mock-task')).toBeDefined();
+  });
+
   it('runTask will run a task by taskName', async () => {
     let taskList = new TaskList();
 

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -37,6 +37,26 @@ export default class TaskList {
   }
 
   /**
+   * Evaluates whether a task exists
+   *
+   * @method hasTask
+   * @param taskName The name of the task to check for existence of
+   */
+  hasTask(taskName: TaskName): boolean {
+    return this.findTask(taskName) !== undefined;
+  }
+
+  /**
+   * Finds a task by task name
+   *
+   * @method findTask
+   * @param taskName The name of the task to find
+   */
+  findTask(taskName: TaskName): Task | undefined {
+    return this.getTasks().find((task) => task.meta.taskName === taskName);
+  }
+
+  /**
    * Runs the task specified by the taskName parameter.
    *
    * @method runTask
@@ -44,23 +64,14 @@ export default class TaskList {
    * @returns {Promise<TaskResult>}
    * @memberof TaskList
    */
-  runTask(taskName: TaskName): Promise<TaskResult> {
-    let task: Task | undefined;
-
-    // TODO: Find a less gross way to do this
-    for (let [, map] of this.categories) {
-      task = map.getTask(taskName);
-
-      if (task !== undefined) {
-        break;
-      }
-    }
+  async runTask(taskName: TaskName): Promise<TaskResult> {
+    let task: Task | undefined = this.findTask(taskName);
 
     if (task === undefined) {
       throw new Error(`The ${taskName} task was not found`);
     }
 
-    return task.run();
+    return await task.run();
   }
 
   /**


### PR DESCRIPTION
The task flag was broken in that it would only run plugin-based tasks. This fix ensures it finds the correct task.