### PR TITLE
Standardize flags

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,15 +58,13 @@ ARGUMENTS
   PATHS    The paths that checkup will operate on. If no paths are provided, checkup will run on the entire directory beginning at --cwd
 
 OPTIONS
-  -c, --config=config                      Use this configuration, overriding .checkuprc.* if present
-  -f, --force
   -h, --help                               show CLI help
-  -o, --reportOutputPath=reportOutputPath  [default: .]
-  -d, --cwd=cwd  [default: .]              [defaultL .] The path referring to the root directory that Checkup will run in
-  -r, --reporter=stdout|json|pdf           [default: stdout]
-  -s, --silent
-  -t, --task=task
   -v, --version                            show CLI version
+  -c, --config=config                      Use this configuration, overriding .checkuprc.* if present
+  -d, --cwd=cwd  [default: .]              [default: .] The path referring to the root directory that Checkup will run in
+  -t, --task=task
+  -f, --format=stdout|json|html            [default: stdout]
+  -o, --outputFile=outputFile              [default: .]
 ```
 
 _See code: [src/commands/run.ts](https://github.com/checkupjs/checkup/blob/v0.0.0/src/commands/run.ts)_

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import { CheckupProject, createTmpDir, stdout } from '@checkup/test-helpers';
 
+import { join } from 'path';
 import { runCommand } from '../__utils__/run-command';
 
 const TEST_TIMEOUT = 100000;
@@ -41,20 +42,20 @@ describe('@checkup/cli', () => {
     );
 
     it('should output checkup result in JSON', async () => {
-      await runCommand(['run', '--reporter', 'json', '--cwd', project.baseDir]);
+      await runCommand(['run', '--format', 'json', '--cwd', project.baseDir]);
 
       expect(stdout()).toMatchSnapshot();
     });
 
     it(
-      'should output an html file in the current directory if the html reporter option is provided',
+      'should output an html file in the current directory if the html format option is provided',
       async () => {
-        await runCommand(['run', '--reporter', 'html', '--cwd', project.baseDir]);
+        await runCommand(['run', '--format', 'html', '--cwd', project.baseDir]);
 
         let outputPath = stdout().trim();
 
         expect(outputPath).toMatch(
-          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.html/
+          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})_(\d{2})_(\d{2})\.html/
         );
         expect(fs.existsSync(outputPath)).toEqual(true);
 
@@ -64,25 +65,23 @@ describe('@checkup/cli', () => {
     );
 
     it(
-      'should output an html file in a custom directory if the html reporter and reporterOutputPath options are provided',
+      'should output an html file in a custom directory if the html format and outputFile options are provided',
       async () => {
         let tmp = createTmpDir();
 
         await runCommand([
           'run',
-          '--reporter',
+          '--format',
           'html',
-          `--reportOutputPath`,
-          tmp,
+          `--outputFile`,
+          join(tmp, 'my-checkup-file.html'),
           '--cwd',
           project.baseDir,
         ]);
 
         let outputPath = stdout().trim();
 
-        expect(outputPath).toMatch(
-          /^(.*)\/checkup-report-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.html/
-        );
+        expect(outputPath).toMatch(/^(.*)\/my-checkup-file.html/);
         expect(fs.existsSync(outputPath)).toEqual(true);
 
         fs.unlinkSync(outputPath);

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -1,10 +1,16 @@
-import { Category, Priority, TaskResult } from '@checkup/core';
+import { Category, OutputFormat, Priority, TaskResult } from '@checkup/core';
+import {
+  DEFAULT_OUTPUT_FILENAME,
+  _transformHTMLResults,
+  _transformJsonResults,
+  getOutputPath,
+} from '../src/reporters';
 
 import { MetaTaskResult } from '../src/types';
 import MockMetaTaskResult from './__utils__/mock-meta-task-result';
-import MockTaskResult from './__utils__/mock-task-result';
 import MockPieChartTaskResult from './__utils__/mock-pie-chart-task-result';
-import { _transformJsonResults, _transformHTMLResults } from '../src/reporters';
+import MockTaskResult from './__utils__/mock-task-result';
+import { join } from 'path';
 
 let metaTaskResults: MetaTaskResult[];
 let pluginTaskResults: TaskResult[];
@@ -253,5 +259,37 @@ describe('_transformHTMLResults', () => {
     ]);
 
     expect(transformed).toMatchSnapshot();
+  });
+});
+
+describe('getOutputPath', () => {
+  it('throws if output format is stdout', () => {
+    expect(() => {
+      getOutputPath(OutputFormat.stdout, '');
+    }).toThrow('The `stdout` format cannot be used to generate an output file path');
+  });
+
+  [OutputFormat.json, OutputFormat.html].forEach((format) => {
+    it(`returns same path when absolute path provided for ${format}`, () => {
+      expect(getOutputPath(format, `/some-file.${format}`)).toEqual(`/some-file.${format}`);
+    });
+
+    it(`returns resolved path when path provided for ${format}`, () => {
+      expect(getOutputPath(format, `some-file.${format}`, __dirname)).toEqual(
+        join(__dirname, `some-file.${format}`)
+      );
+    });
+
+    it(`returns default file format if no outputFile provided for ${format}`, () => {
+      expect(getOutputPath(format, '', __dirname)).toEqual(
+        join(__dirname, `${DEFAULT_OUTPUT_FILENAME}.${format}`)
+      );
+    });
+
+    it(`returns default output path format if {default} token provided for ${format}`, () => {
+      expect(getOutputPath(format, `{default}.${format}`, __dirname)).toEqual(
+        join(__dirname, `${DEFAULT_OUTPUT_FILENAME}.${format}`)
+      );
+    });
   });
 });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import {
   CheckupConfig,
   CheckupConfigService,
-  ReporterType,
+  OutputFormat,
   RunArgs,
   RunFlags,
   TaskContext,
@@ -24,8 +24,8 @@ import { MetaTaskResult } from '../types';
 import OutdatedDependenciesTask from '../tasks/outdated-dependencies-task';
 import ProjectMetaTask from '../tasks/project-meta-task';
 import TaskList from '../task-list';
-import { getReporter } from '../reporters';
 import TodosTask from '../tasks/todos-task';
+import { getReporter } from '../reporters';
 
 export default class RunCommand extends Command {
   static description = 'Provides health check information about your project';
@@ -41,28 +41,29 @@ export default class RunCommand extends Command {
   ];
 
   static flags = {
+    version: flags.version({ char: 'v' }),
+    help: flags.help({ char: 'h' }),
+    config: flags.string({
+      char: 'c',
+      description: 'Use this configuration, overriding .checkuprc.* if present',
+    }),
     cwd: flags.string({
       default: '.',
       char: 'd',
       description: 'The path referring to the root directory that Checkup will run in',
     }),
-    version: flags.version({ char: 'v' }),
-    help: flags.help({ char: 'h' }),
-    force: flags.boolean({ char: 'f' }),
-    silent: flags.boolean({ char: 's' }),
-    reporter: flags.string({
-      char: 'r',
-      options: [...Object.values(ReporterType)],
-      default: 'stdout',
-    }),
-    reportOutputPath: flags.string({
-      char: 'o',
-      default: '.',
-    }),
+
     task: flags.string({ char: 't' }),
-    config: flags.string({
-      char: 'c',
-      description: 'Use this configuration, overriding .checkuprc.* if present',
+    format: flags.string({
+      char: 'f',
+      options: [...Object.values(OutputFormat)],
+      default: 'stdout',
+      description: `The output format, one of ${[...Object.values(OutputFormat)].join(', ')}`,
+    }),
+    outputFile: flags.string({
+      char: 'o',
+      default: '',
+      description: 'Specify file to write report to',
     }),
   };
 

--- a/packages/cli/src/helpers/ui-report.ts
+++ b/packages/cli/src/helpers/ui-report.ts
@@ -2,10 +2,11 @@ import * as Handlebars from 'handlebars';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { readFileSync } from 'fs-extra';
 import { ReportComponentType, UIReportData } from '@checkup/core';
+
 import { pathToFileURL } from 'url';
 import { printToPDF } from './print-to-pdf';
+import { readFileSync } from 'fs-extra';
 
 import tmp = require('tmp');
 
@@ -19,17 +20,9 @@ export async function generateHTMLReport(
 ): Promise<string> {
   let reportHTML = generateHTML(resultsForPdf);
 
-  if (!fs.existsSync(resultOutputPath)) {
-    fs.mkdirSync(resultOutputPath, { recursive: true });
-  }
+  fs.writeFileSync(resultOutputPath, reportHTML);
 
-  let htmlPath = path.join(
-    resultOutputPath,
-    `checkup-report-${date.format(new Date(), 'YYYY-MM-DD-HH-mm-ss')}.html`
-  );
-  fs.writeFileSync(htmlPath, reportHTML);
-
-  return path.resolve(htmlPath);
+  return resultOutputPath;
 }
 
 export async function generatePDFReport(

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -6,13 +6,11 @@ import { getRegisteredParsers } from '../src/parsers/registered-parsers';
 const DEFAULT_FLAGS = {
   version: undefined,
   help: undefined,
-  force: false,
-  silent: false,
-  reporter: 'stdout',
-  reportOutputPath: '.',
+  config: undefined,
   cwd: '.',
   task: undefined,
-  config: undefined,
+  format: 'stdout',
+  outputFile: '',
 };
 
 const DEFAULT_CONFIG = {

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -5,11 +5,9 @@ export type RunArgs = {
 export type RunFlags = {
   version: void;
   help: void;
-  force: boolean;
-  silent: boolean;
-  reporter: string;
-  reportOutputPath: string;
+  config: string | undefined;
   cwd: string;
   task: string | undefined;
-  config: string | undefined;
+  format: string;
+  outputFile: string;
 };

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -102,7 +102,7 @@ export const enum Grade {
   F = 'F',
 }
 
-export enum ReporterType {
+export enum OutputFormat {
   stdout = 'stdout',
   json = 'json',
   html = 'html',

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -3,13 +3,11 @@ import { TaskContext, getRegisteredParsers } from '@checkup/core';
 const DEFAULT_FLAGS = {
   version: undefined,
   help: undefined,
-  force: false,
-  silent: false,
-  reporter: 'stdout',
-  reportOutputPath: '.',
+  config: undefined,
   cwd: '.',
   task: undefined,
-  config: undefined,
+  format: 'stdout',
+  outputFile: '',
 };
 
 const DEFAULT_CONFIG = {


### PR DESCRIPTION
This is primarily a flags cleanup PR. I've done the following:

1. Removed the `silent` option (for now, it wasn't working anyway!)
1. Removed the `force` option (wasn't used)
1. Renamed `reporter` to `format`
1. Renamed `reportOutputDir` to `outputFile`, and made it accept a file path instead

The main change is the last one, and I've added the ability to output both HTML and JSON. You can now do the following:

- `checkup -f <format>` - will output to stdout
- `checkup -f <format> -o '{default}.<format>' - will output using the default name format (example: `checkup-report-2020-05-18-14_56_19.<format>`)
- `checkup -f <format> -o my-file.<format>` - will output using the specified name to the `cwd`
- `checkup -f <format> -o /absolute/my-file.<format>` - will output using the absolute path