### PR TITLE
Removing 'on' option from task config because tasks are always on by default

### DIFF
--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -45,7 +45,7 @@ describe('BaseTask', () => {
       config: {
         plugins: [],
         tasks: {
-          'fake/my-fake': ['on', [{ 'my-fake-option': 20 }]],
+          'fake/my-fake': { 'my-fake-option': 20 },
         },
       },
     });
@@ -53,6 +53,6 @@ describe('BaseTask', () => {
     let fakeTask = new FakeTask('fake', context);
 
     expect(fakeTask.enabled).toEqual(true);
-    expect(fakeTask.config).toEqual([{ 'my-fake-option': 20 }]);
+    expect(fakeTask.config).toEqual({ 'my-fake-option': 20 });
   });
 });

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -44,7 +44,7 @@ export default abstract class BaseTask {
       return;
     }
 
-    let config: 'on' | 'off' | ['on' | 'off', TaskConfig] | undefined = this.context.config.tasks[
+    let config: 'off' | ['off', TaskConfig] | TaskConfig | undefined = this.context.config.tasks[
       this.fullyQualifiedTaskName
     ];
 
@@ -57,6 +57,8 @@ export default abstract class BaseTask {
 
       this.#enabled = enabled;
       this.#config = taskConfig;
+    } else {
+      this.#config = config;
     }
 
     this.debug('%s enabled: %s', this.constructor.name, this.#enabled);

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -4,5 +4,5 @@ export type TaskConfig = { actions?: ActionConfig; [key: string]: any };
 export type CheckupConfig = {
   excludePaths: string[];
   plugins: string[];
-  tasks: Record<string, 'on' | 'off' | ['on' | 'off', TaskConfig]>;
+  tasks: Record<string, 'off' | ['off', TaskConfig] | TaskConfig>;
 };


### PR DESCRIPTION
As tasks are always 'on' by default, there is no reason to have a config option to turn them on. If that changes, we will add this option back in. This change aligns with how the ActionConfig works