### PR TITLE
Adding html as a reporter type, and replacing all pdf() calls with html()

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
@@ -1,5 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`octane-migration-status-task-result HTML output it should have basic HTML results 1`] = `
+Array [
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Native Class",
+    "values": Array [
+      1,
+      10,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Tagless Component",
+    "values": Array [
+      5,
+      1,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Glimmer Component",
+    "values": Array [
+      4,
+      2,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Tracked Properties",
+    "values": Array [
+      5,
+      1,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Angle Brackets",
+    "values": Array [
+      2,
+      1,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Use Named Arguments",
+    "values": Array [
+      3,
+      0,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Own Properties",
+    "values": Array [
+      2,
+      1,
+    ],
+  },
+  Object {
+    "labels": Array [
+      "\\"migrated\\"",
+      "\\"unmigrated\\"",
+    ],
+    "resultDescription": "Use Modifiers",
+    "values": Array [
+      2,
+      1,
+    ],
+  },
+]
+`;
+
 exports[`octane-migration-status-task-result JSON output it should have basic JSON results 1`] = `
 Object {
   "meta": Object {
@@ -1632,99 +1725,6 @@ Object {
     "totalViolations": 33,
   },
 }
-`;
-
-exports[`octane-migration-status-task-result PDF output it should have basic PDF results 1`] = `
-Array [
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Native Class",
-    "values": Array [
-      1,
-      10,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Tagless Component",
-    "values": Array [
-      5,
-      1,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Glimmer Component",
-    "values": Array [
-      4,
-      2,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Tracked Properties",
-    "values": Array [
-      5,
-      1,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Angle Brackets",
-    "values": Array [
-      2,
-      1,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Use Named Arguments",
-    "values": Array [
-      3,
-      0,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Own Properties",
-    "values": Array [
-      2,
-      1,
-    ],
-  },
-  Object {
-    "labels": Array [
-      "\\"migrated\\"",
-      "\\"unmigrated\\"",
-    ],
-    "resultDescription": "Use Modifiers",
-    "values": Array [
-      2,
-      1,
-    ],
-  },
-]
 `;
 
 exports[`octane-migration-status-task-result console output simple console output 1`] = `

--- a/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -44,17 +44,17 @@ describe('octane-migration-status-task-result', () => {
     });
   });
 
-  describe('PDF output', () => {
-    test('it should have basic PDF results', () => {
+  describe('HTML output', () => {
+    test('it should have basic HTML results', () => {
       let task = new OctaneMigrationStatusTask({}, getRegisteredParsers());
       let taskResult = new OctaneMigrationStatusTaskResult(
         task.meta,
         sampleESLintReport,
         sampleTemplateLintReport
       );
-      let pdfResults = taskResult.pdf();
+      let htmlResults = taskResult.html();
 
-      expect(filterPieChartDataForTest(pdfResults)).toMatchSnapshot();
+      expect(filterPieChartDataForTest(htmlResults)).toMatchSnapshot();
     });
   });
 });

--- a/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -55,7 +55,7 @@ export default class OctaneMigrationStatusTaskResult extends BaseTaskResult impl
     };
   }
 
-  pdf() {
+  html() {
     return this.migrationResults
       .map((migrationResult) => this._createPieChartData(migrationResult))
       .filter(Boolean) as PieChartData[];

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/dependencies-task-test.ts.snap
@@ -63,7 +63,7 @@ Object {
 }
 `;
 
-exports[`dependencies-task detects Ember dependencies as PDF, and doesnt create a table without dependencies 1`] = `
+exports[`dependencies-task detects Ember dependencies for html, and doesnt create a table without dependencies 1`] = `
 Array [
   TableData {
     "componentType": "table",

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-project-task-test.ts.snap
@@ -24,7 +24,7 @@ Object {
 }
 `;
 
-exports[`project-info-task for Ember Addons can read project info as PDF 1`] = `
+exports[`project-info-task for Ember Addons can read project info for html 1`] = `
 Array [
   TableData {
     "componentType": "table",
@@ -77,7 +77,7 @@ Object {
 }
 `;
 
-exports[`project-info-task for Ember Applications can read project info as PDF 1`] = `
+exports[`project-info-task for Ember Applications can read project info for html 1`] = `
 Array [
   TableData {
     "componentType": "table",

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/types-task-test.ts.snap
@@ -97,7 +97,7 @@ Object {
 }
 `;
 
-exports[`types-task returns all the types (including nested) found in the app and outputs to PDF 1`] = `
+exports[`types-task returns all the types (including nested) found in the app and outputs to html 1`] = `
 Array [
   TableData {
     "componentType": "table",
@@ -294,7 +294,7 @@ Object {
 }
 `;
 
-exports[`types-task returns all the types found in the app and outputs to PDF 1`] = `
+exports[`types-task returns all the types found in the app and outputs to html 1`] = `
 Array [
   TableData {
     "componentType": "table",

--- a/packages/checkup-plugin-ember/__tests__/dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/dependencies-task-test.ts
@@ -37,12 +37,12 @@ describe('dependencies-task', () => {
     expect(dependencyTaskResult.json()).toMatchSnapshot();
   });
 
-  it('detects Ember dependencies as PDF, and doesnt create a table without dependencies', async () => {
+  it('detects Ember dependencies for html, and doesnt create a table without dependencies', async () => {
     const result = await new DependenciesTask({ path: emberProject.baseDir }).run();
     const dependencyTaskResult = <DependenciesTaskResult>result;
-    const pdfResults = dependencyTaskResult.pdf();
+    const htmlResults = dependencyTaskResult.html();
 
-    expect(pdfResults).toMatchSnapshot();
-    expect(pdfResults).toHaveLength(4);
+    expect(htmlResults).toMatchSnapshot();
+    expect(htmlResults).toHaveLength(4);
   });
 });

--- a/packages/checkup-plugin-ember/__tests__/ember-project-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-project-task-test.ts
@@ -38,11 +38,11 @@ describe('project-info-task', () => {
       expect(taskResult.json()).toMatchSnapshot();
     });
 
-    it('can read project info as PDF', async () => {
+    it('can read project info for html', async () => {
       const result = await new EmberProjectTask({ path: emberProject.baseDir }).run();
       const taskResult = <EmberProjectTaskResult>result;
 
-      expect(taskResult.pdf()).toMatchSnapshot();
+      expect(taskResult.html()).toMatchSnapshot();
     });
   });
 
@@ -79,11 +79,11 @@ describe('project-info-task', () => {
       expect(taskResult.json()).toMatchSnapshot();
     });
 
-    it('can read project info as PDF', async () => {
+    it('can read project info for html', async () => {
       const result = await new EmberProjectTask({ path: emberProject.baseDir }).run();
       const taskResult = <EmberProjectTaskResult>result;
 
-      expect(taskResult.pdf()).toMatchSnapshot();
+      expect(taskResult.html()).toMatchSnapshot();
     });
   });
 });

--- a/packages/checkup-plugin-ember/__tests__/types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/types-task-test.ts
@@ -119,7 +119,7 @@ describe('types-task', () => {
     expect(typesTaskResult.json()).toMatchSnapshot();
   });
 
-  it('returns all the types found in the app and outputs to PDF', async () => {
+  it('returns all the types found in the app and outputs to html', async () => {
     project.files = Object.assign(project.files, {
       'index.js': 'index js file',
       addon: TYPES,
@@ -130,10 +130,10 @@ describe('types-task', () => {
     const result = await new TypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
-    expect(typesTaskResult.pdf()).toMatchSnapshot();
+    expect(typesTaskResult.html()).toMatchSnapshot();
   });
 
-  it('returns all the types (including nested) found in the app and outputs to PDF', async () => {
+  it('returns all the types (including nested) found in the app and outputs to html', async () => {
     project.files = Object.assign(project.files, {
       'index.js': 'index js file',
       addon: TYPES,
@@ -150,6 +150,6 @@ describe('types-task', () => {
     const result = await new TypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <TypesTaskResult>result;
 
-    expect(typesTaskResult.pdf()).toMatchSnapshot();
+    expect(typesTaskResult.html()).toMatchSnapshot();
   });
 });

--- a/packages/checkup-plugin-ember/src/results/dependencies-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/dependencies-task-result.ts
@@ -53,7 +53,7 @@ export default class DependenciesTaskResult extends BaseTaskResult implements Ta
     };
   }
 
-  pdf() {
+  html() {
     let dependencyGroups = [
       this.emberLibraries,
       this.emberAddons.devDependencies,

--- a/packages/checkup-plugin-ember/src/results/ember-project-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-project-task-result.ts
@@ -18,7 +18,7 @@ export default class EmberProjectTaskResult extends BaseTaskResult implements Ta
     return { meta: this.meta, result: { type: this.type } };
   }
 
-  pdf() {
+  html() {
     return [new TableData(this.meta, [{ name: 'type', value: this.type }])];
   }
 }

--- a/packages/checkup-plugin-ember/src/results/types-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/types-task-result.ts
@@ -18,7 +18,7 @@ export default class TypesTaskResult extends BaseTaskResult implements TaskResul
     return { meta: this.meta, result: { types: this.types } };
   }
 
-  pdf() {
+  html() {
     return [
       new TableData(
         this.meta,

--- a/packages/cli/__tests__/__snapshots__/reporters-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/reporters-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`_transformPdfResults transforms meta and plugin results into correct format when chart IS required 1`] = `
+exports[`_transformHTMLResults transforms meta and plugin results into correct format when chart IS required 1`] = `
 Object {
   "meta": Object {
     "mock-meta-task-1": Object {
@@ -68,7 +68,7 @@ Object {
 }
 `;
 
-exports[`_transformPdfResults transforms meta and plugin results into correct format when chart is not required 1`] = `
+exports[`_transformHTMLResults transforms meta and plugin results into correct format when chart is not required 1`] = `
 Object {
   "meta": Object {
     "mock-meta-task-1": Object {

--- a/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
@@ -23,7 +23,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     };
   }
 
-  pdf() {
+  html() {
     return [
       new PieChartData(
         {

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -16,7 +16,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     };
   }
 
-  pdf() {
+  html() {
     return [new NumericalCardData(this.meta, this.result, 'this is a description of your result')];
   }
 }

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -43,14 +43,14 @@ describe('@checkup/cli', () => {
     });
 
     it(
-      'should output a PDF in the current directory if the pdf reporter option is provided',
+      'should output an html file in the current directory if the html reporter option is provided',
       async () => {
-        await cmd.run(['run', '--reporter', 'pdf', project.baseDir]);
+        await cmd.run(['run', '--reporter', 'html', project.baseDir]);
 
         let outputPath = stdout().trim();
 
         expect(outputPath).toMatch(
-          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.pdf/
+          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.html/
         );
         expect(fs.existsSync(outputPath)).toEqual(true);
 
@@ -60,16 +60,16 @@ describe('@checkup/cli', () => {
     );
 
     it(
-      'should output a PDF in a custom directory if the pdf reporter and reporterOutputPath options are provided',
+      'should output an html file in a custom directory if the html reporter and reporterOutputPath options are provided',
       async () => {
         let tmp = createTmpDir();
 
-        await cmd.run(['run', '--reporter', 'pdf', `--reportOutputPath`, tmp, project.baseDir]);
+        await cmd.run(['run', '--reporter', 'html', `--reportOutputPath`, tmp, project.baseDir]);
 
         let outputPath = stdout().trim();
 
         expect(outputPath).toMatch(
-          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.pdf/
+          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.html/
         );
         expect(fs.existsSync(outputPath)).toEqual(true);
 

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -37,8 +37,9 @@ export default class MyFooTaskResult extends BaseTaskResult {
     };
   }
 
-  pdf() {}
-}"
+  html() {}
+}
+"
 `;
 
 exports[`task generator generates correct files with JavaScript 3`] = `
@@ -128,7 +129,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  pdf() {}
+  html() {}
 }
 "
 `;
@@ -222,7 +223,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  pdf() {}
+  html() {}
 }
 "
 `;
@@ -316,7 +317,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  pdf() {}
+  html() {}
 }
 "
 `;
@@ -410,7 +411,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  pdf() {}
+  html() {}
 }
 "
 `;
@@ -491,7 +492,7 @@ export default class MyBarTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  pdf() {}
+  html() {}
 }
 "
 `;

--- a/packages/cli/__tests__/pdf-test.ts
+++ b/packages/cli/__tests__/pdf-test.ts
@@ -7,7 +7,7 @@ import {
   UIReportData,
 } from '@checkup/core';
 
-import { generateHTML } from '../src/helpers/pdf';
+import { generateHTML } from '../src/helpers/ui-report';
 
 describe('generateHTML', () => {
   const taskMeta: TaskMetaData = {
@@ -109,7 +109,7 @@ describe('generateHTML', () => {
     `);
   });
 
-  it('includes tailwind UI lib and stylesheet, but no chartjs (since results dont require it by default)', async () => {
+  it('includes tailwind html lib and stylesheet, but no chartjs (since results dont require it by default)', async () => {
     const htmlString = await generateHTML(mergedResults);
 
     expect(htmlString).toContain('tailwind.min.css');

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -4,7 +4,7 @@ import { MetaTaskResult } from '../src/types';
 import MockMetaTaskResult from './__utils__/mock-meta-task-result';
 import MockTaskResult from './__utils__/mock-task-result';
 import MockPieChartTaskResult from './__utils__/mock-pie-chart-task-result';
-import { _transformJsonResults, _transformPdfResults } from '../src/reporters';
+import { _transformJsonResults, _transformHTMLResults } from '../src/reporters';
 
 let metaTaskResults: MetaTaskResult[];
 let pluginTaskResults: TaskResult[];
@@ -228,14 +228,14 @@ describe('_transformJsonResults', () => {
   });
 });
 
-describe('_transformPdfResults', () => {
+describe('_transformHTMLResults', () => {
   it('transforms meta and plugin results into correct format when chart is not required', () => {
-    let transformed = _transformPdfResults(metaTaskResults, pluginTaskResults);
+    let transformed = _transformHTMLResults(metaTaskResults, pluginTaskResults);
 
     expect(transformed).toMatchSnapshot();
   });
   it('transforms meta and plugin results into correct format when chart IS required', () => {
-    let transformed = _transformPdfResults(metaTaskResults, [
+    let transformed = _transformHTMLResults(metaTaskResults, [
       new MockPieChartTaskResult(
         {
           taskName: 'mock-meta-task-8',

--- a/packages/cli/src/helpers/ui-report.ts
+++ b/packages/cli/src/helpers/ui-report.ts
@@ -2,10 +2,10 @@ import * as Handlebars from 'handlebars';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { pathToFileURL } from 'url';
-import { printToPDF } from './print-to-pdf';
 import { readFileSync } from 'fs-extra';
 import { ReportComponentType, UIReportData } from '@checkup/core';
+import { pathToFileURL } from 'url';
+import { printToPDF } from './print-to-pdf';
 
 import tmp = require('tmp');
 
@@ -13,11 +13,26 @@ import tmp = require('tmp');
 const hbsHelpers = require('handlebars-helpers')('comparison');
 const date = require('date-and-time');
 
-/**
- * @param jsonResult
- * @param results
- */
-export async function generateReport(
+export async function generateHTMLReport(
+  resultOutputPath: string,
+  resultsForPdf: UIReportData
+): Promise<string> {
+  let reportHTML = generateHTML(resultsForPdf);
+
+  if (!fs.existsSync(resultOutputPath)) {
+    fs.mkdirSync(resultOutputPath, { recursive: true });
+  }
+
+  let htmlPath = path.join(
+    resultOutputPath,
+    `checkup-report-${date.format(new Date(), 'YYYY-MM-DD-HH-mm-ss')}.html`
+  );
+  fs.writeFileSync(htmlPath, reportHTML);
+
+  return path.resolve(htmlPath);
+}
+
+export async function generatePDFReport(
   resultOutputPath: string,
   resultsForPdf: UIReportData
 ): Promise<string> {

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -11,9 +11,9 @@ import {
 
 import { MetaTaskResult } from './types';
 import { RunFlags } from './commands/run';
-import { generateReport } from './helpers/pdf';
+import { generateHTMLReport } from './helpers/ui-report';
 
-export function _transformPdfResults(
+export function _transformHTMLResults(
   metaTaskResults: MetaTaskResult[],
   pluginTaskResults: TaskResult[]
 ): UIReportData {
@@ -37,7 +37,7 @@ export function _transformPdfResults(
   let requiresChart = false;
 
   pluginTaskResults
-    .flatMap((result) => result.pdf())
+    .flatMap((result) => result.html())
     .forEach((taskResult) => {
       if (taskResult) {
         let { category, priority } = taskResult.meta.taskClassification;
@@ -87,10 +87,10 @@ export function getReporter(
         let resultJson = _transformJsonResults(metaTaskResults, pluginTaskResults);
         ui.styledJSON(resultJson);
       };
-    case ReporterType.pdf:
+    case ReporterType.html:
       return async () => {
-        let resultsForPdf = _transformPdfResults(metaTaskResults, pluginTaskResults);
-        let reportPath = await generateReport(flags.reportOutputPath, resultsForPdf);
+        let resultsForPdf = _transformHTMLResults(metaTaskResults, pluginTaskResults);
+        let reportPath = await generateHTMLReport(flags.reportOutputPath, resultsForPdf);
 
         ui.log(reportPath);
       };

--- a/packages/cli/templates/src/task/src/results/task-result.js.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.js.ejs
@@ -12,5 +12,5 @@ export default class <%- taskResultClass %> extends BaseTaskResult {
     };
   }
 
-  pdf() {}
+  html() {}
 }

--- a/packages/cli/templates/src/task/src/results/task-result.ts.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.ts.ejs
@@ -12,5 +12,5 @@ export default class <%- taskResultClass %> extends BaseTaskResult implements Ta
     };
   }
 
-  pdf() {}
+  html() {}
 }

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -20,7 +20,7 @@ export interface Task {
 export interface TaskResult {
   stdout: () => void;
   json: () => JsonMetaTaskResult | JsonTaskResult;
-  pdf: () => ReportResultData[];
+  html: () => ReportResultData[];
 }
 
 export interface TaskMetaData {
@@ -91,7 +91,7 @@ export const enum Grade {
 export enum ReporterType {
   stdout = 'stdout',
   json = 'json',
-  pdf = 'pdf',
+  html = 'html',
 }
 
 export interface PieChartItem {


### PR DESCRIPTION
We will now be targeting an html report as our MVP to allow for more interactivity. Changing all existing tasks to use html hook, but leaving pdf infra in place so we can use after MVP is complete