### PR TITLE
Externalizing programmatic invocation of checkup

### DIFF
--- a/packages/cli/__tests__/commands/run-error-test.ts
+++ b/packages/cli/__tests__/commands/run-error-test.ts
@@ -1,7 +1,7 @@
 import * as stringify from 'json-stable-stringify';
 
 import { CheckupProject } from '@checkup/test-helpers';
-import { runCommand } from '../__utils__/run-command';
+import { runCommand } from '../../src/run-command';
 import { white } from 'chalk';
 
 describe('@checkup/cli', () => {

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { CheckupProject, createTmpDir, stdout, clearStdout } from '@checkup/test-helpers';
 
 import { join } from 'path';
-import { runCommand } from '../__utils__/run-command';
+import { runCommand } from '../../src/run-command';
 
 const TEST_TIMEOUT = 100000;
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,3 +21,5 @@ export function run() {
 
   return oclifRun(args);
 }
+
+export { runCommand } from './run-command';

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -5,7 +5,7 @@ const castArray = <T>(input?: T | T[]): T[] => {
   return Array.isArray(input) ? input : [input];
 };
 
-let root = require.resolve('../../src');
+let root = require.resolve('.');
 
 export async function runCommand(args: string[] | string, opts: loadConfig.Options = {}) {
   let config = await Config.load(opts.root || root);


### PR DESCRIPTION
Usage:

```javascript
let checkup = require('@checkup/cli');

checkup
  .runCommand(['run', '--format', 'json', '--cwd', '.'])
  .catch(require('@oclif/errors/handle'));
```