### PR TITLE
chore(test): added a pretest script to execute build prior running the tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ When adding a new breaking change, follow this template in your pull request:
 
 1. Change into that directory, and install dependencies by running `yarn install` (this will install all dependencies for all packages via yarn workspaces):
 
+1. Test the project by running `yarn test`, it will build all the packages prior running the tests.
+
 1. Build the project by running `yarn build`
 
 ## To run Checkup in a project

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:watch": "tsc --watch",
     "clean": "tsc --build --clean",
     "lint": "eslint . --cache --ext .ts",
+    "pretest": "yarn build",
     "test": "yarn workspaces run test"
   },
   "husky": {


### PR DESCRIPTION
When I cloned the project the first thing I did after `yarn install` was `yarn test` as a reflex.
As expected tests failed with 
```
Cannot find module '@checkup/test-helpers'.
Cannot find module '@checkup/core'.
```
I later realized I should have executed `yarn build` prior to the `yarn test`.
Thus added a `pretest` in the `scripts` like so:
```
"pretest": "yarn build",
```
So that `yarn build` gets automatically executed prior to the tests, when running `yarn test`.