### PR TITLE
Renaming task result methods

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -51,7 +51,7 @@ describe('octane-migration-status-task-result', () => {
         sampleESLintReport,
         sampleTemplateLintReport
       );
-      let htmlResults = taskResult.html();
+      let htmlResults = taskResult.toReportData();
 
       expect(filterPieChartDataForTest(htmlResults)).toMatchSnapshot();
     });

--- a/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -37,7 +37,7 @@ describe('octane-migration-status-task-result', () => {
         sampleTemplateLintReport
       );
 
-      let jsonResults = taskResult.json();
+      let jsonResults = taskResult.toJson();
 
       expect(jsonResults).toMatchSnapshot();
     });

--- a/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -22,7 +22,7 @@ describe('octane-migration-status-task-result', () => {
         sampleTemplateLintReport
       );
 
-      taskResult.stdout();
+      taskResult.toConsole();
 
       expect(stdout()).toMatchSnapshot();
     });

--- a/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -28,7 +28,7 @@ export default class OctaneMigrationStatusTaskResult extends BaseTaskResult impl
     this.totalViolations = this.esLintReport.errorCount + this.templateLintReport.errorCount;
   }
 
-  stdout() {
+  toConsole() {
     ui.section(this.meta.friendlyTaskName, () => {
       ui.log(`${ui.emphasize('Octane Violations')}: ${this.totalViolations}`);
       ui.blankLine();

--- a/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -52,7 +52,7 @@ export default class OctaneMigrationStatusTaskResult extends BaseTaskResult impl
     };
   }
 
-  html() {
+  toReportData() {
     return this.migrationResults
       .map((migrationResult) => this._createPieChartData(migrationResult))
       .filter(Boolean) as PieChartData[];

--- a/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
+++ b/packages/checkup-plugin-ember-octane/src/results/octane-migration-status-task-result.ts
@@ -42,7 +42,7 @@ export default class OctaneMigrationStatusTaskResult extends BaseTaskResult impl
     });
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {

--- a/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
@@ -25,7 +25,7 @@ describe('dependencies-task', () => {
     const result = await new EmberDependenciesTask({ path: emberProject.baseDir }).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
 
-    dependencyTaskResult.stdout();
+    dependencyTaskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });

--- a/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
@@ -40,7 +40,7 @@ describe('dependencies-task', () => {
   it('detects Ember dependencies for html, and doesnt create a table without dependencies', async () => {
     const result = await new EmberDependenciesTask({ path: emberProject.baseDir }).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
-    const htmlResults = dependencyTaskResult.html();
+    const htmlResults = dependencyTaskResult.toReportData();
 
     expect(htmlResults).toMatchSnapshot();
     expect(htmlResults).toHaveLength(4);

--- a/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
@@ -34,7 +34,7 @@ describe('dependencies-task', () => {
     const result = await new EmberDependenciesTask({ path: emberProject.baseDir }).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
 
-    expect(dependencyTaskResult.json()).toMatchSnapshot();
+    expect(dependencyTaskResult.toJson()).toMatchSnapshot();
   });
 
   it('detects Ember dependencies for html, and doesnt create a table without dependencies', async () => {

--- a/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
@@ -58,7 +58,7 @@ describe('types-task', () => {
     const result = await new EmberTypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
-    typesTaskResult.stdout();
+    typesTaskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -80,7 +80,7 @@ describe('types-task', () => {
     const result = await new EmberTypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
-    typesTaskResult.stdout();
+    typesTaskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });

--- a/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
@@ -96,7 +96,7 @@ describe('types-task', () => {
     const result = await new EmberTypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
-    expect(typesTaskResult.json()).toMatchSnapshot();
+    expect(typesTaskResult.toJson()).toMatchSnapshot();
   });
 
   it('returns all the types (including nested) found in the app and outputs to JSON', async () => {
@@ -116,7 +116,7 @@ describe('types-task', () => {
     const result = await new EmberTypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
-    expect(typesTaskResult.json()).toMatchSnapshot();
+    expect(typesTaskResult.toJson()).toMatchSnapshot();
   });
 
   it('returns all the types found in the app and outputs to html', async () => {

--- a/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
@@ -130,7 +130,7 @@ describe('types-task', () => {
     const result = await new EmberTypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
-    expect(typesTaskResult.html()).toMatchSnapshot();
+    expect(typesTaskResult.toReportData()).toMatchSnapshot();
   });
 
   it('returns all the types (including nested) found in the app and outputs to html', async () => {
@@ -150,6 +150,6 @@ describe('types-task', () => {
     const result = await new EmberTypesTask({ path: project.baseDir }).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
-    expect(typesTaskResult.html()).toMatchSnapshot();
+    expect(typesTaskResult.toReportData()).toMatchSnapshot();
   });
 });

--- a/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
@@ -60,7 +60,7 @@ export default class EmberDependenciesTaskResult extends BaseTaskResult implemen
     };
   }
 
-  html() {
+  toReportData() {
     let dependencyGroups = [
       this.emberLibraries,
       this.emberAddons.devDependencies,

--- a/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
@@ -25,7 +25,7 @@ export default class EmberDependenciesTaskResult extends BaseTaskResult implemen
     );
   }
 
-  stdout() {
+  toConsole() {
     if (!this.hasDependencies) {
       return;
     }

--- a/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
@@ -49,7 +49,7 @@ export default class EmberDependenciesTaskResult extends BaseTaskResult implemen
     );
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {

--- a/packages/checkup-plugin-ember/src/results/ember-types-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-types-task-result.ts
@@ -17,7 +17,7 @@ export default class EmberTypesTaskResult extends BaseTaskResult implements Task
     return { meta: this.meta, result: { types: this.types } };
   }
 
-  html() {
+  toReportData() {
     return [
       new TableData(
         this.meta,

--- a/packages/checkup-plugin-ember/src/results/ember-types-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-types-task-result.ts
@@ -13,7 +13,7 @@ export default class EmberTypesTaskResult extends BaseTaskResult implements Task
     });
   }
 
-  json() {
+  toJson() {
     return { meta: this.meta, result: { types: this.types } };
   }
 

--- a/packages/checkup-plugin-ember/src/results/ember-types-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-types-task-result.ts
@@ -7,7 +7,7 @@ export default class EmberTypesTaskResult extends BaseTaskResult implements Task
     return this.types.find((type) => type.type === typeName);
   }
 
-  stdout() {
+  toConsole() {
     ui.section(this.meta.friendlyTaskName, () => {
       ui.table(this.types, { type: {}, total: {} });
     });

--- a/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
@@ -11,7 +11,7 @@ export default class MockMetaTaskResult extends BaseMetaTaskResult implements Me
     process.stdout.write(`Result for ${this.meta.taskName}`);
   }
 
-  json() {
+  toJson() {
     return {
       [this.meta.taskName]: this.result,
     };

--- a/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
@@ -7,7 +7,7 @@ export default class MockMetaTaskResult extends BaseMetaTaskResult implements Me
     super(meta);
   }
 
-  stdout() {
+  toConsole() {
     process.stdout.write(`Result for ${this.meta.taskName}`);
   }
 

--- a/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
@@ -1,8 +1,8 @@
 import {
   BaseTaskResult,
-  Priority,
-  PieChartData,
   Category,
+  PieChartData,
+  Priority,
   TaskMetaData,
   TaskResult,
 } from '@checkup/core';
@@ -12,7 +12,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     super(meta);
   }
 
-  stdout() {
+  toConsole() {
     process.stdout.write(`Result for ${this.meta.taskName}`);
   }
 

--- a/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
@@ -23,7 +23,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     };
   }
 
-  html() {
+  toReportData() {
     return [
       new PieChartData(
         {

--- a/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-pie-chart-task-result.ts
@@ -16,7 +16,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     process.stdout.write(`Result for ${this.meta.taskName}`);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: this.result,

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -9,7 +9,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     process.stdout.write(`Result for ${this.meta.taskName}`);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: this.result,

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -16,7 +16,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     };
   }
 
-  html() {
+  toReportData() {
     return [new NumericalCardData(this.meta, this.result, 'this is a description of your result')];
   }
 }

--- a/packages/cli/__tests__/__utils__/mock-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-task-result.ts
@@ -5,7 +5,7 @@ export default class MockTaskResult extends BaseTaskResult implements TaskResult
     super(meta);
   }
 
-  stdout() {
+  toConsole() {
     process.stdout.write(`Result for ${this.meta.taskName}`);
   }
 

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -30,7 +30,7 @@ export default class MyFooTaskResult extends BaseTaskResult {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},
@@ -74,7 +74,7 @@ describe('my-foo-task', () => {
   it('can read task as JSON', async () => {
     const taskResult = await new MyFooTask({ path: checkupProject.baseDir }).run();
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });"
 `;
@@ -122,7 +122,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},
@@ -168,7 +168,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });"
 `;
@@ -216,7 +216,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},
@@ -262,7 +262,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });"
 `;
@@ -310,7 +310,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},
@@ -356,7 +356,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });"
 `;
@@ -404,7 +404,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},
@@ -450,7 +450,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });"
 `;
@@ -485,7 +485,7 @@ export default class MyBarTaskResult extends BaseTaskResult implements TaskResul
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},
@@ -531,7 +531,7 @@ describe('my-bar-task', () => {
     const result = await new MyBarTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyBarTaskResult>result;
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });"
 `;

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -26,7 +26,7 @@ exports[`task generator generates correct files with JavaScript 2`] = `
 "import { BaseTaskResult, ui } from '@checkup/core';
 
 export default class MyFooTaskResult extends BaseTaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
@@ -66,7 +66,7 @@ describe('my-foo-task', () => {
   it('can read task and output to console', async () => {
     const taskResult = await new MyFooTask({ path: checkupProject.baseDir }).run();
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -118,7 +118,7 @@ exports[`task generator generates correct files with TypeScript for defaults 2`]
 "import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
 export default class MyFooTaskResult extends BaseTaskResult implements TaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
@@ -159,7 +159,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -212,7 +212,7 @@ exports[`task generator generates correct files with category 2`] = `
 "import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
 export default class MyFooTaskResult extends BaseTaskResult implements TaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
@@ -253,7 +253,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -306,7 +306,7 @@ exports[`task generator generates correct files with priority 2`] = `
 "import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
 export default class MyFooTaskResult extends BaseTaskResult implements TaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
@@ -347,7 +347,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -400,7 +400,7 @@ exports[`task generator generates multiple correct files with TypeScript for def
 "import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
 export default class MyFooTaskResult extends BaseTaskResult implements TaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
@@ -441,7 +441,7 @@ describe('my-foo-task', () => {
     const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });
@@ -481,7 +481,7 @@ exports[`task generator generates multiple correct files with TypeScript for def
 "import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
 export default class MyBarTaskResult extends BaseTaskResult implements TaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
@@ -522,7 +522,7 @@ describe('my-bar-task', () => {
     const result = await new MyBarTask({ path: checkupProject.baseDir }).run();
     const taskResult = <MyBarTaskResult>result;
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -37,7 +37,7 @@ export default class MyFooTaskResult extends BaseTaskResult {
     };
   }
 
-  html() {}
+  toReportData() {}
 }
 "
 `;
@@ -129,7 +129,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  html() {}
+  toReportData() {}
 }
 "
 `;
@@ -223,7 +223,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  html() {}
+  toReportData() {}
 }
 "
 `;
@@ -317,7 +317,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  html() {}
+  toReportData() {}
 }
 "
 `;
@@ -411,7 +411,7 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  html() {}
+  toReportData() {}
 }
 "
 `;
@@ -492,7 +492,7 @@ export default class MyBarTaskResult extends BaseTaskResult implements TaskResul
     };
   }
 
-  html() {}
+  toReportData() {}
 }
 "
 `;

--- a/packages/cli/__tests__/meta-task-list-test.ts
+++ b/packages/cli/__tests__/meta-task-list-test.ts
@@ -71,7 +71,7 @@ describe('MetaTaskList', () => {
 
     let result = await taskList.runTask('fake-meta-task');
 
-    expect(result.json()).toMatchInlineSnapshot(`
+    expect(result.toJson()).toMatchInlineSnapshot(`
       Object {
         "fake-meta-task": "fake meta task is being run",
       }
@@ -86,7 +86,7 @@ describe('MetaTaskList', () => {
 
     let result = await taskList.runTasks();
 
-    expect(result[0].json()).toMatchSnapshot();
-    expect(result[1].json()).toMatchSnapshot();
+    expect(result[0].toJson()).toMatchSnapshot();
+    expect(result[1].toJson()).toMatchSnapshot();
   });
 });

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -65,7 +65,7 @@ describe('TaskList', () => {
 
     let result = await taskList.runTask('insights-task-high');
 
-    expect(result.json()).toMatchSnapshot();
+    expect(result.toJson()).toMatchSnapshot();
   });
 
   it('runTasks will run all registered tasks', async () => {
@@ -76,8 +76,8 @@ describe('TaskList', () => {
 
     let result = await taskList.runTasks();
 
-    expect(result[0].json()).toMatchSnapshot();
-    expect(result[1].json()).toMatchSnapshot();
+    expect(result[0].toJson()).toMatchSnapshot();
+    expect(result[1].toJson()).toMatchSnapshot();
   });
 
   it('runTasks will sort tasks in the correct order', async () => {

--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -44,7 +44,7 @@ describe('checkup-meta-task', () => {
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
-      taskResult.stdout();
+      taskResult.toConsole();
 
       expect(stdout()).toMatchInlineSnapshot(`
         "Generated using Checkup v0.0.0. Config: ae3266e319bdfb51db83810a2f4dd161
@@ -84,7 +84,7 @@ describe('checkup-meta-task', () => {
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
-      taskResult.stdout();
+      taskResult.toConsole();
 
       expect(stdout()).toMatchInlineSnapshot(`
         "Generated using Checkup v0.0.0. Config: 705deefb6abf2b6d34f93cede7acba07

--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -62,7 +62,7 @@ describe('checkup-meta-task', () => {
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
-      expect(taskResult.json()).toMatchInlineSnapshot(`
+      expect(taskResult.toJson()).toMatchInlineSnapshot(`
         Object {
           "checkup": Object {
             "configHash": "ae3266e319bdfb51db83810a2f4dd161",
@@ -105,7 +105,7 @@ describe('checkup-meta-task', () => {
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
-      expect(taskResult.json()).toMatchInlineSnapshot(`
+      expect(taskResult.toJson()).toMatchInlineSnapshot(`
         Object {
           "checkup": Object {
             "configHash": "705deefb6abf2b6d34f93cede7acba07",

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -39,7 +39,7 @@ describe('project-meta-task', () => {
       const result = await new ProjectMetaTask({ path: checkupProject.baseDir }).run();
       const taskResult = <ProjectMetaTaskResult>result;
 
-      expect(taskResult.json()).toMatchInlineSnapshot(`
+      expect(taskResult.toJson()).toMatchInlineSnapshot(`
         Object {
           "project": Object {
             "name": "checkup-app",

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -23,7 +23,7 @@ describe('project-meta-task', () => {
       const result = await new ProjectMetaTask({ path: checkupProject.baseDir }).run();
       const taskResult = <ProjectMetaTaskResult>result;
 
-      taskResult.stdout();
+      taskResult.toConsole();
 
       expect(stdout()).toMatchInlineSnapshot(`
         "

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -78,8 +78,8 @@ export function getReporter(
     case ReporterType.stdout:
       return async () => {
         if (!flags.silent) {
-          metaTaskResults.forEach((taskResult) => taskResult.stdout());
-          pluginTaskResults.forEach((taskResult) => taskResult.stdout());
+          metaTaskResults.forEach((taskResult) => taskResult.toConsole());
+          pluginTaskResults.forEach((taskResult) => taskResult.toConsole());
         }
       };
     case ReporterType.json:

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -51,7 +51,7 @@ export function _transformHTMLResults(
     });
 
   return {
-    meta: Object.assign({}, ...metaTaskResults.map((result) => result.json())),
+    meta: Object.assign({}, ...metaTaskResults.map((result) => result.toJson())),
     results: mergedResults,
     requiresChart,
   };
@@ -62,8 +62,8 @@ export function _transformJsonResults(
   pluginTaskResults: TaskResult[]
 ) {
   let transformedResult = {
-    meta: Object.assign({}, ...metaTaskResults.map((result) => result.json())),
-    results: pluginTaskResults.map((result) => result.json()),
+    meta: Object.assign({}, ...metaTaskResults.map((result) => result.toJson())),
+    results: pluginTaskResults.map((result) => result.toJson()),
   };
 
   return transformedResult;

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -37,7 +37,7 @@ export function _transformHTMLResults(
   let requiresChart = false;
 
   pluginTaskResults
-    .flatMap((result) => result.html())
+    .flatMap((result) => result.toReportData())
     .forEach((taskResult) => {
       if (taskResult) {
         let { category, priority } = taskResult.meta.taskClassification;

--- a/packages/cli/src/results/checkup-meta-task-result.ts
+++ b/packages/cli/src/results/checkup-meta-task-result.ts
@@ -6,7 +6,7 @@ export default class CheckupMetaTaskResult extends BaseMetaTaskResult implements
   configHash!: string;
   version!: string;
 
-  stdout() {
+  toConsole() {
     ui.dimmed(`Generated using Checkup v${this.version}. Config: ${this.configHash}`);
     ui.blankLine();
   }

--- a/packages/cli/src/results/checkup-meta-task-result.ts
+++ b/packages/cli/src/results/checkup-meta-task-result.ts
@@ -11,7 +11,7 @@ export default class CheckupMetaTaskResult extends BaseMetaTaskResult implements
     ui.blankLine();
   }
 
-  json() {
+  toJson() {
     return {
       checkup: {
         configHash: this.configHash,

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -22,7 +22,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
     ui.blankLine();
   }
 
-  json() {
+  toJson() {
     return {
       project: {
         name: this.name,

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -8,7 +8,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
   version!: string;
   repository!: RepositoryInfo;
 
-  stdout() {
+  toConsole() {
     ui.blankLine();
     ui.log(`Checkup report generated for ${ui.emphasize(`${this.name} v${this.version}`)} .`);
     ui.blankLine();

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -12,7 +12,7 @@ export interface MetaTask {
 
 export interface MetaTaskResult {
   toConsole: () => void;
-  json: () => JsonMetaTaskResult;
+  toJson: () => JsonMetaTaskResult;
 }
 
 export const enum TestType {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -11,7 +11,7 @@ export interface MetaTask {
 }
 
 export interface MetaTaskResult {
-  stdout: () => void;
+  toConsole: () => void;
   json: () => JsonMetaTaskResult;
 }
 

--- a/packages/cli/templates/src/task/__tests__/task.js.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.js.ejs
@@ -31,6 +31,6 @@ describe('<%- name %>-task', () => {
   it('can read task as JSON', async () => {
     const taskResult = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });

--- a/packages/cli/templates/src/task/__tests__/task.js.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.js.ejs
@@ -23,7 +23,7 @@ describe('<%- name %>-task', () => {
   it('can read task and output to console', async () => {
     const taskResult = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });

--- a/packages/cli/templates/src/task/__tests__/task.ts.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.ts.ejs
@@ -24,7 +24,7 @@ describe('<%- name %>-task', () => {
     const result = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
     const taskResult = <<%- resultClass %>>result;
 
-    taskResult.stdout();
+    taskResult.toConsole();
 
     expect(stdout()).toMatchSnapshot();
   });

--- a/packages/cli/templates/src/task/__tests__/task.ts.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.ts.ejs
@@ -33,6 +33,6 @@ describe('<%- name %>-task', () => {
     const result = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
     const taskResult = <<%- resultClass %>>result;
 
-    expect(taskResult.json()).toMatchSnapshot();
+    expect(taskResult.toJson()).toMatchSnapshot();
   });
 });

--- a/packages/cli/templates/src/task/src/results/task-result.js.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.js.ejs
@@ -12,5 +12,5 @@ export default class <%- taskResultClass %> extends BaseTaskResult {
     };
   }
 
-  html() {}
+  toReportData() {}
 }

--- a/packages/cli/templates/src/task/src/results/task-result.js.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.js.ejs
@@ -5,7 +5,7 @@ export default class <%- taskResultClass %> extends BaseTaskResult {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},

--- a/packages/cli/templates/src/task/src/results/task-result.js.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.js.ejs
@@ -1,7 +1,7 @@
 import { BaseTaskResult, ui } from '@checkup/core';
 
 export default class <%- taskResultClass %> extends BaseTaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 

--- a/packages/cli/templates/src/task/src/results/task-result.ts.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.ts.ejs
@@ -1,7 +1,7 @@
 import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
 
 export default class <%- taskResultClass %> extends BaseTaskResult implements TaskResult {
-  stdout() {
+  toConsole() {
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 

--- a/packages/cli/templates/src/task/src/results/task-result.ts.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.ts.ejs
@@ -5,7 +5,7 @@ export default class <%- taskResultClass %> extends BaseTaskResult implements Ta
     ui.styledHeader(this.meta.friendlyTaskName);
   }
 
-  json() {
+  toJson() {
     return {
       meta: this.meta,
       result: {},

--- a/packages/cli/templates/src/task/src/results/task-result.ts.ejs
+++ b/packages/cli/templates/src/task/src/results/task-result.ts.ejs
@@ -12,5 +12,5 @@ export default class <%- taskResultClass %> extends BaseTaskResult implements Ta
     };
   }
 
-  html() {}
+  toReportData() {}
 }

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -20,7 +20,7 @@ export interface Task {
 export interface TaskResult {
   toConsole: () => void;
   toJson: () => JsonMetaTaskResult | JsonTaskResult;
-  html: () => ReportResultData[];
+  toReportData: () => ReportResultData[];
 }
 
 export interface TaskMetaData {

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -19,7 +19,7 @@ export interface Task {
 
 export interface TaskResult {
   toConsole: () => void;
-  json: () => JsonMetaTaskResult | JsonTaskResult;
+  toJson: () => JsonMetaTaskResult | JsonTaskResult;
   html: () => ReportResultData[];
 }
 

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -18,7 +18,7 @@ export interface Task {
 }
 
 export interface TaskResult {
-  stdout: () => void;
+  toConsole: () => void;
   json: () => JsonMetaTaskResult | JsonTaskResult;
   html: () => ReportResultData[];
 }


### PR DESCRIPTION
Renames the following methods in the `TaskResult` interface:

- `stdout` -> `toConsole`
- `json` -> `toJson`
- `html` -> `toResultData`