### PR TITLE
WIP: Cleaning up debug usage in checkup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,12 @@ Checkup using the debug package to provide useful information for debugging. You
 DEBUG='*' checkup
 ```
 
+To filter the output of debug to show information coming from checkup, you can run: 
+```shell
+DEBUG='checkup*' checkup
+```
+
+
 ## Debugging tests
 
 cd into the specific package you want to debug, then run:

--- a/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/octane-migration-status-task.ts
@@ -41,13 +41,12 @@ export default class OctaneMigrationStatusTask extends BaseTask implements Task 
   }
 
   async run(): Promise<OctaneMigrationStatusTaskResult> {
+    this.debugTask('Running ESLint and template-lint...');
     let [esLintReport, templateLintReport] = await Promise.all([
       this.runEsLint(),
       this.runTemplateLint(),
     ]);
-
-    this.debug('ESLint Report', esLintReport);
-    this.debug('Ember Template Lint Report', templateLintReport);
+    this.debugTask('ESLint and template-lint complete!');
 
     let result = new OctaneMigrationStatusTaskResult(
       this.meta,

--- a/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
@@ -35,12 +35,9 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
 
   async run(): Promise<TaskResult> {
     let result = new EmberTestTypesTaskResult(this.meta, this.config);
-
     let esLintReport = await this.runEsLint();
 
-    this.debug('ESLint Report', esLintReport);
     result.testTypes = transformESLintReport(esLintReport);
-
     return result;
   }
 

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -59,8 +59,9 @@ export class EslintSummaryTask extends BaseTask implements Task {
   async run(): Promise<TaskResult> {
     let result: EslintSummaryTaskResult = new EslintSummaryTaskResult(this.meta, this.config);
 
+    this.debugTask('Running ESLint...');
     let esLintReport = await this._runEsLint();
-    this.debug('ESLint Report', esLintReport);
+    this.debugTask('ESLint complete');
     result.esLintReport = esLintReport;
 
     return result;

--- a/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
@@ -25,12 +25,14 @@ export type OutdatedDependency = {
   unused: boolean;
 };
 
-async function getOutdated(path: string): Promise<OutdatedDependency[]> {
+async function getOutdated(path: string, debug: debug.Debugger): Promise<OutdatedDependency[]> {
   let result;
   let packages;
 
   try {
+    debug('Running npmCheck...');
     result = await npmCheck({ cwd: path });
+    debug('npmCheck complete!');
   } catch {
     throw new Error('Could not check project dependencies');
   }
@@ -63,7 +65,7 @@ export default class OutdatedDependenciesTask extends BaseTask implements Task {
       this.config
     );
 
-    result.outdatedDependencies = await getOutdated(this.context.cliFlags.cwd);
+    result.outdatedDependencies = await getOutdated(this.context.cliFlags.cwd, this.debugTask);
     result.totalDependencies = getTotalDependencies(this.context.pkg);
 
     return result;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,3 +1,5 @@
+import * as debug from 'debug';
+
 import {
   CheckupConfig,
   CheckupError,
@@ -92,13 +94,22 @@ export default class RunCommand extends BaseCommand {
   }
 
   public async run() {
+    let debugTaskRuns = debug('checkup:task-runs');
+    let debugTaskReporter = debug('checkup:task-reporter');
+
     ui.action.start('Checking up on your project');
 
     await this.loadConfig();
 
     await this.registerTasks();
+
+    debugTaskRuns('Starting to run tasks...');
     await this.runTasks();
+    debugTaskRuns('Task runs complete!');
+
+    debugTaskReporter('Generating report...');
     await this.report();
+    debugTaskRuns('Report generation complete!');
 
     ui.action.stop();
   }

--- a/packages/cli/src/meta-task-list.ts
+++ b/packages/cli/src/meta-task-list.ts
@@ -12,7 +12,7 @@ export default class MetaTaskList {
   constructor() {
     this._entries = new Map<TaskName, MetaTask>();
     this._errors = [];
-    this.debug = debug('checkup:meta-task');
+    this.debug = debug('checkup:meta-task-runs');
   }
 
   registerTask(task: MetaTask) {
@@ -47,7 +47,7 @@ export default class MetaTaskList {
   async runTasks(): Promise<[MetaTaskResult[], TaskError[]]> {
     let results = await this.eachTask(async (task: MetaTask) => {
       let result;
-      this.debug('start %s run', task.constructor.name);
+      this.debug(`Start ${task.meta.taskName}-task run`);
 
       try {
         result = await task.run();
@@ -55,7 +55,7 @@ export default class MetaTaskList {
         this.addError(task.meta.taskName, error.message);
       }
 
-      this.debug('%s run done', task.constructor.name);
+      this.debug(`Run ${task.meta.taskName}-task done`);
       return result;
     });
 

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -13,7 +13,7 @@ import TaskTypeMap from './task-type-map';
 export default class TaskList {
   private _categories: Map<string, TaskTypeMap>;
   private _errors: TaskError[];
-  debug: debug.Debugger;
+  debugTaskRuns: debug.Debugger;
 
   get categories() {
     return this._categories;
@@ -22,7 +22,7 @@ export default class TaskList {
   constructor() {
     this._categories = new Map<string, TaskTypeMap>();
     this._errors = [];
-    this.debug = debug('checkup:task');
+    this.debugTaskRuns = debug('checkup:task-runs');
   }
 
   /**
@@ -98,7 +98,7 @@ export default class TaskList {
   async runTasks(): Promise<[TaskResult[], TaskError[]]> {
     let results = await this.eachTask(async (task: Task) => {
       let result;
-      this.debug('start %s run', task.constructor.name);
+      this.debugTaskRuns(`${task.meta.taskName}-task starting...`);
 
       try {
         result = await task.run();
@@ -106,7 +106,7 @@ export default class TaskList {
         this.addError(task.meta.taskName, error.message);
       }
 
-      this.debug('%s run done', task.constructor.name);
+      this.debugTaskRuns(`${task.meta.taskName}-task done!`);
       return result;
     });
 

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -8,7 +8,6 @@ import { getShorthandName } from './utils/plugin-name';
 export default abstract class BaseTask {
   context: TaskContext;
   meta!: TaskMetaData | TaskIdentifier;
-  debug: debug.Debugger;
 
   #pluginName: string;
   #config!: TaskConfig;
@@ -17,16 +16,16 @@ export default abstract class BaseTask {
   constructor(pluginName: string, context: TaskContext) {
     this.#pluginName = getShorthandName(pluginName);
     this.context = context;
-
-    this.debug = debug('checkup:task');
-
-    this.debug('%s created', this.constructor.name);
   }
 
   get config() {
     this._parseConfig();
 
     return this.#config;
+  }
+
+  get debugTask() {
+    return debug(`checkup:task:${this.meta?.taskName}-task`);
   }
 
   get enabled() {
@@ -59,7 +58,6 @@ export default abstract class BaseTask {
       this.#config = taskConfig;
     }
 
-    this.debug('%s enabled: %s', this.constructor.name, this.#enabled);
-    this.debug('%s task config: %o', this.constructor.name, this.#config);
+    this.debugTask(`Task enabled: ${this.#enabled}, task config: ${this.#config}`);
   }
 }


### PR DESCRIPTION
We are using the debug package in checkup (https://www.npmjs.com/package/debug) - the prefixes and things being rendered were fairly nonstandard. Standardized them, and made prefixes more logic so the debug output is more useful.