### PR TITLE
Add ability to specify location of output for meta tasks

### DIFF
--- a/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
@@ -1,11 +1,13 @@
+import { MetaTaskResult, OutputPosition } from '../../src/types';
+
 import BaseMetaTaskResult from '../../src/base-meta-task-result';
-import { MetaTaskResult } from '../../src/types';
 import { TaskIdentifier } from '@checkup/core';
 
 export default class MockMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
   constructor(meta: TaskIdentifier, public result: any) {
     super(meta);
   }
+  outputPosition: OutputPosition = OutputPosition.Header;
 
   toConsole() {
     process.stdout.write(`Result for ${this.meta.taskName}`);

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -2,16 +2,17 @@
 
 exports[`@checkup/cli normal cli output should output checkup result 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0 .
+Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
-
-Generated using Checkup v0.0.0. Config: ae3266e319bdfb51db83810a2f4dd161
 
 === Outdated Dependencies ===
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2
 ■ major (2)  ■ minor (0)  ■ patch (0)  
+
+checkup v0.0.0
+config ae3266e319bdfb51db83810a2f4dd161
 
 "
 `;
@@ -88,7 +89,7 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
 
 exports[`@checkup/cli normal cli output should run a single task if the task option is specified 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0 .
+Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -97,16 +98,17 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 exports[`@checkup/cli normal cli output should use the config at the config path if provided 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0 .
+Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
-
-Generated using Checkup v0.0.0. Config: ae3266e319bdfb51db83810a2f4dd161
 
 === Outdated Dependencies ===
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2
 ■ major (2)  ■ minor (0)  ■ patch (0)  
+
+checkup v0.0.0
+config ae3266e319bdfb51db83810a2f4dd161
 
 "
 `;

--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -47,7 +47,8 @@ describe('checkup-meta-task', () => {
       taskResult.toConsole();
 
       expect(stdout()).toMatchInlineSnapshot(`
-        "Generated using Checkup v0.0.0. Config: ae3266e319bdfb51db83810a2f4dd161
+        "checkup v0.0.0
+        config ae3266e319bdfb51db83810a2f4dd161
 
         "
       `);
@@ -87,7 +88,8 @@ describe('checkup-meta-task', () => {
       taskResult.toConsole();
 
       expect(stdout()).toMatchInlineSnapshot(`
-        "Generated using Checkup v0.0.0. Config: 705deefb6abf2b6d34f93cede7acba07
+        "checkup v0.0.0
+        config 705deefb6abf2b6d34f93cede7acba07
 
         "
       `);

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -30,7 +30,7 @@ describe('project-meta-task', () => {
 
       expect(stdout()).toMatchInlineSnapshot(`
         "
-        Checkup report generated for checkup-app v0.0.0 .
+        Checkup report generated for checkup-app v0.0.0
 
         This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -9,8 +9,8 @@ import {
   UIResultData,
   ui,
 } from '@checkup/core';
+import { MetaTaskResult, OutputPosition } from './types';
 
-import { MetaTaskResult } from './types';
 import { generateHTMLReport } from './helpers/ui-report';
 
 export function _transformHTMLResults(
@@ -78,8 +78,13 @@ export function getReporter(
     case ReporterType.stdout:
       return async () => {
         if (!flags.silent) {
-          metaTaskResults.forEach((taskResult) => taskResult.toConsole());
+          metaTaskResults
+            .filter((taskResult) => taskResult.outputPosition === OutputPosition.Header)
+            .forEach((taskResult) => taskResult.toConsole());
           pluginTaskResults.forEach((taskResult) => taskResult.toConsole());
+          metaTaskResults
+            .filter((taskResult) => taskResult.outputPosition === OutputPosition.Footer)
+            .forEach((taskResult) => taskResult.toConsole());
         }
       };
     case ReporterType.json:

--- a/packages/cli/src/results/checkup-meta-task-result.ts
+++ b/packages/cli/src/results/checkup-meta-task-result.ts
@@ -1,13 +1,16 @@
+import { MetaTaskResult, OutputPosition } from '../types';
+
 import BaseMetaTaskResult from '../base-meta-task-result';
-import { MetaTaskResult } from '../types';
 import { ui } from '@checkup/core';
 
 export default class CheckupMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
+  outputPosition: OutputPosition = OutputPosition.Footer;
   configHash!: string;
   version!: string;
 
   toConsole() {
-    ui.dimmed(`Generated using Checkup v${this.version}. Config: ${this.configHash}`);
+    ui.dimmed(`checkup v${this.version}`);
+    ui.dimmed(`config ${this.configHash}`);
     ui.blankLine();
   }
 

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -1,16 +1,17 @@
-import { MetaTaskResult, RepositoryInfo } from '../types';
+import { MetaTaskResult, OutputPosition, RepositoryInfo } from '../types';
 
 import BaseMetaTaskResult from '../base-meta-task-result';
 import { ui } from '@checkup/core';
 
 export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
+  outputPosition: OutputPosition = OutputPosition.Header;
   name!: string;
   version!: string;
   repository!: RepositoryInfo;
 
   toConsole() {
     ui.blankLine();
-    ui.log(`Checkup report generated for ${ui.emphasize(`${this.name} v${this.version}`)} .`);
+    ui.log(`Checkup report generated for ${ui.emphasize(`${this.name} v${this.version}`)}`);
     ui.blankLine();
     ui.log(
       `This project is ${ui.emphasize(`${this.repository.age} old`)}, with ${ui.emphasize(

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -9,8 +9,14 @@ export interface MetaTask {
 }
 
 export interface MetaTaskResult {
+  outputPosition: OutputPosition;
   toConsole: () => void;
   toJson: () => JsonMetaTaskResult;
+}
+
+export const enum OutputPosition {
+  Header,
+  Footer,
 }
 
 export const enum TestType {


### PR DESCRIPTION
Adds an `outputPosition` prop to meta task results, allow us to specify where the meta task is output to.