### PR TITLE
Changing the run command arg so that the root directory is passed in via flag, so args can be used for paths to operate on

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/tasks/octane-migration-status-task-test.ts
+++ b/packages/checkup-plugin-ember-octane/__tests__/tasks/octane-migration-status-task-test.ts
@@ -37,7 +37,10 @@ describe('octane-migration-status-task', () => {
 
     project.writeSync();
 
-    let task = new OctaneMigrationStatusTask(pluginName, getTaskContext({ path: project.baseDir }));
+    let task = new OctaneMigrationStatusTask(
+      pluginName,
+      getTaskContext({}, { cwd: project.baseDir })
+    );
     let taskResult = await task.run();
     let { results, errorCount } = taskResult.esLintReport;
 

--- a/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -40,7 +40,7 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
   }
 
   get rootPath(): string {
-    return this.context.cliArguments.path;
+    return this.context.cliFlags.cwd;
   }
 
   async run(): Promise<OctaneMigrationStatusTaskResult> {

--- a/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
@@ -26,7 +26,7 @@ describe('dependencies-task', () => {
   it('detects Ember dependencies', async () => {
     const result = await new EmberDependenciesTask(
       pluginName,
-      getTaskContext({ path: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir })
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
 
@@ -38,7 +38,7 @@ describe('dependencies-task', () => {
   it('detects Ember dependencies as JSON', async () => {
     const result = await new EmberDependenciesTask(
       pluginName,
-      getTaskContext({ path: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir })
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
 
@@ -48,7 +48,7 @@ describe('dependencies-task', () => {
   it('detects Ember dependencies for html, and doesnt create a table without dependencies', async () => {
     const result = await new EmberDependenciesTask(
       pluginName,
-      getTaskContext({ path: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir })
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
     const htmlResults = dependencyTaskResult.toReportData();

--- a/packages/checkup-plugin-ember/__tests__/ember-in-repo-addons-engines-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-in-repo-addons-engines-task-test.ts
@@ -25,7 +25,7 @@ describe('ember-in-repo-addons-engines-task', () => {
   it('can read task and output to console', async () => {
     const result = await new EmberInRepoAddonEnginesTask(
       pluginName,
-      getTaskContext({ path: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir })
     ).run();
     const taskResult = <EmberInRepoAddonEnginesTaskResult>result;
 
@@ -37,7 +37,7 @@ describe('ember-in-repo-addons-engines-task', () => {
   it('can read task as JSON', async () => {
     const result = await new EmberInRepoAddonEnginesTask(
       pluginName,
-      getTaskContext({ path: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir })
     ).run();
     const taskResult = <EmberInRepoAddonEnginesTaskResult>result;
 
@@ -47,7 +47,7 @@ describe('ember-in-repo-addons-engines-task', () => {
   it('can read task as report data', async () => {
     const result = await new EmberInRepoAddonEnginesTask(
       pluginName,
-      getTaskContext({ path: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir })
     ).run();
     const taskResult = <EmberInRepoAddonEnginesTaskResult>result;
 

--- a/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-types-task-test.ts
@@ -59,7 +59,7 @@ describe('types-task', () => {
 
     const result = await new EmberTypesTask(
       pluginName,
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
@@ -84,7 +84,7 @@ describe('types-task', () => {
 
     const result = await new EmberTypesTask(
       pluginName,
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
@@ -103,7 +103,7 @@ describe('types-task', () => {
 
     const result = await new EmberTypesTask(
       pluginName,
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
@@ -126,7 +126,7 @@ describe('types-task', () => {
 
     const result = await new EmberTypesTask(
       pluginName,
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
@@ -143,7 +143,7 @@ describe('types-task', () => {
 
     const result = await new EmberTypesTask(
       pluginName,
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 
@@ -166,7 +166,7 @@ describe('types-task', () => {
 
     const result = await new EmberTypesTask(
       pluginName,
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const typesTaskResult = <EmberTypesTaskResult>result;
 

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -23,7 +23,7 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
 
   async run(): Promise<TaskResult> {
     let result: EmberDependenciesTaskResult = new EmberDependenciesTaskResult(this.meta);
-    let packageJson = getPackageJson(this.context.cliArguments.path);
+    let packageJson = getPackageJson(this.context.cliFlags.cwd);
 
     let coreLibraries: Record<string, string> = {
       'ember-source': findDependency(packageJson, 'ember-source'),

--- a/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
@@ -37,7 +37,7 @@ export default class EmberInRepoAddonsEnginesTask extends FileSearcherTask imple
     let packageJsonPaths: string[] = searchResults[0].data as string[];
 
     packageJsonPaths.forEach((pathName: string) => {
-      let packageJson: PackageJson = getPackageJson(this.context.cliArguments.path, pathName);
+      let packageJson: PackageJson = getPackageJson(this.context.cliFlags.cwd, pathName);
 
       if (packageJson.keywords?.includes('ember-engine') && packageJson.name) {
         result.inRepoEngines.push(packageJson.name);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,9 +9,15 @@ A CLI that provides health check information about your project.
 [![License](https://img.shields.io/npm/l/@checkup/cli.svg)](https://github.com/checkupjs/checkup/blob/master/package.json)
 
 - [@checkup/cli](#checkupcli)
-  - [Usage](#usage)
-  - [Configuration](#configuration)
-  - [Commands](#commands)
+- [Usage](#usage)
+- [Checkup Command (alias `checkup run`)](#checkup-command-alias-checkup-run)
+  - [`checkup PATH`](#checkup-path)
+- [Generate Command](#generate-command)
+  - [`checkup generate plugin PLUGIN_NAME PATH`](#checkup-generate-plugin-pluginname-path)
+  - [`checkup generate task TASK_NAME PATH`](#checkup-generate-task-taskname-path)
+- [Configuration](#configuration)
+  - [Plugins](#plugins)
+  - [Tasks](#tasks)
 
 # Usage
 
@@ -49,13 +55,14 @@ USAGE
   $ checkup PATH
 
 ARGUMENTS
-  PATH  [default: .] The path referring to the root directory that Checkup will run in
+  PATHS    The paths that checkup will operate on. If no paths are provided, checkup will run on the entire directory beginning at --cwd
 
 OPTIONS
   -c, --config=config                      Use this configuration, overriding .checkuprc.* if present
   -f, --force
   -h, --help                               show CLI help
   -o, --reportOutputPath=reportOutputPath  [default: .]
+  -d, --cwd=cwd  [default: .]              [defaultL .] The path referring to the root directory that Checkup will run in
   -r, --reporter=stdout|json|pdf           [default: stdout]
   -s, --silent
   -t, --task=task

--- a/packages/cli/__tests__/commands/run-error-test.ts
+++ b/packages/cli/__tests__/commands/run-error-test.ts
@@ -8,7 +8,9 @@ describe('@checkup/cli', () => {
       const project = new CheckupProject('checkup-project', '0.0.0');
       project.writeSync();
 
-      await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
+      await expect(
+        runCommand(['run', '--cwd', project.baseDir])
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Could not find a checkup configuration starting from the given path: ${project.baseDir}. See https://github.com/checkupjs/checkup/tree/master/packages/cli#configuration for more info on how to setup a configuration."`
       );
 
@@ -22,7 +24,9 @@ describe('@checkup/cli', () => {
       });
       project.writeSync();
 
-      await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingInlineSnapshot(
+      await expect(
+        runCommand(['run', '--cwd', project.baseDir])
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Cannot find module 'checkup-plugin-unknown' from '${project.baseDir}'"`
       );
 
@@ -36,7 +40,9 @@ describe('@checkup/cli', () => {
       } as unknown) as CheckupConfig);
       project.writeSync();
 
-      await expect(runCommand(['run', project.baseDir])).rejects.toThrowErrorMatchingSnapshot();
+      await expect(
+        runCommand(['run', '--cwd', project.baseDir])
+      ).rejects.toThrowErrorMatchingSnapshot();
 
       project.dispose();
     });

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -33,7 +33,7 @@ describe('@checkup/cli', () => {
     it(
       'should output checkup result',
       async () => {
-        await runCommand(['run', project.baseDir]);
+        await runCommand(['run', '--cwd', project.baseDir]);
 
         expect(stdout()).toMatchSnapshot();
       },
@@ -41,7 +41,7 @@ describe('@checkup/cli', () => {
     );
 
     it('should output checkup result in JSON', async () => {
-      await runCommand(['run', '--reporter', 'json', project.baseDir]);
+      await runCommand(['run', '--reporter', 'json', '--cwd', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -49,7 +49,7 @@ describe('@checkup/cli', () => {
     it(
       'should output an html file in the current directory if the html reporter option is provided',
       async () => {
-        await runCommand(['run', '--reporter', 'html', project.baseDir]);
+        await runCommand(['run', '--reporter', 'html', '--cwd', project.baseDir]);
 
         let outputPath = stdout().trim();
 
@@ -68,7 +68,15 @@ describe('@checkup/cli', () => {
       async () => {
         let tmp = createTmpDir();
 
-        await runCommand(['run', '--reporter', 'html', `--reportOutputPath`, tmp, project.baseDir]);
+        await runCommand([
+          'run',
+          '--reporter',
+          'html',
+          `--reportOutputPath`,
+          tmp,
+          '--cwd',
+          project.baseDir,
+        ]);
 
         let outputPath = stdout().trim();
 
@@ -83,7 +91,7 @@ describe('@checkup/cli', () => {
     );
 
     it('should run a single task if the task option is specified', async () => {
-      await runCommand(['run', '--task', 'project', project.baseDir]);
+      await runCommand(['run', '--task', 'project', '--cwd', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });
@@ -98,6 +106,7 @@ describe('@checkup/cli', () => {
         'run',
         '--config',
         path.join(anotherProject.baseDir, '.checkuprc'),
+        '--cwd',
         project.baseDir,
       ]);
 

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -66,7 +66,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const taskResult = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const taskResult = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
 
     taskResult.toConsole();
 
@@ -74,7 +74,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const taskResult = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const taskResult = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
 
     expect(taskResult.toJson()).toMatchSnapshot();
   });
@@ -162,7 +162,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -171,7 +171,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -260,7 +260,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -269,7 +269,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -358,7 +358,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -367,7 +367,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -456,7 +456,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     taskResult.toConsole();
@@ -465,7 +465,7 @@ describe('my-foo-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyFooTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyFooTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();
@@ -540,7 +540,7 @@ describe('my-bar-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const result = await new MyBarTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyBarTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyBarTaskResult>result;
 
     taskResult.toConsole();
@@ -549,7 +549,7 @@ describe('my-bar-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new MyBarTask(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new MyBarTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <MyBarTaskResult>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();

--- a/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/checkup-meta-task-test.ts
@@ -40,7 +40,7 @@ describe('checkup-meta-task', () => {
 
       const result = await new CheckupMetaTask(
         'meta',
-        getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
+        getTaskContext({}, { cwd: checkupProject.baseDir }, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
@@ -59,7 +59,7 @@ describe('checkup-meta-task', () => {
 
       const result = await new CheckupMetaTask(
         'meta',
-        getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
+        getTaskContext({}, { cwd: checkupProject.baseDir }, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
@@ -81,7 +81,7 @@ describe('checkup-meta-task', () => {
 
       const result = await new CheckupMetaTask(
         'meta',
-        getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
+        getTaskContext({}, { cwd: checkupProject.baseDir }, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 
@@ -103,7 +103,7 @@ describe('checkup-meta-task', () => {
 
       const result = await new CheckupMetaTask(
         'meta',
-        getTaskContext({ path: checkupProject.baseDir }, {}, checkupConfig)
+        getTaskContext({}, { cwd: checkupProject.baseDir }, checkupConfig)
       ).run();
       const taskResult = <CheckupMetaTaskResult>result;
 

--- a/packages/cli/__tests__/tasks/outdated-dependencies-task-test.ts
+++ b/packages/cli/__tests__/tasks/outdated-dependencies-task-test.ts
@@ -23,7 +23,7 @@ describe('outdated-dependencies-task', () => {
   it('detects outdated dependencies and output to console', async () => {
     const result = await new OutdatedDependenciesTask(
       'meta',
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const taskResult = <OutdatedDependenciesTaskResult>result;
 
@@ -35,7 +35,7 @@ describe('outdated-dependencies-task', () => {
   it('detects outdated dependencies as JSON', async () => {
     const result = await new OutdatedDependenciesTask(
       'meta',
-      getTaskContext({ path: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir })
     ).run();
     const taskResult = <OutdatedDependenciesTaskResult>result;
 

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -22,7 +22,7 @@ describe('project-meta-task', () => {
     it('can read project info and output to console', async () => {
       const result = await new ProjectMetaTask(
         'meta',
-        getTaskContext({ path: checkupProject.baseDir })
+        getTaskContext({}, { cwd: checkupProject.baseDir })
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
 
@@ -41,7 +41,7 @@ describe('project-meta-task', () => {
     it('can read project info as JSON', async () => {
       const result = await new ProjectMetaTask(
         'meta',
-        getTaskContext({ path: checkupProject.baseDir })
+        getTaskContext({}, { cwd: checkupProject.baseDir })
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -33,14 +33,18 @@ export default class RunCommand extends Command {
 
   static args = [
     {
-      name: 'path',
-      required: true,
-      description: 'The path referring to the root directory that Checkup will run in',
-      default: '.',
+      name: 'paths',
+      description:
+        'The paths that checkup will operate on. If no paths are provided, checkup will run on the entire directory beginning at --cwd',
     },
   ];
 
   static flags = {
+    cwd: flags.string({
+      default: '.',
+      char: 'd',
+      description: 'The path referring to the root directory that Checkup will run in',
+    }),
     version: flags.version({ char: 'v' }),
     help: flags.help({ char: 'h' }),
     force: flags.boolean({ char: 'f' }),
@@ -126,12 +130,12 @@ export default class RunCommand extends Command {
     try {
       const configLoader = this.runArgs.config
         ? getFilepathLoader(this.runArgs.config)
-        : getSearchLoader(this.runArgs.path);
+        : getSearchLoader(this.runFlags.cwd);
       const configService = await CheckupConfigService.load(configLoader);
 
       this.checkupConfig = configService.get();
 
-      let plugins = await loadPlugins(this.checkupConfig.plugins, this.runArgs.path);
+      let plugins = await loadPlugins(this.checkupConfig.plugins, this.runFlags.cwd);
 
       this.config.plugins.push(...plugins);
     } catch (error) {
@@ -141,11 +145,11 @@ export default class RunCommand extends Command {
 
   private validatePackageJson() {
     try {
-      getPackageJson(this.runArgs.path);
+      getPackageJson(this.runFlags.cwd);
     } catch (error) {
       this.error(
         `The ${path.resolve(
-          this.runArgs.path
+          this.runFlags.cwd
         )} directory found through the 'path' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`,
         error
       );

--- a/packages/cli/src/tasks/outdated-dependencies-task.ts
+++ b/packages/cli/src/tasks/outdated-dependencies-task.ts
@@ -69,8 +69,8 @@ export default class OutdatedDependenciesTask extends BaseTask implements Task {
   async run(): Promise<TaskResult> {
     let result: OutdatedDependenciesTaskResult = new OutdatedDependenciesTaskResult(this.meta);
 
-    result.outdatedDependencies = await getOutdated(this.context.cliArguments.path);
-    result.totalDependencies = getTotalDependencies(this.context.cliArguments.path);
+    result.outdatedDependencies = await getOutdated(this.context.cliFlags.cwd);
+    result.totalDependencies = getTotalDependencies(this.context.cliFlags.cwd);
 
     return result;
   }

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -12,11 +12,11 @@ export default class ProjectMetaTask extends BaseTask implements MetaTask {
 
   async run(): Promise<MetaTaskResult> {
     let result: ProjectMetaTaskResult = new ProjectMetaTaskResult(this.meta);
-    let package_ = getPackageJson(this.context.cliArguments.path);
+    let package_ = getPackageJson(this.context.cliFlags.cwd);
 
     result.name = package_.name || '';
     result.version = package_.version || '';
-    result.repository = await getRepositoryInfo(this.context.cliArguments.path);
+    result.repository = await getRepositoryInfo(this.context.cliFlags.cwd);
 
     return result;
   }

--- a/packages/cli/templates/src/task/__tests__/task.js.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.js.ejs
@@ -23,7 +23,7 @@ describe('<%- name %>-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const taskResult = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const taskResult = await new <%- taskClass %>(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
 
     taskResult.toConsole();
 
@@ -31,7 +31,7 @@ describe('<%- name %>-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const taskResult = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const taskResult = await new <%- taskClass %>(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
 
     expect(taskResult.toJson()).toMatchSnapshot();
   });

--- a/packages/cli/templates/src/task/__tests__/task.ts.ejs
+++ b/packages/cli/templates/src/task/__tests__/task.ts.ejs
@@ -23,7 +23,7 @@ describe('<%- name %>-task', () => {
   });
 
   it('can read task and output to console', async () => {
-    const result = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new <%- taskClass %>(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <<%- resultClass %>>result;
 
     taskResult.toConsole();
@@ -32,7 +32,7 @@ describe('<%- name %>-task', () => {
   });
 
   it('can read task as JSON', async () => {
-    const result = await new <%- taskClass %>(pluginName, getTaskContext({ path: project.baseDir })).run();
+    const result = await new <%- taskClass %>(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
     const taskResult = <<%- resultClass %>>result;
 
     expect(taskResult.toJson()).toMatchSnapshot();

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -10,6 +10,7 @@ const DEFAULT_FLAGS = {
   silent: false,
   reporter: 'stdout',
   reportOutputPath: '.',
+  cwd: '.',
   task: undefined,
   config: undefined,
 };

--- a/packages/core/src/file-searcher-task.ts
+++ b/packages/core/src/file-searcher-task.ts
@@ -22,6 +22,6 @@ export default abstract class FileSearcherTask extends BaseTask {
   constructor(pluginName: string, context: TaskContext, searchPatterns: SearchPatterns) {
     super(pluginName, context);
 
-    this.searcher = new FileSearcher(context.cliArguments.path, searchPatterns);
+    this.searcher = new FileSearcher(context.cliFlags.cwd, searchPatterns);
   }
 }

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -9,6 +9,7 @@ export type RunFlags = {
   silent: boolean;
   reporter: string;
   reportOutputPath: string;
+  cwd: string;
   task: string | undefined;
   config: string | undefined;
 };

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -7,6 +7,7 @@ const DEFAULT_FLAGS = {
   silent: false,
   reporter: 'stdout',
   reportOutputPath: '.',
+  cwd: '.',
   task: undefined,
   config: undefined,
 };


### PR DESCRIPTION
As discussed in [this issue](https://github.com/checkupjs/checkup/issues/400), we are going to be using `--cwd` as an optional flag (defaulting to `'.'`) to pass in the root directory, so the paths command line args can represent paths/globs for checkup to operate on. This PR just moves the paths arg to `--cwd`