### PR TITLE
Fixing missing dependencies in core

### DIFF
--- a/packages/checkup-plugin-ember-octane/package.json
+++ b/packages/checkup-plugin-ember-octane/package.json
@@ -10,14 +10,11 @@
     "@oclif/config": "^1",
     "babel-eslint": "^10.1.0",
     "debug": "^4.1.1",
-    "ember-template-lint": "^2.5.2",
-    "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.4.0",
     "tslib": "^1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
-    "@types/eslint": "^6.8.0",
     "fixturify-project": "^2.1.0",
     "rimraf": "^3.0.2"
   },

--- a/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -11,13 +11,12 @@ import {
   Priority,
   Task,
   TemplateLintReport,
+  TemplateLinter,
 } from '@checkup/core';
 import { OCTANE_ES_LINT_CONFIG, OCTANE_TEMPLATE_LINT_CONFIG } from '../utils/lint-configs';
 
 import { CLIEngine } from 'eslint';
 import OctaneMigrationStatusTaskResult from '../results/octane-migration-status-task-result';
-
-const TemplateLinter = require('ember-template-lint');
 
 export default class OctaneMigrationStatusTask extends BaseTask implements Task {
   meta = {
@@ -30,7 +29,7 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
   };
 
   private eslintParser: Parser<CLIEngine.LintReport>;
-  private templateLinter: typeof TemplateLinter;
+  private templateLinter: TemplateLinter;
 
   constructor(
     cliArguments: any,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "resolve": "^1.16.1"
   },
   "devDependencies": {
+    "@types/eslint": "^6.8.0",
     "@types/js-yaml": "^3.12.3",
     "@types/resolve": "^1.14.0",
     "eslint-plugin-jest": "^23.8.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,8 @@
     "cli-ux": "^5.4.4",
     "cosmiconfig": "^6.0.0",
     "debug": "^4.1.1",
+    "ember-template-lint": "^2.5.2",
+    "eslint": "^6.8.0",
     "fp-ts": "^2.5.3",
     "globby": "^11.0.0",
     "io-ts": "^2.2.1",

--- a/packages/core/src/types/parsers.ts
+++ b/packages/core/src/types/parsers.ts
@@ -1,3 +1,5 @@
+const TemplateLinter = require('ember-template-lint');
+
 export type ParserName = string;
 export type ParserOptions = Record<string, any>;
 export type ParserReport = any;
@@ -8,3 +10,5 @@ export interface Parser<ParserReport> {
 export interface CreateParser<ParserOptions, TParser = Parser<ParserReport>> {
   (config: ParserOptions): TParser;
 }
+
+export type TemplateLinter = typeof TemplateLinter;


### PR DESCRIPTION
Core didn't have direct dependencies on `eslint` and `ember-template-lint`, even though it required them. It was getting these dependencies via `checkup-plugin-ember-octane`. This PR removes the dependencies from the latter package to the former. Additionally, it fixes the types in the latter package to not require direct dependencies.