### PR TITLE
Removing startcase library from checkup

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
@@ -7,8 +7,8 @@ Dependency Types                 Total
 Ember Core Libraries             3     
 Ember Addon Dependencies         1     
 Ember Addon Dev Dependencies     0     
-Ember CLI Addon Dependencies     2     
-Ember CLI Addon Dev Dependencies 1     
+Ember Cli Addon Dependencies     2     
+Ember Cli Addon Dev Dependencies 1     
 
 "
 `;
@@ -53,7 +53,7 @@ Object {
         "ember-cli": "^3.15.0",
         "ember-cli-blueprint-test-helpers": "latest",
       },
-      "displayName": "Ember CLI Addon Dependencies",
+      "displayName": "Ember Cli Addon Dependencies",
       "total": 2,
       "type": "ember-cli addon dependencies",
     },
@@ -61,7 +61,7 @@ Object {
       "data": Object {
         "ember-cli-string-utils": "latest",
       },
-      "displayName": "Ember CLI Addon Dev Dependencies",
+      "displayName": "Ember Cli Addon Dev Dependencies",
       "total": 1,
       "type": "ember-cli addon devDependencies",
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,10 +14,10 @@
     "eslint": "^6.8.0",
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1",
+    "lodash": "^4.17.15",
     "micromatch": "^4.0.2",
     "pkg-up": "^3.1.0",
     "resolve": "^1.17.0",
-    "startcase": "^1.0.0",
     "strip-ansi": "^6.0.0",
     "wrap-ansi": "^7.0.0"
   },

--- a/packages/core/src/utils/data-transformers.ts
+++ b/packages/core/src/utils/data-transformers.ts
@@ -1,4 +1,4 @@
-import * as startCase from 'startcase';
+import { startCase } from 'lodash';
 
 import { TaskItemData } from '../types/tasks';
 

--- a/types/startcase.d.ts
+++ b/types/startcase.d.ts
@@ -1,1 +1,0 @@
-declare module 'startcase';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,11 +2951,6 @@ deps-regex@^0.1.4:
   resolved "https://registry.yarnpkg.com/deps-regex/-/deps-regex-0.1.4.tgz#518667b7691460a5e7e0a341be76eb7ce8090184"
   integrity sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=
 
-deromanize@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/deromanize/-/deromanize-0.1.0.tgz#70d6e19f735ce7b63944e62902159bbd9e6014d7"
-  integrity sha1-cNbhn3Nc57Y5ROYpAhWbvZ5gFNc=
-
 detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
@@ -4717,11 +4712,6 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-indicesof@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/indicesof/-/indicesof-0.0.2.tgz#305d7608b207613a7ff797c13a3946343c097db1"
-  integrity sha1-MF12CLIHYTp/95fBOjlGNDwJfbE=
-
 infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -5948,11 +5938,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash._root@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
-  integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
-
 lodash.camelcase@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -5988,11 +5973,6 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.startcase@^4.0.1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
-  integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
-
 lodash.template@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
@@ -6013,22 +5993,10 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash.tolower@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.tolower/-/lodash.tolower-4.1.2.tgz#d6d309ac43eef8d44e8ded66b73dab0beb0806d7"
-  integrity sha1-1tMJrEPu+NROje1mtz2rC+sIBtc=
-
-lodash.upperfirst@4.3.1, lodash.upperfirst@^4.0.1:
+lodash.upperfirst@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
-
-lodash.words@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.words/-/lodash.words-3.2.0.tgz#4e2a8649bc08745b17c695b1a3ce8fee596623b3"
-  integrity sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=
-  dependencies:
-    lodash._root "^3.0.0"
 
 lodash.zip@^4.2.0:
   version "4.2.0"
@@ -8276,19 +8244,6 @@ stackframe@^0.3.1:
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
   integrity sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=
 
-startcase@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/startcase/-/startcase-1.0.0.tgz#5eb8ff5e037d31595d078e90f6c7d73990bf4efd"
-  integrity sha1-Xrj/XgN9MVldB46Q9sfXOZC/Tv0=
-  dependencies:
-    deromanize "^0.1.0"
-    indicesof "0.0.2"
-    lodash.startcase "^4.0.1"
-    lodash.tolower "^4.0.1"
-    lodash.upperfirst "^4.0.1"
-    lodash.words "^3.1.1"
-    titlecase "^1.0.2"
-
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -8651,11 +8606,6 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
-titlecase@^1.0.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/titlecase/-/titlecase-1.1.3.tgz#fc6d65ff582b0602410768ef1a09b70506313dc3"
-  integrity sha512-pQX4oiemzjBEELPqgK4WE+q0yhAqjp/yzusGtlSJsOuiDys0RQxggepYmo0BuegIDppYS3b3cpdegRwkpyN3hw==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
There were two versions of "startcase" in the repo - lodash's and https://www.npmjs.com/package/startcase. Removing the latter in favor of lodash