### PR TITLE
Removing meta category. Making meta tasks internal

### DIFF
--- a/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
@@ -1,0 +1,19 @@
+import { MetaTaskResult, TaskIdentifier } from '../../src/types';
+
+import BaseMetaTaskResult from '../../src/base-meta-task-result';
+
+export default class MockMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
+  constructor(meta: TaskIdentifier, public result: any) {
+    super(meta);
+  }
+
+  stdout() {
+    process.stdout.write(`Result for ${this.meta.taskName}`);
+  }
+
+  json() {
+    return {
+      [this.meta.taskName]: this.result,
+    };
+  }
+}

--- a/packages/cli/__tests__/__utils__/mock-meta-task.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task.ts
@@ -1,0 +1,22 @@
+import { MetaTask, MetaTaskResult, TaskIdentifier } from '../../src/types';
+
+import { BaseTask } from '@checkup/core';
+import MockMetaTaskResult from './mock-meta-task-result';
+
+const DEFAULT_META = {
+  taskName: 'mock-task',
+  friendlyTaskName: 'Mock Task',
+};
+
+export default class MockMetaTask extends BaseTask implements MetaTask {
+  meta: TaskIdentifier;
+
+  constructor(meta: TaskIdentifier = DEFAULT_META) {
+    super({});
+    this.meta = meta;
+  }
+
+  async run(): Promise<MetaTaskResult> {
+    return new MockMetaTaskResult(this.meta, `${this.meta.taskName} is being run`);
+  }
+}

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -1,10 +1,4 @@
-import {
-  BaseTaskResult,
-  Category,
-  TaskMetaData,
-  TaskResult,
-  NumericalCardData,
-} from '@checkup/core';
+import { BaseTaskResult, NumericalCardData, TaskMetaData, TaskResult } from '@checkup/core';
 
 export default class MockTaskResult extends BaseTaskResult implements TaskResult {
   constructor(meta: TaskMetaData, public result: any) {
@@ -16,16 +10,10 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
   }
 
   json() {
-    if (this.meta.taskClassification.category === Category.Meta) {
-      return {
-        [this.meta.taskName]: this.result,
-      };
-    } else {
-      return {
-        meta: this.meta,
-        result: this.result,
-      };
-    }
+    return {
+      meta: this.meta,
+      result: this.result,
+    };
   }
 
   pdf() {

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -1,36 +1,30 @@
-import { Category, Priority, TaskResult, ReporterType } from '@checkup/core';
+import { Category, Priority, ReporterType, TaskResult } from '@checkup/core';
 
+import { MetaTaskResult } from '../src/types';
+import MockMetaTaskResult from './__utils__/mock-meta-task-result';
 import MockTaskResult from './__utils__/mock-task-result';
 import { _transformResults } from '../src/reporters';
 
 describe('_transformResults', () => {
-  let metaTaskResults: TaskResult[];
+  let metaTaskResults: MetaTaskResult[];
   let pluginTaskResults: TaskResult[];
 
   it('transforms meta and plugin results into correct format', () => {
     metaTaskResults = [
-      new MockTaskResult(
+      new MockMetaTaskResult(
         {
           taskName: 'mock-meta-task-1',
           friendlyTaskName: 'Mock Meta Task 1',
-          taskClassification: {
-            category: Category.Meta,
-            priority: Priority.High,
-          },
         },
         {
           foo: true,
           bar: 'baz',
         }
       ),
-      new MockTaskResult(
+      new MockMetaTaskResult(
         {
           taskName: 'mock-meta-task-2',
           friendlyTaskName: 'Mock Meta Task 2',
-          taskClassification: {
-            category: Category.Meta,
-            priority: Priority.High,
-          },
         },
         {
           blarg: false,

--- a/packages/cli/src/base-meta-task-result.ts
+++ b/packages/cli/src/base-meta-task-result.ts
@@ -1,0 +1,9 @@
+import { TaskIdentifier } from './types';
+
+export default abstract class BaseMetaTaskResult {
+  meta: TaskIdentifier;
+
+  constructor(meta: TaskIdentifier) {
+    this.meta = meta;
+  }
+}

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -16,6 +16,8 @@ import {
 import { Command, flags } from '@oclif/command';
 
 import CheckupMetaTask from '../tasks/checkup-meta-task';
+import MetaTaskList from '../meta-task-list';
+import { MetaTaskResult } from '../types';
 import ProjectMetaTask from '../tasks/project-meta-task';
 import TaskList from '../task-list';
 import { getReporter } from '../reporters';
@@ -53,8 +55,8 @@ export default class RunCommand extends Command {
     }),
   };
 
-  defaultTasks: TaskList = new TaskList();
-  metaTaskResults: TaskResult[] = [];
+  defaultTasks: MetaTaskList = new MetaTaskList();
+  metaTaskResults: MetaTaskResult[] = [];
   pluginTasks: TaskList = new TaskList();
   pluginTaskResults: TaskResult[] = [];
   checkupConfig!: CheckupConfig;

--- a/packages/cli/src/generators/task.ts
+++ b/packages/cli/src/generators/task.ts
@@ -79,7 +79,6 @@ export default class TaskGenerator extends Generator {
           name: 'category',
           message: 'Select a task category',
           choices: [
-            { name: 'meta', value: 'Meta' },
             { name: 'insights', value: 'Insights' },
             { name: 'migrations', value: 'Migrations' },
             { name: 'recommendations', value: 'Recommendations' },

--- a/packages/cli/src/meta-task-list.ts
+++ b/packages/cli/src/meta-task-list.ts
@@ -1,0 +1,55 @@
+import * as debug from 'debug';
+import * as pMap from 'p-map';
+
+import { MetaTask, MetaTaskResult } from './types';
+
+import { TaskName } from '@checkup/core';
+
+export default class MetaTaskList {
+  public _entries: Map<TaskName, MetaTask>;
+  debug: debug.Debugger;
+
+  constructor() {
+    this._entries = new Map<TaskName, MetaTask>();
+    this.debug = debug('checkup:meta-task');
+  }
+
+  registerTask(task: MetaTask) {
+    this._entries.set(task.meta.taskName, task);
+  }
+
+  hasTask(taskName: TaskName): boolean {
+    return this._entries.has(taskName);
+  }
+
+  findTask(taskName: TaskName): MetaTask | undefined {
+    return this._entries.get(taskName);
+  }
+
+  async runTask(taskName: TaskName): Promise<MetaTaskResult> {
+    let task: MetaTask | undefined = this.findTask(taskName);
+
+    if (task === undefined) {
+      throw new Error(`The ${taskName} task was not found`);
+    }
+
+    return await task.run();
+  }
+
+  async runTasks(): Promise<MetaTaskResult[]> {
+    let results = await this.eachTask(async (task: MetaTask) => {
+      this.debug('start %s run', task.constructor.name);
+
+      let result = await task.run();
+
+      this.debug('%s run done', task.constructor.name);
+      return result;
+    });
+
+    return results;
+  }
+
+  private eachTask(fn: (task: MetaTask) => Promise<MetaTaskResult>): Promise<MetaTaskResult[]> {
+    return pMap([...this._entries.values()], fn);
+  }
+}

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -1,14 +1,15 @@
 import { ReporterType, TaskResult, ui } from '@checkup/core';
 
+import { MetaTaskResult } from './types';
 import { generateReport } from './helpers/pdf';
 
 export function _transformResults(
-  metaTaskResults: TaskResult[],
+  metaTaskResults: MetaTaskResult[],
   pluginTaskResults: TaskResult[],
   reporterType: ReporterType
 ) {
   let transformedResult = {
-    meta: Object.assign({}, ...metaTaskResults.map((result) => result[reporterType]())),
+    meta: Object.assign({}, ...metaTaskResults.map((result) => result.json())),
     results: pluginTaskResults.map((result) => result[reporterType]()),
   };
 
@@ -17,7 +18,7 @@ export function _transformResults(
 
 export function getReporter(
   flags: any,
-  metaTaskResults: TaskResult[],
+  metaTaskResults: MetaTaskResult[],
   pluginTaskResults: TaskResult[]
 ) {
   switch (flags.reporter) {

--- a/packages/cli/src/results/checkup-meta-task-result.ts
+++ b/packages/cli/src/results/checkup-meta-task-result.ts
@@ -1,6 +1,8 @@
-import { BaseTaskResult, TaskResult, ui, NumericalCardData } from '@checkup/core';
+import BaseMetaTaskResult from '../base-meta-task-result';
+import { MetaTaskResult } from '../types';
+import { ui } from '@checkup/core';
 
-export default class CheckupMetaTaskResult extends BaseTaskResult implements TaskResult {
+export default class CheckupMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
   configHash!: string;
   version!: string;
 
@@ -20,10 +22,5 @@ export default class CheckupMetaTaskResult extends BaseTaskResult implements Tas
         version: this.version,
       },
     };
-  }
-
-  pdf() {
-    // TODO: add in correct data type for CheckupMetaTaskResult
-    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -1,8 +1,9 @@
-import { BaseTaskResult, TaskResult, ui, NumericalCardData } from '@checkup/core';
+import { MetaTaskResult, RepositoryInfo } from '../types';
 
-import { RepositoryInfo } from '../types';
+import BaseMetaTaskResult from '../base-meta-task-result';
+import { ui } from '@checkup/core';
 
-export default class ProjectMetaTaskResult extends BaseTaskResult implements TaskResult {
+export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
   name!: string;
   version!: string;
   repository!: RepositoryInfo;
@@ -33,10 +34,5 @@ export default class ProjectMetaTaskResult extends BaseTaskResult implements Tas
         repository: this.repository,
       },
     };
-  }
-
-  pdf() {
-    // TODO: add in correct data type for CheckupMetaTaskResult
-    return new NumericalCardData(this.meta, 22, 'this is a description of your result');
   }
 }

--- a/packages/cli/src/tasks/checkup-meta-task.ts
+++ b/packages/cli/src/tasks/checkup-meta-task.ts
@@ -1,15 +1,8 @@
 import * as crypto from 'crypto';
 import * as stringify from 'json-stable-stringify';
 
-import {
-  BaseTask,
-  Category,
-  CheckupConfig,
-  Priority,
-  Task,
-  TaskMetaData,
-  TaskResult,
-} from '@checkup/core';
+import { BaseTask, CheckupConfig } from '@checkup/core';
+import { MetaTask, MetaTaskResult, TaskIdentifier } from '../types';
 
 import CheckupMetaTaskResult from '../results/checkup-meta-task-result';
 import { getVersion } from '../helpers/get-version';
@@ -20,21 +13,17 @@ function getConfigHash(checkupConfig: CheckupConfig) {
   return crypto.createHash('md5').update(configAsJson).digest('hex');
 }
 
-export default class CheckupMetaTask extends BaseTask implements Task {
-  meta: TaskMetaData = {
+export default class CheckupMetaTask extends BaseTask implements MetaTask {
+  meta: TaskIdentifier = {
     taskName: 'checkup',
     friendlyTaskName: 'Checkup Configuration',
-    taskClassification: {
-      category: Category.Meta,
-      priority: Priority.High,
-    },
   };
 
   constructor(cliArguments: any, public checkupConfig: CheckupConfig) {
     super(cliArguments);
   }
 
-  async run(): Promise<TaskResult> {
+  async run(): Promise<MetaTaskResult> {
     let result: CheckupMetaTaskResult = new CheckupMetaTaskResult(this.meta);
 
     result.configHash = getConfigHash(this.checkupConfig);

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -1,27 +1,16 @@
-import {
-  BaseTask,
-  Category,
-  Priority,
-  Task,
-  TaskMetaData,
-  TaskResult,
-  getPackageJson,
-} from '@checkup/core';
+import { BaseTask, getPackageJson } from '@checkup/core';
+import { MetaTask, MetaTaskResult, TaskIdentifier } from '../types';
 
 import ProjectMetaTaskResult from '../results/project-meta-task-result';
 import { getRepositoryInfo } from '../helpers/repository';
 
-export default class ProjectMetaTask extends BaseTask implements Task {
-  meta: TaskMetaData = {
+export default class ProjectMetaTask extends BaseTask implements MetaTask {
+  meta: TaskIdentifier = {
     taskName: 'project',
     friendlyTaskName: 'Project',
-    taskClassification: {
-      category: Category.Meta,
-      priority: Priority.High,
-    },
   };
 
-  async run(): Promise<TaskResult> {
+  async run(): Promise<MetaTaskResult> {
     let result: ProjectMetaTaskResult = new ProjectMetaTaskResult(this.meta);
     let package_ = getPackageJson(this.args.path);
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,4 +1,19 @@
+import { JsonMetaTaskResult } from '@checkup/core';
+
 export default {};
+
+export type TaskIdentifier = { taskName: string; friendlyTaskName: string };
+
+export interface MetaTask {
+  meta: TaskIdentifier;
+
+  run: () => Promise<MetaTaskResult>;
+}
+
+export interface MetaTaskResult {
+  stdout: () => void;
+  json: () => JsonMetaTaskResult;
+}
 
 export const enum TestType {
   Application = 'application',

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -37,7 +37,6 @@ export interface TaskItemData {
 }
 
 export const enum Category {
-  Meta = 'meta',
   Insights = 'insights',
   Migrations = 'migrations',
   Recommendations = 'recommendations',

--- a/packages/core/src/utils/task-result-comparator.ts
+++ b/packages/core/src/utils/task-result-comparator.ts
@@ -3,7 +3,6 @@ import { Category, Priority, TaskClassification } from '../types/tasks';
 import BaseTaskResult from '../base-task-result';
 
 const CATEGORY_SORT_MAP = {
-  [Category.Meta]: 4,
   [Category.Insights]: 3,
   [Category.Migrations]: 2,
   [Category.Recommendations]: 1,


### PR DESCRIPTION
As discussed, we needed to split the meta tasks out to a separate data structure and make them private. This change adds a separate `MetaTaskList` that operates on `MetaTask`s, and return `MetaTaskResult`s.