### PR TITLE
Render the task category in stdout

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
+++ b/packages/checkup-plugin-ember-octane/__tests__/results/__snapshots__/octane-migration-status-tast-result-test.ts.snap
@@ -2014,7 +2014,7 @@ Object {
 `;
 
 exports[`octane-migration-status-task-result console output simple console output 1`] = `
-"=== Ember Octane Migration Status ===
+"Ember Octane Migration Status
 
 Octane Violations: 35
 

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`dependencies-task detects Ember dependencies 1`] = `
-"=== Ember Dependencies ===
+"Ember Dependencies
 
 Dependency Types                 Total 
 Ember Core Libraries             3     

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-in-repo-addons-engines-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-in-repo-addons-engines-task-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ember-in-repo-addons-engines-task can read task and output to console 1`] = `
-"=== Ember In-Repo Addons / Engines ===
+"Ember In-Repo Addons / Engines
 
 In-Repo Addons: 2
 In-Repo Engines: 2

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-test-type-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-test-type-task-test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ember-test-types-task only renders todos/only test types if they a value > 0 1`] = `
-"=== Ember Test Types ===
+"Ember Test Types
 
 Type           test    only    todo    
 unit           0       0       0       
 rendering      1       1       1       
 application    0       0       0       
 
-=== Test Type Breakdown
+Test Type Breakdown
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 tests
 ■ unit (0)  ■ rendering (3)  ■ application (0)  
@@ -17,14 +17,14 @@ application    0       0       0
 `;
 
 exports[`ember-test-types-task returns all the test types (including nested) found in the app and outputs to the console 1`] = `
-"=== Ember Test Types ===
+"Ember Test Types
 
 Type           test    skip    
 unit           2       4 (67%) 
 rendering      2       4 (67%) 
 application    4       8 (67%) 
 
-=== Test Type Breakdown
+Test Type Breakdown
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 24 tests
 ■ unit (6)  ■ rendering (6)  ■ application (12)  
@@ -74,14 +74,14 @@ Object {
 `;
 
 exports[`ember-test-types-task returns all the test types found in the app and outputs to the console 1`] = `
-"=== Ember Test Types ===
+"Ember Test Types
 
 Type           test    skip    
 unit           1       2 (67%) 
 rendering      1       2 (67%) 
 application    2       4 (67%) 
 
-=== Test Type Breakdown
+Test Type Breakdown
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 12 tests
 ■ unit (3)  ■ rendering (3)  ■ application (6)  

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-types-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-types-task-test.ts.snap
@@ -86,7 +86,7 @@ Array [
 `;
 
 exports[`types-task returns all the types (including nested) found in the app and outputs to the console 1`] = `
-"=== Ember Types ===
+"Ember Types
 
 Types                 Total 
 Components            2     
@@ -189,7 +189,7 @@ Array [
 `;
 
 exports[`types-task returns all the types found in the app and outputs to the console 1`] = `
-"=== Ember Types ===
+"Ember Types
 
 Types                 Total 
 Components            1     

--- a/packages/checkup-plugin-ember/__tests__/template-lint-disable-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/template-lint-disable-task-test.ts
@@ -39,10 +39,7 @@ describe('template-lint-disable-task', () => {
     templateLintDisableTaskResult.toConsole();
 
     expect(stdout()).toMatchInlineSnapshot(`
-      "=== Number of template-lint-disable Usages ===
-
-      template-lint-disable Usages Found: 3
-
+      "template-lint-disable Usages Found: 3
       "
     `);
   });

--- a/packages/checkup-plugin-ember/src/results/template-lint-disable-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/template-lint-disable-task-result.ts
@@ -4,9 +4,7 @@ export default class TemplateLintDisableTaskResult extends BaseTaskResult implem
   templateLintDisables!: ResultData;
 
   toConsole() {
-    ui.section(this.meta.friendlyTaskName, () => {
-      ui.log(`template-lint-disable Usages Found: ${this.templateLintDisables.results.length}`);
-    });
+    ui.log(`template-lint-disable Usages Found: ${this.templateLintDisables.results.length}`);
   }
 
   toJson() {

--- a/packages/checkup-plugin-javascript/__tests__/__snapshots__/outdated-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-javascript/__tests__/__snapshots__/outdated-dependencies-task-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`outdated-dependencies-task detects outdated dependencies and output to console 1`] = `
-"=== Outdated Dependencies ===
+"Outdated Dependencies
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2
 ■ major (2)  ■ minor (0)  ■ patch (0)  

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -40,10 +40,7 @@ describe('eslint-disable-task', () => {
     eslintDisableTaskResult.toConsole();
 
     expect(stdout()).toMatchInlineSnapshot(`
-      "=== Number of eslint-disable Usages ===
-
-      eslint-disable Usages Found: 3
-
+      "eslint-disable Usages Found: 3
       "
     `);
   });

--- a/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
@@ -48,17 +48,17 @@ describe('eslint-summary-task', () => {
     taskResult.toConsole();
 
     expect(stdout()).toMatchInlineSnapshot(`
-      "=== Eslint Summary ===
+      "Eslint Summary
 
       Error count: 1
       Warning count: 1
 
-      === Errors
+      Errors
 
       Rule name Failures             
       semi      1 errors (1 fixable) 
 
-      === Warnings
+      Warnings
 
       Rule name Failures               
       no-var    1 warnings (1 fixable) 

--- a/packages/checkup-plugin-javascript/src/results/eslint-disable-task-result.ts
+++ b/packages/checkup-plugin-javascript/src/results/eslint-disable-task-result.ts
@@ -4,9 +4,7 @@ export default class EslintDisableTaskResult extends BaseTaskResult implements T
   eslintDisables!: ResultData;
 
   toConsole() {
-    ui.section(this.meta.friendlyTaskName, () => {
-      ui.log(`eslint-disable Usages Found: ${this.eslintDisables.results.length}`);
-    });
+    ui.log(`eslint-disable Usages Found: ${this.eslintDisables.results.length}`);
   }
 
   toJson() {

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -6,7 +6,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -27,7 +27,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -48,7 +48,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -89,7 +89,7 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
         \\"friendlyTaskName\\": \\"Lines of Code\\",
         \\"taskClassification\\": {
           \\"type\\": \\"insights\\",
-          \\"category\\": \\"meta\\"
+          \\"category\\": \\"project info\\"
         }
       },
       \\"result\\": {
@@ -164,7 +164,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -185,7 +185,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -207,7 +207,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -229,7 +229,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -249,7 +249,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -270,7 +270,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 
@@ -291,7 +291,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Meta
+=== Project Info
 
 Lines of Code
 

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -6,11 +6,14 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 hbs         1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config da25c78e31bb71ef06c3641e8846f64e
@@ -24,11 +27,14 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 js          1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config da25c78e31bb71ef06c3641e8846f64e
@@ -42,12 +48,15 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 hbs         1           0    
 js          1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -145,6 +154,7 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
+
 "
 `;
 
@@ -154,11 +164,14 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 hbs         2           0    
 js          1           1    
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -172,12 +185,15 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 js          3           2    
 hbs         2           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -191,12 +207,15 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 hbs         1           0    
 js          1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -210,10 +229,13 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 json        175         N/A  
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -227,11 +249,14 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 js          1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976
@@ -245,11 +270,14 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 js          1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config da25c78e31bb71ef06c3641e8846f64e
@@ -263,12 +291,15 @@ Checkup report generated for checkup-app v0.0.0
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
-=== Lines of Code ===
+=== Meta
+
+Lines of Code
 
 File type   Total       TODO 
 hbs         1           0    
 js          1           0    
 json        175         N/A  
+
 
 checkup v0.0.0
 config 3720546166a5955def89f6bf69895976

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -1,5 +1,10 @@
 import { TaskType, TaskResult } from '@checkup/core';
-import { DEFAULT_OUTPUT_FILENAME, _transformJsonResults, getOutputPath } from '../src/reporters';
+import {
+  DEFAULT_OUTPUT_FILENAME,
+  _transformJsonResults,
+  getOutputPath,
+  _toSentenceCase,
+} from '../src/reporters';
 
 import { MetaTaskResult } from '../src/types';
 import MockMetaTaskResult from './__utils__/mock-meta-task-result';
@@ -248,5 +253,15 @@ describe('getOutputPath', () => {
     expect(getOutputPath(`{default}.json`, __dirname)).toEqual(
       join(__dirname, `${DEFAULT_OUTPUT_FILENAME}.json`)
     );
+  });
+});
+
+describe('_toSentenceCase', () => {
+  it('transforms lowercase text to sentence case', () => {
+    expect(_toSentenceCase('cara kessler')).toEqual('Cara Kessler');
+  });
+
+  it('leaves sentence case text as sentence case', () => {
+    expect(_toSentenceCase('Cara Kessler')).toEqual('Cara Kessler');
   });
 });

--- a/packages/cli/__tests__/reporters-test.ts
+++ b/packages/cli/__tests__/reporters-test.ts
@@ -1,10 +1,5 @@
-import { TaskType, TaskResult } from '@checkup/core';
-import {
-  DEFAULT_OUTPUT_FILENAME,
-  _transformJsonResults,
-  getOutputPath,
-  _toSentenceCase,
-} from '../src/reporters';
+import { DEFAULT_OUTPUT_FILENAME, _transformJsonResults, getOutputPath } from '../src/reporters';
+import { TaskResult, TaskType } from '@checkup/core';
 
 import { MetaTaskResult } from '../src/types';
 import MockMetaTaskResult from './__utils__/mock-meta-task-result';
@@ -253,15 +248,5 @@ describe('getOutputPath', () => {
     expect(getOutputPath(`{default}.json`, __dirname)).toEqual(
       join(__dirname, `${DEFAULT_OUTPUT_FILENAME}.json`)
     );
-  });
-});
-
-describe('_toSentenceCase', () => {
-  it('transforms lowercase text to sentence case', () => {
-    expect(_toSentenceCase('cara kessler')).toEqual('Cara Kessler');
-  });
-
-  it('leaves sentence case text as sentence case', () => {
-    expect(_toSentenceCase('Cara Kessler')).toEqual('Cara Kessler');
   });
 });

--- a/packages/cli/__tests__/tasks/lines-of-code-task-test.ts
+++ b/packages/cli/__tests__/tasks/lines-of-code-task-test.ts
@@ -40,7 +40,7 @@ describe('lines-of-code-task', () => {
     linesOfCodeResult.toConsole();
 
     expect(stdout()).toMatchInlineSnapshot(`
-      "=== Lines of Code ===
+      "Lines of Code
 
       File type   Total       TODO 
       hbs         1           1    

--- a/packages/cli/__tests__/tasks/lines-of-code-task-test.ts
+++ b/packages/cli/__tests__/tasks/lines-of-code-task-test.ts
@@ -71,7 +71,7 @@ describe('lines-of-code-task', () => {
         "meta": Object {
           "friendlyTaskName": "Lines of Code",
           "taskClassification": Object {
-            "category": "meta",
+            "category": "project info",
             "type": "insights",
           },
           "taskName": "lines-of-code",

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -2,6 +2,7 @@ import { MetaTaskResult, OutputPosition } from './types';
 import { OutputFormat, RunFlags, TaskError, TaskResult, ui } from '@checkup/core';
 import { dirname, isAbsolute, resolve } from 'path';
 import { existsSync, mkdirpSync, writeJsonSync } from 'fs-extra';
+
 import { startCase } from 'lodash';
 
 const date = require('date-and-time');
@@ -94,10 +95,4 @@ export function getReporter(
     default:
       return async () => {};
   }
-}
-
-export function _toSentenceCase(str: string) {
-  return str.replace(/\w\S*/g, function (txt) {
-    return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
-  });
 }

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -2,6 +2,7 @@ import { MetaTaskResult, OutputPosition } from './types';
 import { OutputFormat, RunFlags, TaskError, TaskResult, ui } from '@checkup/core';
 import { dirname, isAbsolute, resolve } from 'path';
 import { existsSync, mkdirpSync, writeJsonSync } from 'fs-extra';
+import { startCase } from 'lodash';
 
 const date = require('date-and-time');
 
@@ -59,7 +60,7 @@ export function getReporter(
           let taskCategory = taskResult.meta.taskClassification.category;
 
           if (taskCategory !== currentCategory) {
-            ui.categoryHeader(_toSentenceCase(taskCategory));
+            ui.categoryHeader(startCase(taskCategory));
             currentCategory = taskCategory;
           }
 

--- a/packages/cli/src/reporters.ts
+++ b/packages/cli/src/reporters.ts
@@ -53,7 +53,20 @@ export function getReporter(
           .filter((taskResult) => taskResult.outputPosition === OutputPosition.Header)
           .forEach((taskResult) => taskResult.toConsole());
 
-        pluginTaskResults.forEach((taskResult) => taskResult.toConsole());
+        let currentCategory = '';
+
+        pluginTaskResults.forEach((taskResult) => {
+          let taskCategory = taskResult.meta.taskClassification.category;
+
+          if (taskCategory !== currentCategory) {
+            ui.categoryHeader(_toSentenceCase(taskCategory));
+            currentCategory = taskCategory;
+          }
+
+          taskResult.toConsole();
+        });
+
+        ui.blankLine();
 
         metaTaskResults
           .filter((taskResult) => taskResult.outputPosition === OutputPosition.Footer)
@@ -80,4 +93,10 @@ export function getReporter(
     default:
       return async () => {};
   }
+}
+
+export function _toSentenceCase(str: string) {
+  return str.replace(/\w\S*/g, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
+  });
 }

--- a/packages/cli/src/tasks/lines-of-code-task.ts
+++ b/packages/cli/src/tasks/lines-of-code-task.ts
@@ -1,4 +1,5 @@
-import { TaskResult, Task, TaskType, TaskMetaData, BaseTask, TaskContext } from '@checkup/core';
+import { BaseTask, Task, TaskContext, TaskMetaData, TaskResult, TaskType } from '@checkup/core';
+
 import LinesOfCodeTaskResult from '../results/lines-of-code-task-result';
 
 const fs = require('fs');
@@ -51,7 +52,7 @@ export default class LinesOfCodeTask extends BaseTask implements Task {
     friendlyTaskName: 'Lines of Code',
     taskClassification: {
       type: TaskType.Insights,
-      category: 'meta', // TODO: change this to a meta task
+      category: 'project info', // TODO: change this to a meta task
     },
   };
 

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -31,6 +31,7 @@ export interface TaskContext {
 }
 
 export interface TaskResult {
+  meta: TaskMetaData;
   toConsole: () => void;
   toJson: () => JsonMetaTaskResult | JsonTaskResult;
 }

--- a/packages/core/src/utils/ui.ts
+++ b/packages/core/src/utils/ui.ts
@@ -15,10 +15,13 @@ export const ui = Object.assign(ux, {
     process.stdout.write('\u001B[0f');
   },
 
+  categoryHeader(header: string) {
+    ui.styledHeader(header);
+    ui.blankLine();
+  },
+
   sectionHeader(header: string) {
-    process.stdout.write(
-      `${chalk.dim('===')} ${chalk.bold(chalk.white(header))} ${chalk.dim('===')}\n`
-    );
+    process.stdout.write(this.emphasize(`${chalk.underline(chalk.white(header))}\n`));
     ui.blankLine();
   },
 
@@ -29,7 +32,7 @@ export const ui = Object.assign(ux, {
   },
 
   subHeader(header: string) {
-    ui.styledHeader(header);
+    process.stdout.write(`${chalk.underline(chalk.white(header))}\n`);
     ui.blankLine();
   },
 


### PR DESCRIPTION
In a previous PR, I added the concept of a string `category` to checkup, and sorted the results by category. In this PR, I actually render the category to stdout for each group as a header (bold, with the `===` before and after the string), and changed the task headers to not render the `===`, making them more sort of subheaders.

Attached before and after to help show the UI changes.