### PR TITLE
Splitting out pdf results into sections

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
@@ -5,8 +5,8 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Ember Octane Migration Status",
     "taskClassification": Object {
-      "category": "insights",
-      "priority": "medium",
+      "category": "migrations",
+      "priority": "high",
     },
     "taskName": "octane-migration-status",
   },

--- a/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -24,8 +24,8 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
     taskName: 'octane-migration-status',
     friendlyTaskName: 'Ember Octane Migration Status',
     taskClassification: {
-      category: Category.Insights,
-      priority: Priority.Medium,
+      category: Category.Migrations,
+      priority: Priority.High,
     },
   };
 

--- a/packages/cli/__tests__/__snapshots__/reporters-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/reporters-test.ts.snap
@@ -1,0 +1,217 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_transformPdfResults transforms meta and plugin results into correct format when chart IS required 1`] = `
+Object {
+  "meta": Object {
+    "mock-meta-task-1": Object {
+      "bar": "baz",
+      "foo": true,
+    },
+    "mock-meta-task-2": Object {
+      "blarg": false,
+      "bleek": Object {
+        "bork": "bye!",
+      },
+    },
+  },
+  "requiresChart": true,
+  "results": Object {
+    "insights": Object {
+      "high": Array [],
+      "low": Array [],
+      "medium": Array [
+        PieChartData {
+          "UUID": 100,
+          "backgroundColors": Array [
+            "\\"#4FD1C5\\"",
+            "\\"#7F9CF5\\"",
+            "\\"#FC8181\\"",
+            "\\"#63B3ED\\"",
+          ],
+          "componentType": "pie-chart",
+          "grade": "A",
+          "labels": Array [
+            "\\"blah\\"",
+            "\\"blah\\"",
+            "\\"black\\"",
+            "\\"sheep\\"",
+          ],
+          "meta": Object {
+            "friendlyTaskName": "Mock Task",
+            "taskClassification": Object {
+              "category": "insights",
+              "priority": "medium",
+            },
+            "taskName": "mock-task",
+          },
+          "resultDescription": "this is a chart",
+          "values": Array [
+            33,
+            23,
+            13,
+            3,
+          ],
+        },
+      ],
+    },
+    "migrations": Object {
+      "high": Array [],
+      "low": Array [],
+      "medium": Array [],
+    },
+    "recommendations": Object {
+      "high": Array [],
+      "low": Array [],
+      "medium": Array [],
+    },
+  },
+}
+`;
+
+exports[`_transformPdfResults transforms meta and plugin results into correct format when chart is not required 1`] = `
+Object {
+  "meta": Object {
+    "mock-meta-task-1": Object {
+      "bar": "baz",
+      "foo": true,
+    },
+    "mock-meta-task-2": Object {
+      "blarg": false,
+      "bleek": Object {
+        "bork": "bye!",
+      },
+    },
+  },
+  "requiresChart": false,
+  "results": Object {
+    "insights": Object {
+      "high": Array [
+        NumericalCardData {
+          "componentType": "numerical-card",
+          "grade": "A",
+          "meta": Object {
+            "friendlyTaskName": "Mock Meta Task 3",
+            "taskClassification": Object {
+              "category": "insights",
+              "priority": "high",
+            },
+            "taskName": "mock-meta-task-3",
+          },
+          "resultData": Object {
+            "bar": "baz",
+            "foo": true,
+          },
+          "resultDescription": "this is a description of your result",
+          "resultHelp": undefined,
+        },
+        NumericalCardData {
+          "componentType": "numerical-card",
+          "grade": "A",
+          "meta": Object {
+            "friendlyTaskName": "Mock Meta Task 5",
+            "taskClassification": Object {
+              "category": "insights",
+              "priority": "high",
+            },
+            "taskName": "mock-meta-task-5",
+          },
+          "resultData": Object {
+            "bar": "baz",
+            "foo": true,
+          },
+          "resultDescription": "this is a description of your result",
+          "resultHelp": undefined,
+        },
+      ],
+      "low": Array [
+        NumericalCardData {
+          "componentType": "numerical-card",
+          "grade": "A",
+          "meta": Object {
+            "friendlyTaskName": "Mock Meta Task 6",
+            "taskClassification": Object {
+              "category": "insights",
+              "priority": "low",
+            },
+            "taskName": "mock-meta-task-6",
+          },
+          "resultData": Object {
+            "bar": "baz",
+            "foo": true,
+          },
+          "resultDescription": "this is a description of your result",
+          "resultHelp": undefined,
+        },
+      ],
+      "medium": Array [
+        NumericalCardData {
+          "componentType": "numerical-card",
+          "grade": "A",
+          "meta": Object {
+            "friendlyTaskName": "Mock Meta Task 4",
+            "taskClassification": Object {
+              "category": "insights",
+              "priority": "medium",
+            },
+            "taskName": "mock-meta-task-4",
+          },
+          "resultData": Object {
+            "bar": "baz",
+            "foo": true,
+          },
+          "resultDescription": "this is a description of your result",
+          "resultHelp": undefined,
+        },
+      ],
+    },
+    "migrations": Object {
+      "high": Array [
+        NumericalCardData {
+          "componentType": "numerical-card",
+          "grade": "A",
+          "meta": Object {
+            "friendlyTaskName": "Mock Meta Task 7",
+            "taskClassification": Object {
+              "category": "migrations",
+              "priority": "high",
+            },
+            "taskName": "mock-meta-task-7",
+          },
+          "resultData": Object {
+            "bar": "baz",
+            "foo": true,
+          },
+          "resultDescription": "this is a description of your result",
+          "resultHelp": undefined,
+        },
+      ],
+      "low": Array [
+        NumericalCardData {
+          "componentType": "numerical-card",
+          "grade": "A",
+          "meta": Object {
+            "friendlyTaskName": "Mock Meta Task 8",
+            "taskClassification": Object {
+              "category": "migrations",
+              "priority": "low",
+            },
+            "taskName": "mock-meta-task-8",
+          },
+          "resultData": Object {
+            "bar": "baz",
+            "foo": true,
+          },
+          "resultDescription": "this is a description of your result",
+          "resultHelp": undefined,
+        },
+      ],
+      "medium": Array [],
+    },
+    "recommendations": Object {
+      "high": Array [],
+      "low": Array [],
+      "medium": Array [],
+    },
+  },
+}
+`;

--- a/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
@@ -1,0 +1,46 @@
+import {
+  BaseTaskResult,
+  Priority,
+  PieChartData,
+  Category,
+  TaskMetaData,
+  TaskResult,
+} from '@checkup/core';
+
+export default class MockTaskResult extends BaseTaskResult implements TaskResult {
+  constructor(meta: TaskMetaData, public result: any) {
+    super(meta);
+  }
+
+  stdout() {
+    process.stdout.write(`Result for ${this.meta.taskName}`);
+  }
+
+  json() {
+    return {
+      meta: this.meta,
+      result: this.result,
+    };
+  }
+
+  pdf() {
+    return new PieChartData(
+      {
+        taskName: 'mock-task',
+        friendlyTaskName: 'Mock Task',
+        taskClassification: {
+          category: Category.Insights,
+          priority: Priority.Medium,
+        },
+      },
+      [
+        { value: 33, description: 'blah' },
+        { value: 23, description: 'blah' },
+        { value: 13, description: 'black' },
+        { value: 3, description: 'sheep' },
+      ],
+      'this is a chart',
+      100
+    );
+  }
+}

--- a/packages/cli/__tests__/pdf-test.ts
+++ b/packages/cli/__tests__/pdf-test.ts
@@ -1,4 +1,11 @@
-import { Category, NumericalCardData, Priority, TaskMetaData, PieChartData } from '@checkup/core';
+import {
+  Category,
+  NumericalCardData,
+  Priority,
+  TaskMetaData,
+  PieChartData,
+  UIReportData,
+} from '@checkup/core';
 
 import { generateHTML } from '../src/helpers/pdf';
 
@@ -29,9 +36,26 @@ describe('generateHTML', () => {
     },
   };
 
-  const mergedResults: any = {
+  const mergedResults: UIReportData = {
     meta: projectMeta,
-    results: [new NumericalCardData(taskMeta, 100, 'bad patterns in your app')],
+    results: {
+      [Category.Insights]: {
+        [Priority.High]: [],
+        [Priority.Medium]: [new NumericalCardData(taskMeta, 100, 'bad patterns in your app')],
+        [Priority.Low]: [],
+      },
+      [Category.Migrations]: {
+        [Priority.High]: [],
+        [Priority.Medium]: [],
+        [Priority.Low]: [],
+      },
+      [Category.Recommendations]: {
+        [Priority.High]: [],
+        [Priority.Medium]: [],
+        [Priority.Low]: [],
+      },
+    },
+    requiresChart: false,
   };
 
   it('returns correct HTML string', async () => {
@@ -58,16 +82,51 @@ describe('generateHTML', () => {
           <h2 class=\\"text-base italic\\">This project is 8 years old, has been active for 1380 days, has 1571 files, and 5870 commits</h2>
         </div>
 
-        <div class=\\"grid grid-cols-3 gap-4\\">
-            <div class=\\"max-w-sm rounded overflow-hidden shadow-lg bg-white\\">
-              <div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
-                <div class=\\"text-xl font-bold self-end\\">A</div>
-                <h1 class=\\"text-xl self-center\\">Mock Task</h1>
-                <div class=\\"text-4xl self-center\\">100</div>
-                <p>bad patterns in your app</p>
+          <section class=\\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 border border-gray-500 m-5\\">
+          <h3>insights</h3>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>high</h4>
               </div>
-            </div>
-        </div>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>medium</h4>
+                  <div class=\\"max-w-sm rounded overflow-hidden shadow-lg bg-white\\">
+                    <div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
+                      <div class=\\"text-xl font-bold self-end\\">A</div>
+                      <h1 class=\\"text-xl self-center\\">Mock Task</h1>
+                      <div class=\\"text-4xl self-center\\">100</div>
+                      <p>bad patterns in your app</p>
+                    </div>
+                  </div>
+              </div>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>low</h4>
+              </div>
+          </section>
+          <section class=\\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 border border-gray-500 m-5\\">
+          <h3>migrations</h3>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>high</h4>
+              </div>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>medium</h4>
+              </div>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>low</h4>
+              </div>
+          </section>
+          <section class=\\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 border border-gray-500 m-5\\">
+          <h3>recommendations</h3>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>high</h4>
+              </div>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>medium</h4>
+              </div>
+              <div class=\\"grid grid-cols-3 gap-4\\">
+                <h4>low</h4>
+              </div>
+          </section>
+
       </body>
       </html>
       "
@@ -86,25 +145,42 @@ describe('generateHTML', () => {
   it('includes chartsjs css and js when there is a pie-chart being rendered as part of the results', async () => {
     const htmlString = await generateHTML({
       meta: projectMeta,
-      results: [
-        new PieChartData(
-          {
-            taskName: 'mock-task',
-            friendlyTaskName: 'Mock Task',
-            taskClassification: {
-              category: Category.Insights,
-              priority: Priority.Medium,
-            },
-          },
-          [
-            { value: 33, description: 'blah' },
-            { value: 23, description: 'blah' },
-            { value: 13, description: 'black' },
-            { value: 3, description: 'sheep' },
+      results: {
+        [Category.Insights]: {
+          [Priority.High]: [],
+          [Priority.Medium]: [],
+          [Priority.Low]: [],
+        },
+        [Category.Migrations]: {
+          [Priority.High]: [],
+          [Priority.Medium]: [],
+          [Priority.Low]: [],
+        },
+        [Category.Recommendations]: {
+          [Priority.High]: [],
+          [Priority.Medium]: [
+            new PieChartData(
+              {
+                taskName: 'mock-task',
+                friendlyTaskName: 'Mock Task',
+                taskClassification: {
+                  category: Category.Insights,
+                  priority: Priority.Medium,
+                },
+              },
+              [
+                { value: 33, description: 'blah' },
+                { value: 23, description: 'blah' },
+                { value: 13, description: 'black' },
+                { value: 3, description: 'sheep' },
+              ],
+              'this is a chart'
+            ),
           ],
-          'this is a chart'
-        ),
-      ],
+          [Priority.Low]: [],
+        },
+      },
+      requiresChart: true,
     });
 
     expect(htmlString).toContain('Chart.js v2.9.3 CSS');

--- a/packages/cli/__tests__/report-components/numerical-card-test.ts
+++ b/packages/cli/__tests__/report-components/numerical-card-test.ts
@@ -21,13 +21,11 @@ describe('the correct data is rendered for a numerical card', () => {
     );
 
     expect(htmlString).toMatchInlineSnapshot(`
-      "<div class=\\"max-w-sm rounded overflow-hidden shadow-lg bg-white\\">
-        <div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
-          <div class=\\"text-xl font-bold self-end\\">A</div>
-          <h1 class=\\"text-xl self-center\\">Mock Task</h1>
-          <div class=\\"text-4xl self-center\\">100</div>
-          <p>bad patterns in your app</p>
-        </div>
+      "<div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
+        <div class=\\"text-xl font-bold self-end\\">A</div>
+        <h1 class=\\"text-xl self-center\\">Mock Task</h1>
+        <div class=\\"text-4xl self-center\\">100</div>
+        <p>bad patterns in your app</p>
       </div>
       "
     `);

--- a/packages/cli/__tests__/report-components/pie-chart-test.ts
+++ b/packages/cli/__tests__/report-components/pie-chart-test.ts
@@ -25,11 +25,9 @@ describe('the correct data is rendered for a pie chart', () => {
     );
 
     expect(htmlString).toMatchInlineSnapshot(`
-      "<div class=\\"max-w-sm rounded overflow-hidden shadow-lg bg-white\\">
-        <div class=\\"px-6 py-4\\">
-          <div class=\\"font-bold text-xl mb-2\\">Mock Task</div>
-          <canvas id=\\"chart-area-100\\"></canvas>
-        </div>
+      "<div class=\\"px-6 py-4\\">
+        <div class=\\"font-bold text-xl mb-2\\">Mock Task</div>
+        <canvas id=\\"chart-area-100\\"></canvas>
       </div>
 
 

--- a/packages/cli/__tests__/report-components/table-test.ts
+++ b/packages/cli/__tests__/report-components/table-test.ts
@@ -34,33 +34,31 @@ describe('the correct data is rendered for a table', () => {
     );
 
     expect(htmlString).toMatchInlineSnapshot(`
-      "<div class=\\"max-w-sm rounded overflow-hidden shadow-lg bg-white\\">
-        <div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
-          <div class=\\"text-xl font-bold self-center\\">Mock Task</div>
+      "<div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
+        <div class=\\"text-xl font-bold self-center\\">Mock Task</div>
 
-          <table class=\\"table-auto rounded\\">
-            <thead>
-              <tr class=\\"font-bold\\">
-                  <th class=\\"px-4 py-2\\">name</th>
-                  <th class=\\"px-4 py-2\\">value</th>
+        <table class=\\"table-auto rounded\\">
+          <thead>
+            <tr class=\\"font-bold\\">
+                <th class=\\"px-4 py-2\\">name</th>
+                <th class=\\"px-4 py-2\\">value</th>
+            </tr>
+          </thead>
+          <tbody>
+              <tr class=\\"bg-gray-100\\">
+                  <td class=\\"border px-4 py-2\\">reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaly-long-name</td>
+                  <td class=\\"border px-4 py-2\\">12.2.2</td>
               </tr>
-            </thead>
-            <tbody>
-                <tr class=\\"bg-gray-100\\">
-                    <td class=\\"border px-4 py-2\\">reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaly-long-name</td>
-                    <td class=\\"border px-4 py-2\\">12.2.2</td>
-                </tr>
-                <tr class=\\"bg-gray-100\\">
-                    <td class=\\"border px-4 py-2\\">foo</td>
-                    <td class=\\"border px-4 py-2\\">4.2.2</td>
-                </tr>
-                <tr class=\\"bg-gray-100\\">
-                    <td class=\\"border px-4 py-2\\">bar</td>
-                    <td class=\\"border px-4 py-2\\">6.1.2</td>
-                </tr>
-            </tbody>
-          </table>
-        </div>
+              <tr class=\\"bg-gray-100\\">
+                  <td class=\\"border px-4 py-2\\">foo</td>
+                  <td class=\\"border px-4 py-2\\">4.2.2</td>
+              </tr>
+              <tr class=\\"bg-gray-100\\">
+                  <td class=\\"border px-4 py-2\\">bar</td>
+                  <td class=\\"border px-4 py-2\\">6.1.2</td>
+              </tr>
+          </tbody>
+        </table>
       </div>
       "
     `);
@@ -89,33 +87,31 @@ describe('the correct data is rendered for a graded table', () => {
     );
 
     expect(htmlString).toMatchInlineSnapshot(`
-      "<div class=\\"max-w-sm rounded overflow-hidden shadow-lg bg-white\\">
-        <div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
-          <div class=\\"text-xl font-bold self-center\\">Mock Task</div>
+      "<div class=\\"px-6 py-4 flex flex-wrap flex-col\\">
+        <div class=\\"text-xl font-bold self-center\\">Mock Task</div>
 
-          <table class=\\"table-auto rounded\\">
-            <thead>
-              <tr class=\\"font-bold\\">
-                  <th class=\\"px-4 py-2\\">name</th>
-                  <th class=\\"px-4 py-2\\">value</th>
+        <table class=\\"table-auto rounded\\">
+          <thead>
+            <tr class=\\"font-bold\\">
+                <th class=\\"px-4 py-2\\">name</th>
+                <th class=\\"px-4 py-2\\">value</th>
+            </tr>
+          </thead>
+          <tbody>
+              <tr class=\\"bg-green-600\\">
+                  <td class=\\"border px-4 py-2\\">foo</td>
+                  <td class=\\"border px-4 py-2\\">12.2.2</td>
               </tr>
-            </thead>
-            <tbody>
-                <tr class=\\"bg-green-600\\">
-                    <td class=\\"border px-4 py-2\\">foo</td>
-                    <td class=\\"border px-4 py-2\\">12.2.2</td>
-                </tr>
-                <tr class=\\"bg-green-200\\">
-                    <td class=\\"border px-4 py-2\\">bar</td>
-                    <td class=\\"border px-4 py-2\\">4.2.2</td>
-                </tr>
-                <tr class=\\"bg-orange-500\\">
-                    <td class=\\"border px-4 py-2\\">baz</td>
-                    <td class=\\"border px-4 py-2\\">6.1.2</td>
-                </tr>
-            </tbody>
-          </table>
-        </div>
+              <tr class=\\"bg-green-200\\">
+                  <td class=\\"border px-4 py-2\\">bar</td>
+                  <td class=\\"border px-4 py-2\\">4.2.2</td>
+              </tr>
+              <tr class=\\"bg-orange-500\\">
+                  <td class=\\"border px-4 py-2\\">baz</td>
+                  <td class=\\"border px-4 py-2\\">6.1.2</td>
+              </tr>
+          </tbody>
+        </table>
       </div>
       "
     `);

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -1,126 +1,127 @@
-import { Category, Priority, ReporterType, TaskResult } from '@checkup/core';
+import { Category, Priority, TaskResult } from '@checkup/core';
 
 import { MetaTaskResult } from '../src/types';
 import MockMetaTaskResult from './__utils__/mock-meta-task-result';
 import MockTaskResult from './__utils__/mock-task-result';
-import { _transformResults } from '../src/reporters';
+import MockPieChartTaskResult from './__utils__/mock-pie-chart-task-result';
+import { _transformJsonResults, _transformPdfResults } from '../src/reporters';
 
-describe('_transformResults', () => {
-  let metaTaskResults: MetaTaskResult[];
-  let pluginTaskResults: TaskResult[];
+let metaTaskResults: MetaTaskResult[];
+let pluginTaskResults: TaskResult[];
 
+metaTaskResults = [
+  new MockMetaTaskResult(
+    {
+      taskName: 'mock-meta-task-1',
+      friendlyTaskName: 'Mock Meta Task 1',
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+  new MockMetaTaskResult(
+    {
+      taskName: 'mock-meta-task-2',
+      friendlyTaskName: 'Mock Meta Task 2',
+    },
+    {
+      blarg: false,
+      bleek: { bork: 'bye!' },
+    }
+  ),
+];
+
+pluginTaskResults = [
+  new MockTaskResult(
+    {
+      taskName: 'mock-meta-task-6',
+      friendlyTaskName: 'Mock Meta Task 6',
+      taskClassification: {
+        category: Category.Insights,
+        priority: Priority.Low,
+      },
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+  new MockTaskResult(
+    {
+      taskName: 'mock-meta-task-7',
+      friendlyTaskName: 'Mock Meta Task 7',
+      taskClassification: {
+        category: Category.Migrations,
+        priority: Priority.High,
+      },
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+  new MockTaskResult(
+    {
+      taskName: 'mock-meta-task-3',
+      friendlyTaskName: 'Mock Meta Task 3',
+      taskClassification: {
+        category: Category.Insights,
+        priority: Priority.High,
+      },
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+  new MockTaskResult(
+    {
+      taskName: 'mock-meta-task-5',
+      friendlyTaskName: 'Mock Meta Task 5',
+      taskClassification: {
+        category: Category.Insights,
+        priority: Priority.High,
+      },
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+  new MockTaskResult(
+    {
+      taskName: 'mock-meta-task-8',
+      friendlyTaskName: 'Mock Meta Task 8',
+      taskClassification: {
+        category: Category.Migrations,
+        priority: Priority.Low,
+      },
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+  new MockTaskResult(
+    {
+      taskName: 'mock-meta-task-4',
+      friendlyTaskName: 'Mock Meta Task 4',
+      taskClassification: {
+        category: Category.Insights,
+        priority: Priority.Medium,
+      },
+    },
+    {
+      foo: true,
+      bar: 'baz',
+    }
+  ),
+];
+
+describe('_transformJsonResults', () => {
   it('transforms meta and plugin results into correct format', () => {
-    metaTaskResults = [
-      new MockMetaTaskResult(
-        {
-          taskName: 'mock-meta-task-1',
-          friendlyTaskName: 'Mock Meta Task 1',
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-      new MockMetaTaskResult(
-        {
-          taskName: 'mock-meta-task-2',
-          friendlyTaskName: 'Mock Meta Task 2',
-        },
-        {
-          blarg: false,
-          bleek: { bork: 'bye!' },
-        }
-      ),
-    ];
-
-    pluginTaskResults = [
-      new MockTaskResult(
-        {
-          taskName: 'mock-meta-task-6',
-          friendlyTaskName: 'Mock Meta Task 6',
-          taskClassification: {
-            category: Category.Insights,
-            priority: Priority.Low,
-          },
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-      new MockTaskResult(
-        {
-          taskName: 'mock-meta-task-7',
-          friendlyTaskName: 'Mock Meta Task 7',
-          taskClassification: {
-            category: Category.Migrations,
-            priority: Priority.High,
-          },
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-      new MockTaskResult(
-        {
-          taskName: 'mock-meta-task-3',
-          friendlyTaskName: 'Mock Meta Task 3',
-          taskClassification: {
-            category: Category.Insights,
-            priority: Priority.High,
-          },
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-      new MockTaskResult(
-        {
-          taskName: 'mock-meta-task-5',
-          friendlyTaskName: 'Mock Meta Task 5',
-          taskClassification: {
-            category: Category.Insights,
-            priority: Priority.High,
-          },
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-      new MockTaskResult(
-        {
-          taskName: 'mock-meta-task-8',
-          friendlyTaskName: 'Mock Meta Task 8',
-          taskClassification: {
-            category: Category.Migrations,
-            priority: Priority.Low,
-          },
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-      new MockTaskResult(
-        {
-          taskName: 'mock-meta-task-4',
-          friendlyTaskName: 'Mock Meta Task 4',
-          taskClassification: {
-            category: Category.Insights,
-            priority: Priority.Medium,
-          },
-        },
-        {
-          foo: true,
-          bar: 'baz',
-        }
-      ),
-    ];
-
-    let transformed = _transformResults(metaTaskResults, pluginTaskResults, ReporterType.json);
+    let transformed = _transformJsonResults(metaTaskResults, pluginTaskResults);
 
     expect(transformed).toMatchInlineSnapshot(`
       Object {
@@ -224,5 +225,33 @@ describe('_transformResults', () => {
         ],
       }
     `);
+  });
+});
+
+describe('_transformPdfResults', () => {
+  it('transforms meta and plugin results into correct format when chart is not required', () => {
+    let transformed = _transformPdfResults(metaTaskResults, pluginTaskResults);
+
+    expect(transformed).toMatchSnapshot();
+  });
+  it('transforms meta and plugin results into correct format when chart IS required', () => {
+    let transformed = _transformPdfResults(metaTaskResults, [
+      new MockPieChartTaskResult(
+        {
+          taskName: 'mock-meta-task-8',
+          friendlyTaskName: 'Mock Meta Task 8',
+          taskClassification: {
+            category: Category.Migrations,
+            priority: Priority.Low,
+          },
+        },
+        {
+          foo: true,
+          bar: 'baz',
+        }
+      ),
+    ]);
+
+    expect(transformed).toMatchSnapshot();
   });
 });

--- a/packages/cli/src/helpers/pdf.ts
+++ b/packages/cli/src/helpers/pdf.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { printToPDF } from './print-to-pdf';
 import { readFileSync } from 'fs-extra';
-import { ReportComponentType, ReportResultData } from '@checkup/core';
+import { ReportComponentType, UIReportData } from '@checkup/core';
 
 import tmp = require('tmp');
 
@@ -17,7 +17,7 @@ const date = require('date-and-time');
  */
 export async function generateReport(
   resultOutputPath: string,
-  resultsForPdf: any
+  resultsForPdf: UIReportData
 ): Promise<string> {
   let reportHTML = generateHTML(resultsForPdf);
 
@@ -41,7 +41,7 @@ export async function generateReport(
   return outputFilePath;
 }
 
-export function generateHTML(resultsForPdf: any) {
+export function generateHTML(resultsForPdf: UIReportData) {
   const reportPath = path.join(__dirname, '../../static/report-template.hbs');
   const reportTemplateRaw = requiresChart(resultsForPdf)
     ? appendChartjsCssSourceFiles(readFileSync(reportPath, 'utf8'))
@@ -69,9 +69,7 @@ function registerPartials() {
 }
 
 function requiresChart(resultsForPdf: any): boolean {
-  return resultsForPdf.results.some(
-    (result: ReportResultData) => result.componentType === ReportComponentType.PieChart
-  );
+  return resultsForPdf.requiresChart;
 }
 
 function appendChartjsCssSourceFiles(reportTemplateRaw: string): string {

--- a/packages/cli/static/components/numerical-card.hbs
+++ b/packages/cli/static/components/numerical-card.hbs
@@ -1,8 +1,6 @@
-<div class="max-w-sm rounded overflow-hidden shadow-lg bg-white">
-  <div class="px-6 py-4 flex flex-wrap flex-col">
-    <div class="text-xl font-bold self-end">{{resultData.grade}}</div>
-    <h1 class="text-xl self-center">{{resultData.meta.friendlyTaskName}}</h1>
-    <div class="text-4xl self-center">{{resultData.resultData}}</div>
-    <p>{{resultData.resultDescription}}</p>
-  </div>
+<div class="px-6 py-4 flex flex-wrap flex-col">
+  <div class="text-xl font-bold self-end">{{resultData.grade}}</div>
+  <h1 class="text-xl self-center">{{resultData.meta.friendlyTaskName}}</h1>
+  <div class="text-4xl self-center">{{resultData.resultData}}</div>
+  <p>{{resultData.resultDescription}}</p>
 </div>

--- a/packages/cli/static/components/pie-chart.hbs
+++ b/packages/cli/static/components/pie-chart.hbs
@@ -1,8 +1,6 @@
-<div class="max-w-sm rounded overflow-hidden shadow-lg bg-white">
-  <div class="px-6 py-4">
-    <div class="font-bold text-xl mb-2">{{resultData.meta.friendlyTaskName}}</div>
-    <canvas id="chart-area-{{resultData.UUID}}"></canvas>
-  </div>
+<div class="px-6 py-4">
+  <div class="font-bold text-xl mb-2">{{resultData.meta.friendlyTaskName}}</div>
+  <canvas id="chart-area-{{resultData.UUID}}"></canvas>
 </div>
 
 {{!-- CHECKUP-CHART-JS --}}

--- a/packages/cli/static/components/table.hbs
+++ b/packages/cli/static/components/table.hbs
@@ -1,27 +1,25 @@
-<div class="max-w-sm rounded overflow-hidden shadow-lg bg-white">
-  <div class="px-6 py-4 flex flex-wrap flex-col">
-    {{#if resultData.grade}}
-      <div class="text-xl font-bold self-end">{{resultData.grade}}</div>
-    {{/if}}
-    <div class="text-xl font-bold self-center">{{resultData.meta.friendlyTaskName}}</div>
+<div class="px-6 py-4 flex flex-wrap flex-col">
+  {{#if resultData.grade}}
+    <div class="text-xl font-bold self-end">{{resultData.grade}}</div>
+  {{/if}}
+  <div class="text-xl font-bold self-center">{{resultData.meta.friendlyTaskName}}</div>
 
-    <table class="table-auto rounded">
-      <thead>
-        <tr class="font-bold">
-          {{#each resultData.tableHeaders as |header|}}
-            <th class="px-4 py-2">{{header}}</th>
+  <table class="table-auto rounded">
+    <thead>
+      <tr class="font-bold">
+        {{#each resultData.tableHeaders as |header|}}
+          <th class="px-4 py-2">{{header}}</th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each resultData.resultsToRender as |formattedResult|}}
+        <tr class="{{formattedResult.rowClass}}">
+          {{#each formattedResult.result as |resultItem|}}
+            <td class="border px-4 py-2">{{resultItem}}</td>
           {{/each}}
         </tr>
-      </thead>
-      <tbody>
-        {{#each resultData.resultsToRender as |formattedResult|}}
-          <tr class="{{formattedResult.rowClass}}">
-            {{#each formattedResult.result as |resultItem|}}
-              <td class="border px-4 py-2">{{resultItem}}</td>
-            {{/each}}
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
-  </div>
+      {{/each}}
+    </tbody>
+  </table>
 </div>

--- a/packages/cli/static/report-template.hbs
+++ b/packages/cli/static/report-template.hbs
@@ -20,10 +20,21 @@
     <h2 class="text-base italic">This project is {{meta.project.repository.age}} old, has been active for {{meta.project.repository.activeDays}} days, has {{meta.project.repository.totalFiles}} files, and {{meta.project.repository.totalCommits}} commits</h2>
   </div>
 
-  <div class="grid grid-cols-3 gap-4">
-    {{#each results as |result|}}
-      {{> (lookup . 'componentType') resultData=result}}
-    {{/each}}
-  </div>
+  {{#each results as |categorizedResults resultCategory|}}
+    <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 border border-gray-500 m-5">
+    <h3>{{resultCategory}}</h3>
+      {{#each categorizedResults as |prioritizedResults priority|}}
+        <div class="grid grid-cols-3 gap-4">
+          <h4>{{priority}}</h4>
+          {{#each prioritizedResults as |resultData|}}
+            <div class="max-w-sm rounded overflow-hidden shadow-lg bg-white">
+              {{> (lookup . 'componentType') resultData=resultData}}
+            </div>
+          {{/each}}
+        </div>
+      {{/each}}
+    </section>
+  {{/each}}
+
 </body>
 </html>

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -62,6 +62,18 @@ export type JsonTaskResult = {
 
 export type ReportResultData = NumericalCardData | TableData | PieChartData;
 
+export type UIResultData = {
+  [key in Category]: {
+    [key in Priority]: ReportResultData[];
+  };
+};
+
+export type UIReportData = {
+  meta: JsonMetaTaskResult;
+  results: UIResultData;
+  requiresChart: boolean;
+};
+
 export const enum ReportComponentType {
   NumericalCard = 'numerical-card',
   Table = 'table',

--- a/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
@@ -34,7 +34,7 @@ Object {
     "friendlyTaskName": "Project Dependencies",
     "taskClassification": Object {
       "category": "insights",
-      "priority": "medium",
+      "priority": "low",
     },
     "taskName": "dependencies",
   },

--- a/packages/plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
@@ -13,7 +13,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Ember Project",
     "taskClassification": Object {
-      "category": "insights",
+      "category": "recommendations",
       "priority": "medium",
     },
     "taskName": "ember-project",
@@ -37,7 +37,7 @@ Object {
   "meta": Object {
     "friendlyTaskName": "Ember Project",
     "taskClassification": Object {
-      "category": "insights",
+      "category": "recommendations",
       "priority": "medium",
     },
     "taskName": "ember-project",

--- a/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
+++ b/packages/plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "friendlyTaskName": "Project Types",
     "taskClassification": Object {
       "category": "insights",
-      "priority": "medium",
+      "priority": "high",
     },
     "taskName": "types",
   },
@@ -121,7 +121,7 @@ Object {
     "friendlyTaskName": "Project Types",
     "taskClassification": Object {
       "category": "insights",
-      "priority": "medium",
+      "priority": "high",
     },
     "taskName": "types",
   },

--- a/packages/plugin-ember/src/tasks/dependencies-task.ts
+++ b/packages/plugin-ember/src/tasks/dependencies-task.ts
@@ -62,7 +62,7 @@ export default class DependenciesTask extends BaseTask implements Task {
     friendlyTaskName: 'Project Dependencies',
     taskClassification: {
       category: Category.Insights,
-      priority: Priority.Medium,
+      priority: Priority.Low,
     },
   };
 

--- a/packages/plugin-ember/src/tasks/ember-project-task.ts
+++ b/packages/plugin-ember/src/tasks/ember-project-task.ts
@@ -8,7 +8,7 @@ export default class EmberProjectTask extends BaseTask implements Task {
     taskName: 'ember-project',
     friendlyTaskName: 'Ember Project',
     taskClassification: {
-      category: Category.Insights,
+      category: Category.Recommendations,
       priority: Priority.Medium,
     },
   };

--- a/packages/plugin-ember/src/tasks/types-task.ts
+++ b/packages/plugin-ember/src/tasks/types-task.ts
@@ -21,7 +21,7 @@ export default class TypesTask extends FileSearcherTask implements Task {
     friendlyTaskName: 'Project Types',
     taskClassification: {
       category: Category.Insights,
-      priority: Priority.Medium,
+      priority: Priority.High,
     },
   };
 


### PR DESCRIPTION
Previously, there was a PR that went in that flattened the data structure of the results. While that works well for the JSON results, the PDF results need a bit more shape/structure so we can iterate over the different categories and priorities separately. This is useful so we can have a different section per each category and type. So basically reverted the flattening change for the pdf flow, changes the hbs files so we can render the different sections based on the new data format, and added some useful types to remove the `any` around the results coming into the pdf flow to keep things robust moving forward 

Note - none of the UI being generated right now is "to spec" - just a bunch of partials inside some section boxes with titles.