### PR TITLE
(bug fix) Restricting file types for LOC class

### DIFF
--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -12,11 +12,9 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-hbs              1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+hbs         1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config da25c78e31bb71ef06c3641e8846f64e
@@ -38,11 +36,9 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-js               1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+js          1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config da25c78e31bb71ef06c3641e8846f64e
@@ -69,12 +65,10 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-hbs              1           0    
-js               1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+hbs         1           0    
+js          1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -174,21 +168,6 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
         \\"fileResults\\": [
           {
             \\"results\\": {
-              \\"total\\": 0,
-              \\"todo\\": 0,
-              \\"block\\": 0,
-              \\"blockEmpty\\": 0,
-              \\"comment\\": 0,
-              \\"empty\\": 0,
-              \\"mixed\\": 0,
-              \\"single\\": 0,
-              \\"source\\": 0
-            },
-            \\"fileExension\\": \\"checkuprc\\",
-            \\"errors\\": []
-          },
-          {
-            \\"results\\": {
               \\"total\\": 1,
               \\"todo\\": 0,
               \\"block\\": 0,
@@ -215,21 +194,6 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
               \\"source\\": 1
             },
             \\"fileExension\\": \\"js\\",
-            \\"errors\\": []
-          },
-          {
-            \\"results\\": {
-              \\"total\\": 0,
-              \\"todo\\": 0,
-              \\"block\\": 0,
-              \\"blockEmpty\\": 0,
-              \\"comment\\": 0,
-              \\"empty\\": 0,
-              \\"mixed\\": 0,
-              \\"single\\": 0,
-              \\"source\\": 0
-            },
-            \\"fileExension\\": \\"bin/loose-envify\\",
             \\"errors\\": []
           },
           {
@@ -301,12 +265,10 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-js               3           2    
-hbs              2           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+js          3           2    
+hbs         2           0    
+json        175         N/A  
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -333,12 +295,10 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-hbs              1           0    
-js               1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+hbs         1           0    
+js          1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -363,10 +323,8 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+json        175         N/A  
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -391,11 +349,9 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-js               1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+js          1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -415,11 +371,9 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-js               1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+js          1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config da25c78e31bb71ef06c3641e8846f64e
@@ -441,12 +395,10 @@ eslint-disable Usages Found: 0
 
 === Lines of Code ===
 
-File type        Total       TODO 
-checkuprc        0           0    
-hbs              1           0    
-js               1           0    
-bin/loose-envify 0           0    
-json             175         N/A  
+File type   Total       TODO 
+hbs         1           0    
+js          1           0    
+json        175         N/A  
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976

--- a/packages/cli/__tests__/tasks/lines-of-code-task-test.ts
+++ b/packages/cli/__tests__/tasks/lines-of-code-task-test.ts
@@ -8,6 +8,7 @@ describe('lines-of-code-task', () => {
 
   beforeEach(function () {
     project = new CheckupProject('foo', '0.0.0');
+    project.files['index.whatever'] = 'whatever';
     project.files['index.js'] = '// TODO: write better code';
     project.files['index.hbs'] = '{{!-- i should TODO: write code --}}';
     project.files['index.scss'] = `
@@ -49,6 +50,9 @@ describe('lines-of-code-task', () => {
 
       "
     `);
+
+    // random file extensions not supported by SLOC or checkup are not included in results
+    expect(stdout()).not.toContain('whatever');
   });
 
   it('returns all the lines of code by type found in the app and outputs to json', async () => {

--- a/packages/core/__tests__/utils/get-paths-test.ts
+++ b/packages/core/__tests__/utils/get-paths-test.ts
@@ -20,6 +20,12 @@ describe('getFilePaths', function () {
       baz: {
         'index.js': '// TODO: write better code',
       },
+      node_modules: {
+        '.bin': {
+          'foo.js': 'whatever',
+        },
+        'index.js': 'module.exports = {};',
+      },
     });
     project.writeSync();
   });
@@ -29,10 +35,10 @@ describe('getFilePaths', function () {
   });
 
   describe('basic', function () {
-    it('returns all files when no patterns are provided', function () {
-      let files = getFilePaths(project.baseDir);
+    it('returns all files except exclusions when no patterns are provided', function () {
+      let filteredFiles = filterFilePathResults(getFilePaths(project.baseDir));
 
-      expect(filterFilePathResults(files)).toMatchInlineSnapshot(`
+      expect(filteredFiles).toMatchInlineSnapshot(`
         FilePathsArray [
           "/bar/index.js",
           "/baz/index.js",
@@ -41,6 +47,8 @@ describe('getFilePaths', function () {
           "/package.json",
         ]
       `);
+
+      expect(filteredFiles).not.toContain('node_modules');
     });
 
     it('returns all files when no patterns are provided and a base path other than "." is provided', function () {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,8 +5,8 @@
   "author": "Steve Calvert <steve.calvert@gmail.com>",
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
-    "ajv": "^6.12.2",
     "@types/micromatch": "^4.0.1",
+    "ajv": "^6.12.2",
     "chalk": "^4.0.0",
     "cli-ux": "^5.4.6",
     "debug": "^4.1.1",

--- a/packages/core/src/utils/get-paths.ts
+++ b/packages/core/src/utils/get-paths.ts
@@ -2,12 +2,11 @@ import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 import { FilePathsArray } from './file-paths-array';
 
-const micromatch = require('micromatch');
 const isValidGlob = require('is-valid-glob');
+const micromatch = require('micromatch');
 const walkSync = require('walk-sync');
-const globby = require('globby');
 
-const PATHS_TO_IGNORE = [
+const PATHS_TO_IGNORE: string[] = [
   '**/node_modules/**',
   'bower_components/**',
   '**/tests/dummy/**',
@@ -31,6 +30,7 @@ export function getFilePaths(
   if (globs.length > 0) {
     return expandFileGlobs(globs, basePath, mergedPathsToIgnore);
   }
+
   const allFiles: string[] = walkSync(basePath, {
     ignore: mergedPathsToIgnore,
     directories: false,
@@ -49,7 +49,7 @@ function expandFileGlobs(
       let isLiteralPath = !isValidGlob(pattern) && existsSync(pattern);
 
       if (isLiteralPath) {
-        let isIgnored = !micromatch.isMatch(pattern, PATHS_TO_IGNORE);
+        let isIgnored = !micromatch.isMatch(pattern, excludePaths);
 
         if (!isIgnored) {
           return pattern;
@@ -58,10 +58,10 @@ function expandFileGlobs(
         return [];
       }
 
-      let expandedGlobs = globby.sync(pattern, {
-        cwd: basePath,
+      let expandedGlobs = walkSync(basePath, {
+        globs: [pattern],
+        directories: false,
         ignore: excludePaths,
-        gitignore: true,
       }) as string[];
 
       return resolveFilePaths(expandedGlobs, basePath);


### PR DESCRIPTION
Previously, we were taking all "extensions" and using them to call sloc. Extensions were defined as a string after a period. However, when running this on a real app, there was a ton of random garbage getting thrown in there. I decided to just use the exensions supported by sloc, and just add
two additional (json and md). This fits our current use case, and we can re-evaluate (also re-evaluate using this subpar library) if things change and it no longer fits our use case.

