### PR TITLE
Adding pkg: PackageJson to the TaskContext and updating all tasks to use it

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-dependencies-task-test.ts
@@ -26,7 +26,7 @@ describe('dependencies-task', () => {
   it('detects Ember dependencies', async () => {
     const result = await new EmberDependenciesTask(
       pluginName,
-      getTaskContext({}, { cwd: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir }, {}, emberProject.pkg)
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
 
@@ -38,7 +38,7 @@ describe('dependencies-task', () => {
   it('detects Ember dependencies as JSON', async () => {
     const result = await new EmberDependenciesTask(
       pluginName,
-      getTaskContext({}, { cwd: emberProject.baseDir })
+      getTaskContext({}, { cwd: emberProject.baseDir }, {}, emberProject.pkg)
     ).run();
     const dependencyTaskResult = <EmberDependenciesTaskResult>result;
 

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -1,12 +1,4 @@
-import {
-  BaseTask,
-  Category,
-  Priority,
-  Task,
-  TaskResult,
-  getPackageJson,
-  toTaskData,
-} from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskResult, toTaskData } from '@checkup/core';
 
 import EmberDependenciesTaskResult from '../results/ember-dependencies-task-result';
 import { PackageJson } from 'type-fest';
@@ -23,7 +15,7 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
 
   async run(): Promise<TaskResult> {
     let result: EmberDependenciesTaskResult = new EmberDependenciesTaskResult(this.meta);
-    let packageJson = getPackageJson(this.context.cliFlags.cwd);
+    let packageJson = this.context.pkg;
 
     let coreLibraries: Record<string, string> = {
       'ember-source': findDependency(packageJson, 'ember-source'),

--- a/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
@@ -8,8 +8,10 @@ import {
   TaskContext,
 } from '@checkup/core';
 import EmberInRepoAddonEnginesTaskResult from '../results/ember-in-repo-addons-engines-task-result';
-import { getPackageJson } from '@checkup/core';
+
 import { PackageJson } from 'type-fest';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 
 export default class EmberInRepoAddonsEnginesTask extends FileSearcherTask implements Task {
   meta: TaskMetaData = {
@@ -47,4 +49,19 @@ export default class EmberInRepoAddonsEnginesTask extends FileSearcherTask imple
     });
     return result;
   }
+}
+
+function getPackageJson(basePath: string, pathName: string = 'package.json'): PackageJson {
+  let package_ = {};
+  let packageJsonPath = path.join(path.resolve(basePath), pathName);
+
+  try {
+    package_ = fs.readJsonSync(packageJsonPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error(`No package.json file detected at ${packageJsonPath}`);
+    }
+  }
+
+  return package_;
 }

--- a/packages/checkup-plugin-ember/src/utils/project.ts
+++ b/packages/checkup-plugin-ember/src/utils/project.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { ProjectType } from '../types';
-import { getPackageJson } from '@checkup/core';
+import { PackageJson } from 'type-fest';
 
 /**
  * Gets the current type of project, either App, Engine, or Addon
@@ -10,22 +10,16 @@ import { getPackageJson } from '@checkup/core';
  * @returns {ProjectType}
  * @param basePath
  */
-export function getProjectType(basePath: string): ProjectType {
-  let package_ = getPackageJson(basePath);
-
-  if (
-    package_.keywords &&
-    Array.isArray(package_.keywords) &&
-    package_.keywords.includes('ember-addon')
-  ) {
+export function getProjectType(pkg: PackageJson): ProjectType {
+  if (pkg.keywords && Array.isArray(pkg.keywords) && pkg.keywords.includes('ember-addon')) {
     if (fs.existsSync(path.join(process.cwd(), 'addon', 'engine.js'))) {
       return ProjectType.Engine;
     } else {
       return ProjectType.Addon;
     }
   } else if (
-    (package_.dependencies && Object.keys(package_.dependencies).includes('ember-cli')) ||
-    (package_.devDependencies && Object.keys(package_.devDependencies).includes('ember-cli'))
+    (pkg.dependencies && Object.keys(pkg.dependencies).includes('ember-cli')) ||
+    (pkg.devDependencies && Object.keys(pkg.devDependencies).includes('ember-cli'))
   ) {
     return ProjectType.App;
   }

--- a/packages/cli/__tests__/tasks/outdated-dependencies-task-test.ts
+++ b/packages/cli/__tests__/tasks/outdated-dependencies-task-test.ts
@@ -23,7 +23,7 @@ describe('outdated-dependencies-task', () => {
   it('detects outdated dependencies and output to console', async () => {
     const result = await new OutdatedDependenciesTask(
       'meta',
-      getTaskContext({}, { cwd: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir }, {}, project.pkg)
     ).run();
     const taskResult = <OutdatedDependenciesTaskResult>result;
 
@@ -35,7 +35,7 @@ describe('outdated-dependencies-task', () => {
   it('detects outdated dependencies as JSON', async () => {
     const result = await new OutdatedDependenciesTask(
       'meta',
-      getTaskContext({}, { cwd: project.baseDir })
+      getTaskContext({}, { cwd: project.baseDir }, {}, project.pkg)
     ).run();
     const taskResult = <OutdatedDependenciesTaskResult>result;
 

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -22,7 +22,7 @@ describe('project-meta-task', () => {
     it('can read project info and output to console', async () => {
       const result = await new ProjectMetaTask(
         'meta',
-        getTaskContext({}, { cwd: checkupProject.baseDir })
+        getTaskContext({}, { cwd: checkupProject.baseDir }, {}, checkupProject.pkg)
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
 
@@ -41,7 +41,7 @@ describe('project-meta-task', () => {
     it('can read project info as JSON', async () => {
       const result = await new ProjectMetaTask(
         'meta',
-        getTaskContext({}, { cwd: checkupProject.baseDir })
+        getTaskContext({}, { cwd: checkupProject.baseDir }, {}, checkupProject.pkg)
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import {
   CheckupConfig,
   CheckupConfigService,
@@ -9,7 +7,6 @@ import {
   TaskContext,
   TaskResult,
   getFilepathLoader,
-  getPackageJson,
   getRegisteredParsers,
   getSearchLoader,
   loadPlugins,
@@ -26,6 +23,7 @@ import ProjectMetaTask from '../tasks/project-meta-task';
 import TaskList from '../task-list';
 import TodosTask from '../tasks/todos-task';
 import { getReporter } from '../reporters';
+import { getPackageJson } from '../helpers/get-package-json';
 
 export default class RunCommand extends Command {
   static description = 'Provides health check information about your project';
@@ -87,8 +85,6 @@ export default class RunCommand extends Command {
 
     await this.loadConfig();
 
-    this.validatePackageJson();
-
     await this.registerTasks();
     await this.runTasks();
     await this.report();
@@ -147,19 +143,6 @@ export default class RunCommand extends Command {
     }
   }
 
-  private validatePackageJson() {
-    try {
-      getPackageJson(this.runFlags.cwd);
-    } catch (error) {
-      this.error(
-        `The ${path.resolve(
-          this.runFlags.cwd
-        )} directory found through the 'path' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`,
-        error
-      );
-    }
-  }
-
   private async registerTasks() {
     let taskContext: TaskContext;
 
@@ -172,6 +155,7 @@ export default class RunCommand extends Command {
       cliFlags: this.runFlags,
       parsers: getRegisteredParsers(),
       config: this.checkupConfig,
+      pkg: getPackageJson(this.runFlags.cwd),
     });
 
     await this.registerDefaultTasks(taskContext);

--- a/packages/cli/src/helpers/get-package-json.ts
+++ b/packages/cli/src/helpers/get-package-json.ts
@@ -14,7 +14,11 @@ export function getPackageJson(basePath: string, pathName: string = 'package.jso
     package_ = fs.readJsonSync(packageJsonPath);
   } catch (error) {
     if (error.code === 'ENOENT') {
-      throw new Error(`No package.json file detected at ${packageJsonPath}`);
+      throw new Error(
+        `The ${path.resolve(
+          basePath
+        )} directory found through the 'path' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`
+      );
     }
   }
 

--- a/packages/cli/src/tasks/outdated-dependencies-task.ts
+++ b/packages/cli/src/tasks/outdated-dependencies-task.ts
@@ -1,16 +1,9 @@
 import * as npmCheck from 'npm-check';
 
-import {
-  BaseTask,
-  Category,
-  Priority,
-  Task,
-  TaskMetaData,
-  TaskResult,
-  getPackageJson,
-} from '@checkup/core';
+import { BaseTask, Category, Priority, Task, TaskMetaData, TaskResult } from '@checkup/core';
 
 import OutdatedDependenciesTaskResult from '../results/outdated-dependencies-task-result';
+import { PackageJson } from 'type-fest';
 
 export type OutdatedDependency = {
   moduleName: string;
@@ -47,9 +40,7 @@ async function getOutdated(path: string): Promise<OutdatedDependency[]> {
   return packages;
 }
 
-function getTotalDependencies(path: string) {
-  let packageJson = getPackageJson(path);
-
+function getTotalDependencies(packageJson: PackageJson) {
   return (
     Object.keys(packageJson.dependencies ?? {}).length +
     Object.keys(packageJson.devDependencies ?? {}).length
@@ -70,7 +61,7 @@ export default class OutdatedDependenciesTask extends BaseTask implements Task {
     let result: OutdatedDependenciesTaskResult = new OutdatedDependenciesTaskResult(this.meta);
 
     result.outdatedDependencies = await getOutdated(this.context.cliFlags.cwd);
-    result.totalDependencies = getTotalDependencies(this.context.cliFlags.cwd);
+    result.totalDependencies = getTotalDependencies(this.context.pkg);
 
     return result;
   }

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -1,4 +1,4 @@
-import { BaseTask, TaskIdentifier, getPackageJson } from '@checkup/core';
+import { BaseTask, TaskIdentifier } from '@checkup/core';
 import { MetaTask, MetaTaskResult } from '../types';
 
 import ProjectMetaTaskResult from '../results/project-meta-task-result';
@@ -12,7 +12,7 @@ export default class ProjectMetaTask extends BaseTask implements MetaTask {
 
   async run(): Promise<MetaTaskResult> {
     let result: ProjectMetaTaskResult = new ProjectMetaTaskResult(this.meta);
-    let package_ = getPackageJson(this.context.cliFlags.cwd);
+    let package_ = this.context.pkg;
 
     result.name = package_.name || '';
     result.version = package_.version || '';

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -1,22 +1,7 @@
 import { Category, Priority, TaskContext } from '../src/types/tasks';
+import { getTaskContext } from '@checkup/test-helpers';
 
 import BaseTask from '../src/base-task';
-import { getRegisteredParsers } from '../src/parsers/registered-parsers';
-
-const DEFAULT_FLAGS = {
-  version: undefined,
-  help: undefined,
-  config: undefined,
-  cwd: '.',
-  task: undefined,
-  format: 'stdout',
-  outputFile: '',
-};
-
-const DEFAULT_CONFIG = {
-  plugins: [],
-  tasks: {},
-};
 
 class FakeTask extends BaseTask {
   meta = {
@@ -31,12 +16,7 @@ class FakeTask extends BaseTask {
 
 describe('BaseTask', () => {
   it('creates a task with correct defaults set', () => {
-    let context: TaskContext = {
-      cliArguments: {},
-      cliFlags: DEFAULT_FLAGS,
-      parsers: getRegisteredParsers(),
-      config: DEFAULT_CONFIG,
-    };
+    let context: TaskContext = getTaskContext();
 
     let fakeTask = new FakeTask('fake', context);
 
@@ -46,17 +26,16 @@ describe('BaseTask', () => {
   });
 
   it('creates a disabled task if config is set to "off"', () => {
-    let context: TaskContext = {
-      cliArguments: {},
-      cliFlags: DEFAULT_FLAGS,
-      parsers: getRegisteredParsers(),
-      config: {
+    let context: TaskContext = getTaskContext(
+      {},
+      {},
+      {
         plugins: [],
         tasks: {
           'fake/my-fake': 'off',
         },
-      },
-    };
+      }
+    );
 
     let fakeTask = new FakeTask('fake', context);
 
@@ -64,17 +43,16 @@ describe('BaseTask', () => {
   });
 
   it('creates a task with custom config values', () => {
-    let context: TaskContext = {
-      cliArguments: {},
-      cliFlags: DEFAULT_FLAGS,
-      parsers: getRegisteredParsers(),
-      config: {
+    let context: TaskContext = getTaskContext(
+      {},
+      {},
+      {
         plugins: [],
         tasks: {
           'fake/my-fake': ['on', { 'my-fake-option': true }],
         },
-      },
-    };
+      }
+    );
 
     let fakeTask = new FakeTask('fake', context);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,6 @@ export { default as CosmiconfigService } from './configuration/cosmiconfig-servi
 export { default as getInitializationConfigLoader } from './configuration/loaders/get-initialization-loader';
 
 export { getPluginName, normalizePackageName, getShorthandName } from './utils/plugin-name';
-export { getPackageJson } from './utils/get-package-json';
 export { exec } from './utils/exec';
 export { ui } from './utils/ui';
 export { toPairs, toTaskData, toTaskItemData, toPercent } from './utils/data-transformers';

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -2,7 +2,7 @@ import { CreateParser, Parser, ParserName, ParserOptions, ParserReport } from '.
 import { RunArgs, RunFlags } from './cli';
 
 import { CheckupConfig } from './configuration';
-import { JsonObject } from 'type-fest';
+import { JsonObject, PackageJson } from 'type-fest';
 import NumericalCardData from '../report-components/numerical-card-data';
 import PieChartData from '../report-components/pie-chart-data';
 import TableData from '../report-components/table-data';
@@ -28,6 +28,7 @@ export interface TaskContext {
   readonly cliFlags: RunFlags;
   readonly parsers: Map<ParserName, CreateParser<ParserOptions, Parser<ParserReport>>>;
   readonly config: CheckupConfig;
+  readonly pkg: PackageJson;
 }
 
 export interface TaskResult {

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -1,4 +1,5 @@
 import { TaskContext, getRegisteredParsers } from '@checkup/core';
+import { PackageJson } from 'type-fest';
 
 const DEFAULT_FLAGS = {
   version: undefined,
@@ -15,15 +16,23 @@ const DEFAULT_CONFIG = {
   tasks: {},
 };
 
+const DEFAULT_PACKAGE_JSON = {
+  name: 'foo-project',
+  version: '0.0.0',
+  keywords: [],
+};
+
 export function getTaskContext(
   cliArguments: {} = {},
   cliFlags: {} = DEFAULT_FLAGS,
-  config: {} = DEFAULT_CONFIG
+  config: {} = DEFAULT_CONFIG,
+  pkg: PackageJson = DEFAULT_PACKAGE_JSON
 ): TaskContext {
   return {
     cliArguments,
     cliFlags: Object.assign({}, DEFAULT_FLAGS, cliFlags),
     parsers: getRegisteredParsers(),
     config: Object.assign({}, DEFAULT_CONFIG, config),
+    pkg: pkg,
   };
 }


### PR DESCRIPTION
This is a part of https://github.com/checkupjs/checkup/issues/400.
Also removing getPackageJson from core, so it isnt made available to the plugins, as they shouldnt need to use it.

The one task that is still implemented questionably is `ember-in-repo-addons-engines-task` - it reads all package.jsons in a repo, I think it should likely still just operate from root, and traverse and find all package.jsons, but I will revisit that implementation when I add in support for the globs