### PR TITLE
Removing node 10 from our CI test flow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        node: ['10', '12']
+        node: ['12']
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
We have pinned node to 12 via volta in this app, and node 10 will only be supported until 5/19. Since we are still in prerelease, and have pinned node, removing node 10 from our testing matrix