### PR TITLE
Changes `checkup run` to default to `checkup` (without `run`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ When adding a new breaking change, follow this template in your pull request:
 1. Execute Checkup in your project
 
    ```shell
-   checkup run .
+   checkup .
    ```
 
 ### Running a specific Checkup task in your project
@@ -84,7 +84,7 @@ When adding a new breaking change, follow this template in your pull request:
 To run a specific task:
 
 ```
-checkup run --task TASK_NAME
+checkup --task TASK_NAME
 ```
 
 ## Running tests
@@ -100,7 +100,7 @@ yarn test
 Checkup using the debug package to provide useful information for debugging. You can enable it by running:
 
 ```shell
-DEBUG='*' checkup run .
+DEBUG='*' checkup
 ```
 
 ## Debugging tests

--- a/packages/checkup-plugin-ember-octane/README.md
+++ b/packages/checkup-plugin-ember-octane/README.md
@@ -42,5 +42,5 @@ A plugin for CheckupJS that tracks progress of Ember Octane migration tasks.
 4. Run checkup.
 
    ```sh-session
-   $ checkup run .
+   $ checkup
    ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,19 +34,19 @@ $ checkup generate config
 The `checkup` CLI is now available to run. Use the `run` command to run Checkup against your project directory:
 
 ```sh-session
-$ checkup run .
+$ checkup
 Checking up on your project...
 ```
 
-# Run Command
+# Checkup Command (alias `checkup run`)
 
-## `checkup run PATH`
+## `checkup PATH`
 
 A CLI that provides health check information about your project
 
 ```
 USAGE
-  $ checkup run PATH
+  $ checkup PATH
 
 ARGUMENTS
   PATH  [default: .] The path referring to the root directory that Checkup will run in

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -29,6 +29,8 @@ import { getReporter } from '../reporters';
 export default class RunCommand extends Command {
   static description = 'Provides health check information about your project';
 
+  static usage = '[run] PATH';
+
   static args = [
     {
       name: 'path',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,21 @@
-export { run } from '@oclif/command';
+import { basename, extname, join } from 'path';
+
+import { run as oclifRun } from '@oclif/command';
+import { readdirSync } from 'fs';
+
+const DEFAULT_COMMAND = 'run';
+const COMMANDS = readdirSync(join(__dirname, 'commands')).map((filename: string) =>
+  basename(filename, extname(filename))
+);
+
+export function run() {
+  let args = process.argv.slice(2);
+  let maybeCommand = args[0];
+
+  // if the args don't contain a known command, we default to the `run` command
+  if (!COMMANDS.includes(maybeCommand)) {
+    args.unshift(DEFAULT_COMMAND);
+  }
+
+  return oclifRun(args);
+}


### PR DESCRIPTION
When we swapped to a multi-command, we lost the ability to invoke checkup without having to specify a subcommand. This PR restores that ability.

Before:

```shell
checkup run PATH
```

After:

```shell
checkup PATH
```