### PR TITLE
Part 3 of task context refactoring: Passing normalized plugin names to tasks

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/octane-migration-status-tast-result-test.ts
@@ -1,4 +1,4 @@
-import { ESLintReport, TemplateLintReport } from '@checkup/core';
+import { ESLintReport, TemplateLintReport, getPluginName } from '@checkup/core';
 import { filterPieChartDataForTest, getTaskContext, stdout } from '@checkup/test-helpers';
 
 import OctaneMigrationStatusTask from '../../src/tasks/octane-migration-status-task';
@@ -7,6 +7,7 @@ import OctaneMigrationStatusTaskResult from '../../src/results/octane-migration-
 describe('octane-migration-status-task-result', () => {
   let sampleESLintReport: ESLintReport;
   let sampleTemplateLintReport: TemplateLintReport;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
     sampleESLintReport = require('../__fixtures__/sample-octane-eslint-report.json');
@@ -15,7 +16,7 @@ describe('octane-migration-status-task-result', () => {
 
   describe('console output', () => {
     test('simple console output', async () => {
-      let task = new OctaneMigrationStatusTask(getTaskContext());
+      let task = new OctaneMigrationStatusTask(pluginName, getTaskContext());
       let taskResult = new OctaneMigrationStatusTaskResult(
         task.meta,
         sampleESLintReport,
@@ -30,7 +31,7 @@ describe('octane-migration-status-task-result', () => {
 
   describe('JSON output', () => {
     test('it should have basic JSON results', () => {
-      let task = new OctaneMigrationStatusTask(getTaskContext());
+      let task = new OctaneMigrationStatusTask(pluginName, getTaskContext());
       let taskResult = new OctaneMigrationStatusTaskResult(
         task.meta,
         sampleESLintReport,
@@ -45,7 +46,7 @@ describe('octane-migration-status-task-result', () => {
 
   describe('HTML output', () => {
     test('it should have basic HTML results', () => {
-      let task = new OctaneMigrationStatusTask(getTaskContext());
+      let task = new OctaneMigrationStatusTask(pluginName, getTaskContext());
       let taskResult = new OctaneMigrationStatusTaskResult(
         task.meta,
         sampleESLintReport,

--- a/packages/checkup-plugin-ember-octane/__tests__/tasks/octane-migration-status-task-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/tasks/octane-migration-status-task-test.ts
@@ -1,9 +1,11 @@
 import { EmberProject, getTaskContext } from '@checkup/test-helpers';
 
 import OctaneMigrationStatusTask from '../../src/tasks/octane-migration-status-task';
+import { getPluginName } from '@checkup/core';
 
 describe('octane-migration-status-task', () => {
   let project: EmberProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(function () {
     project = new EmberProject('checkup-app', '0.0.0');
@@ -35,7 +37,7 @@ describe('octane-migration-status-task', () => {
 
     project.writeSync();
 
-    let task = new OctaneMigrationStatusTask(getTaskContext({ path: project.baseDir }));
+    let task = new OctaneMigrationStatusTask(pluginName, getTaskContext({ path: project.baseDir }));
     let taskResult = await task.run();
     let { results, errorCount } = taskResult.esLintReport;
 

--- a/packages/checkup-plugin-ember-octane/src/hooks/register-tasks.ts
+++ b/packages/checkup-plugin-ember-octane/src/hooks/register-tasks.ts
@@ -1,8 +1,11 @@
 import { Hook } from '@oclif/config';
 import OctaneMigrationStatusTask from '../tasks/octane-migration-status-task';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function ({ context, tasks }: any) {
-  tasks.registerTask(new OctaneMigrationStatusTask(context));
+  let pluginName = getPluginName(__dirname);
+
+  tasks.registerTask(new OctaneMigrationStatusTask(pluginName, context));
 };
 
 export default hook;

--- a/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -28,8 +28,8 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
   private eslintParser: Parser<ESLintReport>;
   private templateLinter: TemplateLinter;
 
-  constructor(context: TaskContext) {
-    super(context);
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
 
     let createEslintParser = this.context.parsers.get('eslint')!;
 

--- a/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
@@ -2,9 +2,11 @@ import { EmberProject, stdout, getTaskContext } from '@checkup/test-helpers';
 
 import EmberDependenciesTask from '../src/tasks/ember-dependencies-task';
 import EmberDependenciesTaskResult from '../src/results/ember-dependencies-task-result';
+import { getPluginName } from '@checkup/core';
 
 describe('dependencies-task', () => {
   let emberProject: EmberProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(function () {
     emberProject = new EmberProject('checkup-app', '0.0.0', (project) => {
@@ -23,6 +25,7 @@ describe('dependencies-task', () => {
 
   it('detects Ember dependencies', async () => {
     const result = await new EmberDependenciesTask(
+      pluginName,
       getTaskContext({ path: emberProject.baseDir })
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
@@ -34,6 +37,7 @@ describe('dependencies-task', () => {
 
   it('detects Ember dependencies as JSON', async () => {
     const result = await new EmberDependenciesTask(
+      pluginName,
       getTaskContext({ path: emberProject.baseDir })
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
@@ -43,6 +47,7 @@ describe('dependencies-task', () => {
 
   it('detects Ember dependencies for html, and doesnt create a table without dependencies', async () => {
     const result = await new EmberDependenciesTask(
+      pluginName,
       getTaskContext({ path: emberProject.baseDir })
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;

--- a/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
@@ -2,6 +2,7 @@ import { EmberProject, stdout, getTaskContext } from '@checkup/test-helpers';
 
 import EmberTypesTask from '../src/tasks/ember-types-task';
 import EmberTypesTaskResult from '../src/results/ember-types-task-result';
+import { getPluginName } from '@checkup/core';
 
 const TYPES = {
   components: {
@@ -38,6 +39,7 @@ const TYPES = {
 
 describe('types-task', () => {
   let project: EmberProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(function () {
     project = new EmberProject('checkup-app', '0.0.0');
@@ -55,7 +57,10 @@ describe('types-task', () => {
 
     project.writeSync();
 
-    const result = await new EmberTypesTask(getTaskContext({ path: project.baseDir })).run();
+    const result = await new EmberTypesTask(
+      pluginName,
+      getTaskContext({ path: project.baseDir })
+    ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
     typesTaskResult.toConsole();
@@ -77,7 +82,10 @@ describe('types-task', () => {
 
     project.writeSync();
 
-    const result = await new EmberTypesTask(getTaskContext({ path: project.baseDir })).run();
+    const result = await new EmberTypesTask(
+      pluginName,
+      getTaskContext({ path: project.baseDir })
+    ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
     typesTaskResult.toConsole();
@@ -93,7 +101,10 @@ describe('types-task', () => {
 
     project.writeSync();
 
-    const result = await new EmberTypesTask(getTaskContext({ path: project.baseDir })).run();
+    const result = await new EmberTypesTask(
+      pluginName,
+      getTaskContext({ path: project.baseDir })
+    ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
     expect(typesTaskResult.toJson()).toMatchSnapshot();
@@ -113,7 +124,10 @@ describe('types-task', () => {
 
     project.writeSync();
 
-    const result = await new EmberTypesTask(getTaskContext({ path: project.baseDir })).run();
+    const result = await new EmberTypesTask(
+      pluginName,
+      getTaskContext({ path: project.baseDir })
+    ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
     expect(typesTaskResult.toJson()).toMatchSnapshot();
@@ -127,7 +141,10 @@ describe('types-task', () => {
 
     project.writeSync();
 
-    const result = await new EmberTypesTask(getTaskContext({ path: project.baseDir })).run();
+    const result = await new EmberTypesTask(
+      pluginName,
+      getTaskContext({ path: project.baseDir })
+    ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
     expect(typesTaskResult.toReportData()).toMatchSnapshot();
@@ -147,7 +164,10 @@ describe('types-task', () => {
 
     project.writeSync();
 
-    const result = await new EmberTypesTask(getTaskContext({ path: project.baseDir })).run();
+    const result = await new EmberTypesTask(
+      pluginName,
+      getTaskContext({ path: project.baseDir })
+    ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
     expect(typesTaskResult.toReportData()).toMatchSnapshot();

--- a/packages/checkup-plugin-ember/src/hooks/register-tasks.ts
+++ b/packages/checkup-plugin-ember/src/hooks/register-tasks.ts
@@ -1,10 +1,13 @@
 import EmberDependenciesTask from '../tasks/ember-dependencies-task';
 import EmberTypesTask from '../tasks/ember-types-task';
 import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function ({ context, tasks }: any) {
-  tasks.registerTask(new EmberTypesTask(context));
-  tasks.registerTask(new EmberDependenciesTask(context));
+  let pluginName = getPluginName(__dirname);
+
+  tasks.registerTask(new EmberTypesTask(pluginName, context));
+  tasks.registerTask(new EmberDependenciesTask(pluginName, context));
 };
 
 export default hook;

--- a/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
@@ -25,8 +25,8 @@ export default class EmberTypesTask extends FileSearcherTask implements Task {
     },
   };
 
-  constructor(context: TaskContext) {
-    super(context, SEARCH_PATTERNS);
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context, SEARCH_PATTERNS);
   }
 
   async run(): Promise<TaskResult> {

--- a/packages/cli/__tests__/__utils__/mock-tasks.ts
+++ b/packages/cli/__tests__/__utils__/mock-tasks.ts
@@ -1,4 +1,4 @@
-import { BaseTask, Category, Priority, Task, TaskResult } from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskContext, TaskResult } from '@checkup/core';
 
 import MockTaskResult from './mock-task-result';
 
@@ -11,6 +11,10 @@ export class InsightsTaskHigh extends BaseTask implements Task {
       priority: Priority.High,
     },
   };
+
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
 
   async run(): Promise<TaskResult> {
     return new MockTaskResult(this.meta, 'insights task high is being run');
@@ -27,6 +31,9 @@ export class InsightsTaskLow extends BaseTask implements Task {
     },
   };
 
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
   async run(): Promise<TaskResult> {
     return new MockTaskResult(this.meta, 'insights task low is being run');
   }
@@ -42,6 +49,9 @@ export class RecommendationsTaskHigh extends BaseTask implements Task {
     },
   };
 
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
   async run(): Promise<TaskResult> {
     return new MockTaskResult(this.meta, 'recommendations task high is being run');
   }
@@ -57,6 +67,9 @@ export class RecommendationsTaskLow extends BaseTask implements Task {
     },
   };
 
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
   async run(): Promise<TaskResult> {
     return new MockTaskResult(this.meta, 'recommendations task low is being run');
   }
@@ -72,6 +85,9 @@ export class MigrationTaskHigh extends BaseTask implements Task {
     },
   };
 
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
   async run(): Promise<TaskResult> {
     return new MockTaskResult(this.meta, 'migration task high is being run');
   }
@@ -87,6 +103,9 @@ export class MigrationTaskLow extends BaseTask implements Task {
     },
   };
 
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
   async run(): Promise<TaskResult> {
     return new MockTaskResult(this.meta, 'migration task low is being run');
   }

--- a/packages/cli/__tests__/commands/run-error-test.ts
+++ b/packages/cli/__tests__/commands/run-error-test.ts
@@ -17,13 +17,13 @@ describe('@checkup/cli', () => {
 
     it('should error if a plugin cannot be loaded', async () => {
       const project = new CheckupProject('checkup-project', '0.0.0').addCheckupConfig({
-        plugins: ['@checkup/unknown-plugin'],
+        plugins: ['unknown'],
         tasks: {},
       });
       project.writeSync();
 
       await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Cannot find module '@checkup/unknown-plugin' from '${project.baseDir}'"`
+        `"Cannot find module 'checkup-plugin-unknown' from '${project.baseDir}'"`
       );
 
       project.dispose();

--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -129,9 +129,10 @@ export * from './types';
 
 exports[`plugin generator generates plugin into existing directory with defaults 6`] = `
 "import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;
@@ -255,9 +256,10 @@ exports[`plugin generator generates plugin with JavaScript defaults 4`] = `
 
 exports[`plugin generator generates plugin with JavaScript defaults 5`] = `
 "import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook = async function({ context, tasks }) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;
@@ -413,9 +415,10 @@ export * from './types';
 
 exports[`plugin generator generates plugin with custom options 6`] = `
 "import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;
@@ -571,9 +574,10 @@ export * from './types';
 
 exports[`plugin generator generates plugin with defaults 6`] = `
 "import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;
@@ -729,9 +733,10 @@ export * from './types';
 
 exports[`plugin generator generates plugin with unmodified name with defaults 6`] = `
 "import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -43,28 +43,30 @@ export default class MyFooTaskResult extends BaseTaskResult {
 `;
 
 exports[`task generator generates correct files with JavaScript 3`] = `
-"import { CheckupProject, stdout } from '@checkup/test-helpers';
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import MyFooTask from '../src/tasks/my-foo-task';
 import MyFooTaskResult from '../src/results/my-foo-task-result';
 
 describe('my-foo-task', () => {
-  let checkupProject;
+  let project;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const taskResult = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const taskResult = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
 
     taskResult.toConsole();
 
@@ -72,7 +74,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const taskResult = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const taskResult = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
 
     expect(taskResult.toJson()).toMatchSnapshot();
   });
@@ -81,11 +83,12 @@ describe('my-foo-task', () => {
 
 exports[`task generator generates correct files with JavaScript 4`] = `
 "import { Hook } from '@oclif/config';
-
 import MyFooTask from '../tasks/my-foo-task';
+import { getPluginName } from '@checkup/core';
 
 const hook = async function({ context, tasks }) {
-  tasks.registerTask(new MyFooTask(context));
+  let pluginName = getPluginName(__dirname);
+  tasks.registerTask(new MyFooTask(pluginName, context));
 };
 
 export default hook;
@@ -135,28 +138,30 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
 `;
 
 exports[`task generator generates correct files with TypeScript for defaults 3`] = `
-"import { CheckupProject, stdout } from '@checkup/test-helpers';
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import MyFooTask from '../src/tasks/my-foo-task';
 import MyFooTaskResult from '../src/results/my-foo-task-result';
 
 describe('my-foo-task', () => {
-  let checkupProject: CheckupProject;
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -165,7 +170,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -175,11 +180,12 @@ describe('my-foo-task', () => {
 
 exports[`task generator generates correct files with TypeScript for defaults 4`] = `
 "import { Hook } from '@oclif/config';
-
 import MyFooTask from '../tasks/my-foo-task';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  tasks.registerTask(new MyFooTask(context));
+  let pluginName = getPluginName(__dirname);
+  tasks.registerTask(new MyFooTask(pluginName, context));
 };
 
 export default hook;
@@ -229,28 +235,30 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
 `;
 
 exports[`task generator generates correct files with category 3`] = `
-"import { CheckupProject, stdout } from '@checkup/test-helpers';
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import MyFooTask from '../src/tasks/my-foo-task';
 import MyFooTaskResult from '../src/results/my-foo-task-result';
 
 describe('my-foo-task', () => {
-  let checkupProject: CheckupProject;
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -259,7 +267,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -269,11 +277,12 @@ describe('my-foo-task', () => {
 
 exports[`task generator generates correct files with category 4`] = `
 "import { Hook } from '@oclif/config';
-
 import MyFooTask from '../tasks/my-foo-task';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  tasks.registerTask(new MyFooTask(context));
+  let pluginName = getPluginName(__dirname);
+  tasks.registerTask(new MyFooTask(pluginName, context));
 };
 
 export default hook;
@@ -323,28 +332,30 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
 `;
 
 exports[`task generator generates correct files with priority 3`] = `
-"import { CheckupProject, stdout } from '@checkup/test-helpers';
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import MyFooTask from '../src/tasks/my-foo-task';
 import MyFooTaskResult from '../src/results/my-foo-task-result';
 
 describe('my-foo-task', () => {
-  let checkupProject: CheckupProject;
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -353,7 +364,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -363,11 +374,12 @@ describe('my-foo-task', () => {
 
 exports[`task generator generates correct files with priority 4`] = `
 "import { Hook } from '@oclif/config';
-
 import MyFooTask from '../tasks/my-foo-task';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  tasks.registerTask(new MyFooTask(context));
+  let pluginName = getPluginName(__dirname);
+  tasks.registerTask(new MyFooTask(pluginName, context));
 };
 
 export default hook;
@@ -417,28 +429,30 @@ export default class MyFooTaskResult extends BaseTaskResult implements TaskResul
 `;
 
 exports[`task generator generates multiple correct files with TypeScript for defaults 3`] = `
-"import { CheckupProject, stdout } from '@checkup/test-helpers';
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import MyFooTask from '../src/tasks/my-foo-task';
 import MyFooTaskResult from '../src/results/my-foo-task-result';
 
 describe('my-foo-task', () => {
-  let checkupProject: CheckupProject;
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -447,7 +461,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -498,28 +512,30 @@ export default class MyBarTaskResult extends BaseTaskResult implements TaskResul
 `;
 
 exports[`task generator generates multiple correct files with TypeScript for defaults 6`] = `
-"import { CheckupProject, stdout } from '@checkup/test-helpers';
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import MyBarTask from '../src/tasks/my-bar-task';
 import MyBarTaskResult from '../src/results/my-bar-task-result';
 
 describe('my-bar-task', () => {
-  let checkupProject: CheckupProject;
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyBarTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyBarTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyBarTaskResult>result;
 
     taskResult.toConsole();
@@ -528,7 +544,7 @@ describe('my-bar-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyBarTask({ path: checkupProject.baseDir }).run();
+    const result = await new MyBarTask(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <MyBarTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -538,14 +554,14 @@ describe('my-bar-task', () => {
 
 exports[`task generator generates multiple correct files with TypeScript for defaults 7`] = `
 "import { Hook } from '@oclif/config';
-
 import MyBarTask from '../tasks/my-bar-task';
-
 import MyFooTask from '../tasks/my-foo-task';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  tasks.registerTask(new MyFooTask(context));
-  tasks.registerTask(new MyBarTask(context));
+  let pluginName = getPluginName(__dirname);
+  tasks.registerTask(new MyFooTask(pluginName, context));
+  tasks.registerTask(new MyBarTask(pluginName, context));
 };
 
 export default hook;

--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -39,7 +39,7 @@ describe('checkup-meta-task', () => {
       let checkupConfig = await getConfig();
 
       const result = await new CheckupMetaTask(
-        'core',
+        'meta',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
@@ -57,7 +57,7 @@ describe('checkup-meta-task', () => {
       let checkupConfig = await getConfig();
 
       const result = await new CheckupMetaTask(
-        'core',
+        'meta',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
@@ -79,7 +79,7 @@ describe('checkup-meta-task', () => {
       });
 
       const result = await new CheckupMetaTask(
-        'core',
+        'meta',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
@@ -100,7 +100,7 @@ describe('checkup-meta-task', () => {
       });
 
       const result = await new CheckupMetaTask(
-        'core',
+        'meta',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;

--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -39,6 +39,7 @@ describe('checkup-meta-task', () => {
       let checkupConfig = await getConfig();
 
       const result = await new CheckupMetaTask(
+        'core',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
@@ -56,6 +57,7 @@ describe('checkup-meta-task', () => {
       let checkupConfig = await getConfig();
 
       const result = await new CheckupMetaTask(
+        'core',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
@@ -77,6 +79,7 @@ describe('checkup-meta-task', () => {
       });
 
       const result = await new CheckupMetaTask(
+        'core',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
@@ -97,6 +100,7 @@ describe('checkup-meta-task', () => {
       });
 
       const result = await new CheckupMetaTask(
+        'core',
         getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -21,7 +21,7 @@ describe('project-meta-task', () => {
 
     it('can read project info and output to console', async () => {
       const result = await new ProjectMetaTask(
-        'core',
+        'meta',
         getTaskContext({ path: checkupProject.baseDir })
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
@@ -40,7 +40,7 @@ describe('project-meta-task', () => {
 
     it('can read project info as JSON', async () => {
       const result = await new ProjectMetaTask(
-        'core',
+        'meta',
         getTaskContext({ path: checkupProject.baseDir })
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -21,6 +21,7 @@ describe('project-meta-task', () => {
 
     it('can read project info and output to console', async () => {
       const result = await new ProjectMetaTask(
+        'core',
         getTaskContext({ path: checkupProject.baseDir })
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
@@ -39,6 +40,7 @@ describe('project-meta-task', () => {
 
     it('can read project info as JSON', async () => {
       const result = await new ProjectMetaTask(
+        'core',
         getTaskContext({ path: checkupProject.baseDir })
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -88,8 +88,10 @@ export default class RunCommand extends Command {
   }
 
   private async registerDefaultTasks(context: TaskContext) {
-    this.defaultTasks.registerTask(new ProjectMetaTask(context));
-    this.defaultTasks.registerTask(new CheckupMetaTask(context));
+    let pluginName = 'core';
+
+    this.defaultTasks.registerTask(new ProjectMetaTask(pluginName, context));
+    this.defaultTasks.registerTask(new CheckupMetaTask(pluginName, context));
   }
 
   private async runTasks() {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -88,7 +88,7 @@ export default class RunCommand extends Command {
   }
 
   private async registerDefaultTasks(context: TaskContext) {
-    let pluginName = 'core';
+    let pluginName = 'meta';
 
     this.defaultTasks.registerTask(new ProjectMetaTask(pluginName, context));
     this.defaultTasks.registerTask(new CheckupMetaTask(pluginName, context));

--- a/packages/cli/src/generators/task.ts
+++ b/packages/cli/src/generators/task.ts
@@ -125,7 +125,10 @@ export default class TaskGenerator extends BaseGenerator {
     let registerTasksSource = this.fs.read(hooksDestinationPath);
     let registerTaskStatement = t.expressionStatement(
       t.callExpression(t.memberExpression(t.identifier('tasks'), t.identifier('registerTask')), [
-        t.newExpression(t.identifier(this.options.taskClass), [t.identifier('context')]),
+        t.newExpression(t.identifier(this.options.taskClass), [
+          t.identifier('pluginName'),
+          t.identifier('context'),
+        ]),
       ])
     );
 

--- a/packages/cli/src/tasks/checkup-meta-task.ts
+++ b/packages/cli/src/tasks/checkup-meta-task.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import * as stringify from 'json-stable-stringify';
 
-import { BaseTask, CheckupConfig, TaskContext, TaskIdentifier } from '@checkup/core';
+import { BaseTask, CheckupConfig, TaskIdentifier } from '@checkup/core';
 import { MetaTask, MetaTaskResult } from '../types';
 
 import CheckupMetaTaskResult from '../results/checkup-meta-task-result';
@@ -18,10 +18,6 @@ export default class CheckupMetaTask extends BaseTask implements MetaTask {
     taskName: 'checkup',
     friendlyTaskName: 'Checkup Configuration',
   };
-
-  constructor(context: TaskContext) {
-    super(context);
-  }
 
   async run(): Promise<MetaTaskResult> {
     let result: CheckupMetaTaskResult = new CheckupMetaTaskResult(this.meta);

--- a/packages/cli/templates/src/plugin/src/hooks/register-tasks.js.ejs
+++ b/packages/cli/templates/src/plugin/src/hooks/register-tasks.js.ejs
@@ -1,7 +1,8 @@
 import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook = async function({ context, tasks }) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;

--- a/packages/cli/templates/src/plugin/src/hooks/register-tasks.ts.ejs
+++ b/packages/cli/templates/src/plugin/src/hooks/register-tasks.ts.ejs
@@ -1,7 +1,8 @@
 import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
 
 const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
-  
+  let pluginName = getPluginName(__dirname);
 };
 
 export default hook;

--- a/packages/cli/templates/src/task/__tests__/task.js.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.js.ejs
@@ -1,27 +1,29 @@
 <%_ const taskClass = `${_.upperFirst(_.camelCase(name))}Task` _%>
 <%_ const resultClass = `${taskClass}Result` _%>
-import { CheckupProject, stdout } from '@checkup/test-helpers';
+import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import <%- taskClass %> from '../src/tasks/<%- name %>-task';
 import <%- resultClass %> from '../src/results/<%- name %>-task-result';
 
 describe('<%- name %>-task', () => {
-  let checkupProject;
+  let project;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const taskResult = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
+    const taskResult = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir }).run();
 
     taskResult.toConsole();
 
@@ -29,7 +31,7 @@ describe('<%- name %>-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const taskResult = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
+    const taskResult = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir }).run();
 
     expect(taskResult.toJson()).toMatchSnapshot();
   });

--- a/packages/cli/templates/src/task/__tests__/task.ts.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.ts.ejs
@@ -1,27 +1,29 @@
 <%_ const taskClass = `${_.upperFirst(_.camelCase(name))}Task` _%>
 <%_ const resultClass = `${taskClass}Result` _%>
-import { CheckupProject, stdout } from '@checkup/test-helpers';
+import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
 import <%- taskClass %> from '../src/tasks/<%- name %>-task';
 import <%- resultClass %> from '../src/results/<%- name %>-task-result';
 
 describe('<%- name %>-task', () => {
-  let checkupProject: CheckupProject;
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
 
   beforeEach(() => {
-    checkupProject = new CheckupProject('checkup-app', '0.0.0', project => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
       project.addDependency('ember-cli', '^3.15.0');
     });
 
-    checkupProject.writeSync();
-    checkupProject.gitInit();
+    project.writeSync();
+    project.gitInit();
   });
 
   afterEach(() => {
-    checkupProject.dispose();
+    project.dispose();
   });
 
   it('can read task and output to console', async () => {
-    const result = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
+    const result = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <<%- resultClass %>>result;
 
     taskResult.toConsole();
@@ -30,7 +32,7 @@ describe('<%- name %>-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new <%- taskClass %>({ path: checkupProject.baseDir }).run();
+    const result = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir }).run();
     const taskResult = <<%- resultClass %>>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -39,7 +39,7 @@ describe('BaseTask', () => {
       config: DEFAULT_CONFIG,
     };
 
-    let fakeTask = new FakeTask(context);
+    let fakeTask = new FakeTask('fake', context);
 
     expect(fakeTask.context).toEqual(context);
     expect(fakeTask.config).toEqual({});
@@ -54,12 +54,12 @@ describe('BaseTask', () => {
       config: {
         plugins: [],
         tasks: {
-          'my-fake': 'off',
+          'fake/my-fake': 'off',
         },
       },
     };
 
-    let fakeTask = new FakeTask(context);
+    let fakeTask = new FakeTask('fake', context);
 
     expect(fakeTask.enabled).toEqual(false);
   });
@@ -72,12 +72,12 @@ describe('BaseTask', () => {
       config: {
         plugins: [],
         tasks: {
-          'my-fake': ['on', { 'my-fake-option': true }],
+          'fake/my-fake': ['on', { 'my-fake-option': true }],
         },
       },
     };
 
-    let fakeTask = new FakeTask(context);
+    let fakeTask = new FakeTask('fake', context);
 
     expect(fakeTask.enabled).toEqual(true);
     expect(fakeTask.config).toEqual({ 'my-fake-option': true });

--- a/packages/core/__tests__/configuration/checkup-config-service-test.ts
+++ b/packages/core/__tests__/configuration/checkup-config-service-test.ts
@@ -25,6 +25,23 @@ describe('checkup-config-service', () => {
     expect(configService.get()).toStrictEqual(defaultConfig);
   });
 
+  it('should normalize plugin names when get is called', async () => {
+    const configService = await CheckupConfigService.load(async () => ({
+      filepath: '.',
+      config: {
+        plugins: ['checkup-plugin-foo', 'bar', 'baz'],
+        tasks: {},
+      },
+      format: CheckupConfigFormat.JSON,
+    }));
+
+    expect(configService.get().plugins).toStrictEqual([
+      'checkup-plugin-foo',
+      'checkup-plugin-bar',
+      'checkup-plugin-baz',
+    ]);
+  });
+
   it('should throw an error if an invalid config is present and get is called', async () => {
     const configService = await CheckupConfigService.load(async () => ({
       filepath: '.',

--- a/packages/core/__tests__/utils/plugin-name-test.ts
+++ b/packages/core/__tests__/utils/plugin-name-test.ts
@@ -1,0 +1,28 @@
+import { getShorthandName, normalizePackageName } from '../../src/utils/plugin-name';
+
+describe('plugin-name', () => {
+  it.each([
+    ['foo', 'checkup-plugin-foo'],
+    ['checkup-plugin-foo', 'checkup-plugin-foo'],
+    ['@z/foo', '@z/checkup-plugin-foo'],
+    ['@z\\foo', '@z/checkup-plugin-foo'],
+    ['@z\\foo\\bar.js', '@z/checkup-plugin-foo/bar.js'],
+    ['@z/checkup-plugin', '@z/checkup-plugin'],
+    ['@z/checkup-plugin-foo', '@z/checkup-plugin-foo'],
+  ])('normalizes plugin name from %s to %s', (input, expected) => {
+    let pluginName = normalizePackageName(input);
+    expect(pluginName).toEqual(expected);
+  });
+
+  it.each([
+    ['foo', 'foo'],
+    ['checkup-plugin-foo', 'foo'],
+    ['@z', '@z'],
+    ['@z/checkup-plugin', '@z'],
+    ['@z/foo', '@z/foo'],
+    ['@z/checkup-plugin-foo', '@z/foo'],
+  ])('gets short plugin name from %s to %s', (input, expected) => {
+    let pluginName = getShorthandName(input);
+    expect(pluginName).toEqual(expected);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "fp-ts": "^2.5.4",
     "globby": "^11.0.0",
     "io-ts": "^2.2.2",
+    "pkg-up": "^3.1.0",
     "resolve": "^1.17.0"
   },
   "devDependencies": {

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -3,7 +3,7 @@ import * as debug from 'debug';
 import { TaskContext, TaskIdentifier, TaskMetaData } from './types/tasks';
 
 import { TaskConfig } from './types/configuration';
-import { toShortPluginName } from './utils/plugin-name';
+import { getShorthandName } from './utils/plugin-name';
 
 export default abstract class BaseTask {
   context: TaskContext;
@@ -15,7 +15,7 @@ export default abstract class BaseTask {
   #enabled!: string;
 
   constructor(pluginName: string, context: TaskContext) {
-    this.#pluginName = toShortPluginName(pluginName);
+    this.#pluginName = getShorthandName(pluginName);
     this.context = context;
 
     this.debug = debug('checkup:task');

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -3,41 +3,24 @@ import * as debug from 'debug';
 import { TaskContext, TaskIdentifier, TaskMetaData } from './types/tasks';
 
 import { TaskConfig } from './types/configuration';
+import { toShortPluginName } from './utils/plugin-name';
 
 export default abstract class BaseTask {
   context: TaskContext;
   meta!: TaskMetaData | TaskIdentifier;
   debug: debug.Debugger;
 
+  #pluginName: string;
   #config!: unknown;
   #enabled!: string;
 
-  constructor(context: TaskContext) {
+  constructor(pluginName: string, context: TaskContext) {
+    this.#pluginName = toShortPluginName(pluginName);
     this.context = context;
 
     this.debug = debug('checkup:task');
 
-    this.debug('%s %s', this.constructor.name, 'created');
-  }
-
-  private _parseConfig() {
-    if (this.#config) {
-      return;
-    }
-
-    let config: TaskConfig | undefined = this.context.config.tasks[this.meta.taskName];
-
-    this.#config = {};
-    this.#enabled = 'on';
-
-    if (typeof config === 'string') {
-      this.#enabled = config;
-    } else if (Array.isArray(config)) {
-      let [enabled, taskConfig] = config;
-
-      this.#enabled = enabled;
-      this.#config = taskConfig;
-    }
+    this.debug('%s created', this.constructor.name);
   }
 
   get config() {
@@ -50,5 +33,32 @@ export default abstract class BaseTask {
     this._parseConfig();
 
     return this.#enabled === 'on';
+  }
+
+  private get fullyQualifiedTaskName() {
+    return `${this.#pluginName}/${this.meta.taskName}`;
+  }
+
+  private _parseConfig() {
+    if (this.#config) {
+      return;
+    }
+
+    let config: TaskConfig | undefined = this.context.config.tasks[this.fullyQualifiedTaskName];
+
+    this.#config = {};
+    this.#enabled = 'on';
+
+    if (typeof config === 'string') {
+      this.#enabled = config;
+    } else if (Array.isArray(config)) {
+      let [enabled, taskConfig] = config;
+
+      this.#enabled = enabled;
+      this.#config = taskConfig;
+    }
+
+    this.debug('%s enabled: %s', this.constructor.name, this.#enabled);
+    this.debug('%s task config: %o', this.constructor.name, this.#config);
   }
 }

--- a/packages/core/src/configuration/checkup-config-service.ts
+++ b/packages/core/src/configuration/checkup-config-service.ts
@@ -6,8 +6,8 @@ import { CheckupConfig, CheckupConfigFormat, CheckupConfigLoader } from '../type
 import { RuntimeCheckupConfig } from '../types/runtime-types';
 import { basename } from 'path';
 import { fold } from 'fp-ts/lib/Either';
+import { normalizePackageName } from '../utils/plugin-name';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { toFullPluginName } from '../utils/plugin-name';
 
 /**
  * A service to interact with a {@link CheckupConfig}. Create an instance via
@@ -81,7 +81,7 @@ export default class CheckupConfigService {
 
   private normalizePluginNames() {
     this.config.plugins.forEach((plugin, index, arr) => {
-      arr[index] = toFullPluginName(plugin);
+      arr[index] = normalizePackageName(plugin);
     });
   }
 

--- a/packages/core/src/configuration/checkup-config-service.ts
+++ b/packages/core/src/configuration/checkup-config-service.ts
@@ -7,6 +7,7 @@ import { RuntimeCheckupConfig } from '../types/runtime-types';
 import { basename } from 'path';
 import { fold } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
+import { toFullPluginName } from '../utils/plugin-name';
 
 /**
  * A service to interact with a {@link CheckupConfig}. Create an instance via
@@ -35,6 +36,7 @@ export default class CheckupConfigService {
    */
   get() {
     this.validate();
+    this.normalizePluginNames();
     debug('checkup:config')('%j', this.config);
     return this.config;
   }
@@ -75,6 +77,12 @@ export default class CheckupConfigService {
         () => ['no errors']
       )
     );
+  }
+
+  private normalizePluginNames() {
+    this.config.plugins.forEach((plugin, index, arr) => {
+      arr[index] = toFullPluginName(plugin);
+    });
   }
 
   private constructor(config: CheckupConfig, configPath: string, format: CheckupConfigFormat) {

--- a/packages/core/src/file-searcher-task.ts
+++ b/packages/core/src/file-searcher-task.ts
@@ -19,8 +19,8 @@ export default abstract class FileSearcherTask extends BaseTask {
    * @param result {TaskResult[]} the result object that aggregates data together for output.
    * @param searchPatterns {SearchPatterns} the search pattern that your FileSearcher uses to return the results.
    */
-  constructor(context: TaskContext, searchPatterns: SearchPatterns) {
-    super(context);
+  constructor(pluginName: string, context: TaskContext, searchPatterns: SearchPatterns) {
+    super(pluginName, context);
 
     this.searcher = new FileSearcher(context.cliArguments.path, searchPatterns);
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export { default as getFilepathLoader } from './configuration/loaders/get-filepa
 export { default as CosmiconfigService } from './configuration/cosmiconfig-service';
 export { default as getInitializationConfigLoader } from './configuration/loaders/get-initialization-loader';
 
+export { getPluginName, toShortPluginName, toFullPluginName } from './utils/plugin-name';
 export { getPackageJson } from './utils/get-package-json';
 export { ui } from './utils/ui';
 export { toPairs } from './utils/data-transformers';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,7 @@ export { default as getFilepathLoader } from './configuration/loaders/get-filepa
 export { default as CosmiconfigService } from './configuration/cosmiconfig-service';
 export { default as getInitializationConfigLoader } from './configuration/loaders/get-initialization-loader';
 
-export { getPluginName, toShortPluginName, toFullPluginName } from './utils/plugin-name';
+export { getPluginName, normalizePackageName, getShorthandName } from './utils/plugin-name';
 export { getPackageJson } from './utils/get-package-json';
 export { ui } from './utils/ui';
 export { toPairs } from './utils/data-transformers';

--- a/packages/core/src/utils/plugin-name.ts
+++ b/packages/core/src/utils/plugin-name.ts
@@ -2,18 +2,80 @@ import { PackageJson } from 'type-fest';
 import { readJsonSync } from 'fs-extra';
 import { sync } from 'pkg-up';
 
-const PLUGIN_NAME_PATTERN = /checkup-plugin-.*/;
+/**
+ * The below functions are referenced from eslint's plugin name normalization.
+ * https://github.com/eslint/eslint/blob/bcafd0f8508e19ab8087a35fac7b97fc4295df3e/lib/shared/naming.js
+ */
 
-export function toShortPluginName(pluginName: string) {
-  return pluginName.replace('checkup-plugin-', '');
-}
+/**
+ * Brings package name to correct format based on prefix
+ * @param {string} name The name of the package.
+ * @param {string} prefix Can be either "checkup-plugin"
+ * @returns {string} Normalized name of the package
+ * @private
+ */
+export function normalizePackageName(name: string) {
+  let prefix = 'checkup-plugin';
+  let normalizedName = name;
 
-export function toFullPluginName(pluginName: string) {
-  if (!PLUGIN_NAME_PATTERN.test(pluginName)) {
-    return `checkup-plugin-${pluginName}`;
+  /**
+   * On Windows, name can come in with Windows slashes instead of Unix slashes.
+   * Normalize to Unix first to avoid errors later on.
+   * https://github.com/eslint/eslint/issues/5644
+   */
+  if (normalizedName.includes('\\')) {
+    normalizedName = normalizedName.replace(/\\/gu, '/');
   }
 
-  return pluginName;
+  if (normalizedName.charAt(0) === '@') {
+    /**
+     * it's a scoped package
+     * package name is the prefix, or just a username
+     */
+    const scopedPackageShortcutRegex = new RegExp(`^(@[^/]+)(?:/(?:${prefix})?)?$`, 'u'),
+      scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`, 'u');
+
+    if (scopedPackageShortcutRegex.test(normalizedName)) {
+      normalizedName = normalizedName.replace(scopedPackageShortcutRegex, `$1/${prefix}`);
+    } else if (!scopedPackageNameRegex.test(normalizedName.split('/')[1])) {
+      /**
+       * for scoped packages, insert the prefix after the first / unless
+       * the path is already @scope/eslint or @scope/eslint-xxx-yyy
+       */
+      normalizedName = normalizedName.replace(/^@([^/]+)\/(.*)$/u, `@$1/${prefix}-$2`);
+    }
+  } else if (!normalizedName.startsWith(`${prefix}-`)) {
+    normalizedName = `${prefix}-${normalizedName}`;
+  }
+
+  return normalizedName;
+}
+
+/**
+ * Removes the prefix from a fullName.
+ * @param {string} fullName The term which may have the prefix.
+ * @param {string} prefix The prefix to remove.
+ * @returns {string} The term without prefix.
+ */
+export function getShorthandName(fullName: string) {
+  let prefix = 'checkup-plugin';
+
+  if (fullName[0] === '@') {
+    let matchResult = new RegExp(`^(@[^/]+)/${prefix}$`, 'u').exec(fullName);
+
+    if (matchResult) {
+      return matchResult[1];
+    }
+
+    matchResult = new RegExp(`^(@[^/]+)/${prefix}-(.+)$`, 'u').exec(fullName);
+    if (matchResult) {
+      return `${matchResult[1]}/${matchResult[2]}`;
+    }
+  } else if (fullName.startsWith(`${prefix}-`)) {
+    return fullName.slice(prefix.length + 1);
+  }
+
+  return fullName;
 }
 
 export function getPluginName(cwd: string): string {

--- a/packages/core/src/utils/plugin-name.ts
+++ b/packages/core/src/utils/plugin-name.ts
@@ -17,7 +17,15 @@ export function toFullPluginName(pluginName: string) {
 }
 
 export function getPluginName(cwd: string): string {
-  let packageJson: PackageJson = readJsonSync(sync({ cwd })!);
+  let packageJsonPath = sync({ cwd });
+  let packageJson: PackageJson = readJsonSync(packageJsonPath!);
+
+  if (!packageJson.keywords?.includes('checkup-plugin')) {
+    throw new Error(
+      `You tried to retrieve a pluginName from a package.json that isn't from a checkup plugin.
+Path: ${packageJsonPath}`
+    );
+  }
 
   return packageJson.name!;
 }

--- a/packages/core/src/utils/plugin-name.ts
+++ b/packages/core/src/utils/plugin-name.ts
@@ -1,0 +1,23 @@
+import { PackageJson } from 'type-fest';
+import { readJsonSync } from 'fs-extra';
+import { sync } from 'pkg-up';
+
+const PLUGIN_NAME_PATTERN = /checkup-plugin-.*/;
+
+export function toShortPluginName(pluginName: string) {
+  return pluginName.replace('checkup-plugin-', '');
+}
+
+export function toFullPluginName(pluginName: string) {
+  if (!PLUGIN_NAME_PATTERN.test(pluginName)) {
+    return `checkup-plugin-${pluginName}`;
+  }
+
+  return pluginName;
+}
+
+export function getPluginName(cwd: string): string {
+  let packageJson: PackageJson = readJsonSync(sync({ cwd })!);
+
+  return packageJson.name!;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6537,6 +6537,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"


### PR DESCRIPTION
Continues where #372 left off.

Updates config loading to normalize plugin names to `checkup-plugin-*`, so that configs can eliminate the need to specify the fully qualified plugin name.

Passes in plugin name to task, so it can use the fully qualified plugin name to look up it's config, eg. `ember/ember-types`, where `ember` is `checkup-plugin-ember`