### PR TITLE
Fixing command tests

### DIFF
--- a/packages/cli/__tests__/__utils__/run-command.ts
+++ b/packages/cli/__tests__/__utils__/run-command.ts
@@ -1,0 +1,26 @@
+import * as Config from '@oclif/config';
+
+const castArray = <T>(input?: T | T[]): T[] => {
+  if (input === undefined) return [];
+  return Array.isArray(input) ? input : [input];
+};
+
+let root = require.resolve('../../src');
+
+export async function runCommand(args: string[] | string, opts: loadConfig.Options = {}) {
+  let config = await Config.load(opts.root || root);
+
+  args = castArray(args);
+
+  const [id, ...extra] = args;
+  await config.runHook('init', { id, argv: extra });
+  await config.runCommand(id, extra);
+}
+
+export namespace loadConfig {
+  export let root: string;
+  export interface Options {
+    root?: string;
+    reset?: boolean;
+  }
+}

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -4,8 +4,7 @@ import * as path from 'path';
 import { CheckupProject, createTmpDir, stdout } from '@checkup/test-helpers';
 
 import { CheckupConfig } from '@checkup/core';
-
-import cmd = require('../../src');
+import { runCommand } from '../__utils__/run-command';
 
 const TEST_TIMEOUT = 100000;
 
@@ -29,7 +28,7 @@ describe('@checkup/cli', () => {
     it(
       'should output checkup result',
       async () => {
-        await cmd.run(['run', project.baseDir]);
+        await runCommand(['run', project.baseDir]);
 
         expect(stdout()).toMatchSnapshot();
       },
@@ -37,7 +36,7 @@ describe('@checkup/cli', () => {
     );
 
     it('should output checkup result in JSON', async () => {
-      await cmd.run(['run', '--reporter', 'json', project.baseDir]);
+      await runCommand(['run', '--reporter', 'json', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -45,7 +44,7 @@ describe('@checkup/cli', () => {
     it(
       'should output an html file in the current directory if the html reporter option is provided',
       async () => {
-        await cmd.run(['run', '--reporter', 'html', project.baseDir]);
+        await runCommand(['run', '--reporter', 'html', project.baseDir]);
 
         let outputPath = stdout().trim();
 
@@ -64,7 +63,7 @@ describe('@checkup/cli', () => {
       async () => {
         let tmp = createTmpDir();
 
-        await cmd.run(['run', '--reporter', 'html', `--reportOutputPath`, tmp, project.baseDir]);
+        await runCommand(['run', '--reporter', 'html', `--reportOutputPath`, tmp, project.baseDir]);
 
         let outputPath = stdout().trim();
 
@@ -79,7 +78,7 @@ describe('@checkup/cli', () => {
     );
 
     it('should run a single task if the task option is specified', async () => {
-      await cmd.run(['run', '--task', 'project', project.baseDir]);
+      await runCommand(['run', '--task', 'project', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -90,7 +89,7 @@ describe('@checkup/cli', () => {
         tasks: {},
       });
       anotherProject.writeSync();
-      await cmd.run([
+      await runCommand([
         'run',
         '--config',
         path.join(anotherProject.baseDir, '.checkuprc'),
@@ -107,7 +106,7 @@ describe('@checkup/cli', () => {
       const project = new CheckupProject('checkup-project', '0.0.0');
       project.writeSync();
 
-      await expect(cmd.run(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
+      await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Could not find a checkup configuration starting from the given path: ${project.baseDir}. See https://github.com/checkupjs/checkup/tree/master/packages/cli#configuration for more info on how to setup a configuration."`
       );
 
@@ -121,7 +120,7 @@ describe('@checkup/cli', () => {
       });
       project.writeSync();
 
-      await expect(cmd.run(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
+      await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Cannot find module '@checkup/unknown-plugin' from '${project.baseDir}'"`
       );
 
@@ -139,7 +138,7 @@ describe('@checkup/cli', () => {
       } as unknown) as CheckupConfig);
       project.writeSync();
 
-      await expect(cmd.run(['run', project.baseDir])).rejects.toThrowErrorMatchingSnapshot();
+      await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingSnapshot();
 
       project.dispose();
     });

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
     "@checkup/core": "0.0.12",
+    "@oclif/config": "^1.15.1",
     "fixturify-project": "^2.1.0",
     "handlebars": "^4.7.6",
     "stdout-stderr": "^0.1.13",


### PR DESCRIPTION
Adding new `runCommand` method to correctly invoke commands in tests.
