### PR TITLE
Ensuring generators can generate into a specific path

### DIFF
--- a/packages/cli/__tests__/__utils__/generate-plugin.ts
+++ b/packages/cli/__tests__/__utils__/generate-plugin.ts
@@ -27,5 +27,7 @@ export async function generatePlugin(
     .withOptions(mergedOptions)
     .withPrompts(mergedPrompts);
 
-  return join(dir, `checkup-plugin-${mergedOptions.name}`);
+  return options.path
+    ? join(dir, options.path, `checkup-plugin-${mergedOptions.name}`)
+    : join(dir, `checkup-plugin-${mergedOptions.name}`);
 }

--- a/packages/cli/__tests__/generators/__snapshots__/generate-config-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-config-test.ts.snap
@@ -8,3 +8,12 @@ exports[`config-init-generator should write a config 1`] = `
 }
 "
 `;
+
+exports[`config-init-generator should write a config in custom path 1`] = `
+"{
+  \\"excludePaths\\": [],
+  \\"plugins\\": [],
+  \\"tasks\\": {}
+}
+"
+`;

--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -604,6 +604,165 @@ Array [
 ]
 `;
 
+exports[`plugin generator generates plugin with defaults in custom path 1`] = `
+"{
+  \\"name\\": \\"checkup-plugin-my-plugin\\",
+  \\"description\\": \\"Checkup plugin\\",
+  \\"version\\": \\"0.0.0\\",
+  \\"author\\": \\"\\",
+  \\"dependencies\\": {
+    \\"@checkup/core\\": \\"^0.0.1\\",
+    \\"@oclif/command\\": \\"^1\\",
+    \\"@oclif/config\\": \\"^1\\",
+    \\"tslib\\": \\"^1\\"
+  },
+  \\"devDependencies\\": {
+    \\"@checkup/test-helpers\\": \\"^0.0.1\\",
+    \\"@oclif/dev-cli\\": \\"^1\\",
+    \\"@types/jest\\": \\"^25.1.3\\",
+    \\"@types/node\\": \\"^13\\",
+    \\"jest\\": \\"^25.1.0\\",
+    \\"ts-jest\\": \\"^25.2.1\\",
+    \\"ts-node\\": \\"^8\\",
+    \\"typescript\\": \\"^3.8\\"
+  },
+  \\"engines\\": {
+    \\"node\\": \\">= 12.*\\"
+  },
+  \\"files\\": [
+    \\"/lib\\",
+    \\"/oclif.manifest.json\\"
+  ],
+  \\"keywords\\": [
+    \\"checkup-plugin\\",
+    \\"oclif-plugin\\"
+  ],
+  \\"license\\": \\"MIT\\",
+  \\"oclif\\": {
+    \\"devPlugins\\": [
+      \\"@oclif/plugin-help\\"
+    ],
+    \\"hooks\\": {
+      \\"register-tasks\\": \\"./lib/hooks/register-tasks\\"
+    }
+  },
+  \\"repository\\": \\"\\",
+  \\"scripts\\": {
+    \\"build\\": \\"yarn clean && tsc\\",
+    \\"build:watch\\": \\"yarn build -w\\",
+    \\"clean\\": \\"rm -rf lib\\",
+    \\"postpack\\": \\"rm -f oclif.manifest.json\\",
+    \\"prepack\\": \\"rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme\\",
+    \\"test\\": \\"jest --no-cache\\",
+    \\"version\\": \\"oclif-dev readme && git add README.md\\"
+  },
+  \\"types\\": \\"lib/index.d.ts\\",
+  \\"main\\": \\"lib/index.js\\"
+}
+"
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 2`] = `
+"# checkup-plugin-my-plugin
+
+Checkup plugin
+
+[![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
+[![Version](https://img.shields.io/npm/v/plugin-default.svg)](https://npmjs.org/package/plugin-default)
+[![Downloads/week](https://img.shields.io/npm/dw/plugin-default.svg)](https://npmjs.org/package/plugin-default)
+[![License](https://img.shields.io/npm/l/plugin-default.svg)](https://github.com/checkupjs/checkup/blob/master/package.json)
+
+<!-- toc -->
+
+# Usage
+
+<!-- usage -->
+
+# Commands
+
+<!-- commands -->
+"
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 3`] = `
+"module.exports = {
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: { '\\\\\\\\.ts$': 'ts-jest' },
+  coverageReporters: ['lcov', 'text-summary'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['/templates/'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+  testPathIgnorePatterns: ['__fixtures__'],
+};
+"
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 4`] = `
+"{
+  \\"compilerOptions\\": {
+    \\"declaration\\": true,
+    \\"importHelpers\\": true,
+    \\"module\\": \\"commonjs\\",
+    \\"strict\\": true,
+    \\"target\\": \\"es2017\\",
+    \\"allowSyntheticDefaultImports\\": true,
+    \\"sourceMap\\": true,
+    \\"outDir\\": \\"lib\\",
+    \\"rootDir\\": \\"src\\",
+    \\"types\\": [\\"jest\\", \\"node\\"]
+  },
+  \\"include\\": [\\"src/**/*\\"]
+}
+"
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 5`] = `
+"export default {};
+
+export * from './types';
+"
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 6`] = `
+"import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
+
+const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
+  let pluginName = getPluginName(__dirname);
+};
+
+export default hook;
+"
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 7`] = `""`;
+
+exports[`plugin generator generates plugin with defaults in custom path 8`] = `
+Array [
+  ".gitkeep",
+]
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 9`] = `
+Array [
+  ".gitkeep",
+]
+`;
+
+exports[`plugin generator generates plugin with defaults in custom path 10`] = `
+Array [
+  ".gitkeep",
+]
+`;
+
 exports[`plugin generator generates plugin with unmodified name with defaults 1`] = `
 "{
   \\"name\\": \\"checkup-plugin-foo\\",

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -190,6 +190,102 @@ export default hook;
 "
 `;
 
+exports[`task generator generates correct files with TypeScript for defaults in custom path 1`] = `
+"import { BaseTask, Task, TaskMetaData, TaskResult } from '@checkup/core';
+import MyFooTaskResult from '../results/my-foo-task-result';
+
+export default class MyFooTask extends BaseTask implements Task {
+  meta: TaskMetaData = {
+    taskName: 'my-foo',
+    friendlyTaskName: 'My Foo',
+    taskClassification: {
+      category: '',
+    },
+  };
+
+  async run(): Promise<TaskResult> {
+    let result: MyFooTaskResult = new MyFooTaskResult(this.meta);
+
+    return result;
+  }
+}
+"
+`;
+
+exports[`task generator generates correct files with TypeScript for defaults in custom path 2`] = `
+"import { BaseTaskResult, TaskResult, ui } from '@checkup/core';
+
+export default class MyFooTaskResult extends BaseTaskResult implements TaskResult {
+  toConsole() {
+    ui.styledHeader(this.meta.friendlyTaskName);
+  }
+
+  toJson() {
+    return {
+      meta: this.meta,
+      result: {},
+    };
+  }
+}
+"
+`;
+
+exports[`task generator generates correct files with TypeScript for defaults in custom path 3`] = `
+"import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
+import MyFooTask from '../src/tasks/my-foo-task';
+import MyFooTaskResult from '../src/results/my-foo-task-result';
+
+describe('my-foo-task', () => {
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
+
+  beforeEach(() => {
+    project = new CheckupProject('checkup-app', '0.0.0', project => {
+      project.addDependency('ember-cli', '^3.15.0');
+    });
+
+    project.writeSync();
+    project.gitInit();
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  it('can read task and output to console', async () => {
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
+    const taskResult = <MyFooTaskResult>result;
+
+    taskResult.toConsole();
+
+    expect(stdout()).toMatchSnapshot();
+  });
+
+  it('can read task as JSON', async () => {
+    const result = await new MyFooTask(pluginName, getTaskContext({},  {cwd: project.baseDir})).run();
+    const taskResult = <MyFooTaskResult>result;
+
+    expect(taskResult.toJson()).toMatchSnapshot();
+  });
+});
+"
+`;
+
+exports[`task generator generates correct files with TypeScript for defaults in custom path 4`] = `
+"import { Hook } from '@oclif/config';
+import MyFooTask from '../tasks/my-foo-task';
+import { getPluginName } from '@checkup/core';
+
+const hook: Hook<'register-tasks'> = async function({ context, tasks }: any) {
+  let pluginName = getPluginName(__dirname);
+  tasks.registerTask(new MyFooTask(pluginName, context));
+};
+
+export default hook;
+"
+`;
+
 exports[`task generator generates correct files with category 1`] = `
 "import { BaseTask, Task, TaskMetaData, TaskResult } from '@checkup/core';
 import MyFooTaskResult from '../results/my-foo-task-result';

--- a/packages/cli/__tests__/generators/generate-config-test.ts
+++ b/packages/cli/__tests__/generators/generate-config-test.ts
@@ -15,6 +15,14 @@ describe('config-init-generator', () => {
     expect(testRoot(dir).file('.checkuprc').contents).toMatchSnapshot();
   });
 
+  it('should write a config in custom path', async () => {
+    let tmp = createTmpDir();
+
+    const dir = await helpers.run(ConfigGenerator).cd(tmp).withOptions({ path: './lib' });
+
+    expect(testRoot(join(dir, 'lib')).file('.checkuprc').contents).toMatchSnapshot();
+  });
+
   it('should error if a checkuprc file is already present', async () => {
     await expect(
       helpers.run(ConfigGenerator).inTmpDir(function (dir) {

--- a/packages/cli/__tests__/generators/generate-plugin-test.ts
+++ b/packages/cli/__tests__/generators/generate-plugin-test.ts
@@ -27,6 +27,23 @@ describe('plugin generator', () => {
     expect(root.directory('src/tasks').contents).toMatchSnapshot();
   });
 
+  it('generates plugin with defaults in custom path', async () => {
+    let dir = await generatePlugin({ path: './lib' });
+
+    let root = testRoot(dir);
+
+    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(root.file('README.md').contents).toMatchSnapshot();
+    expect(root.file('jest.config.js').contents).toMatchSnapshot();
+    expect(root.file('tsconfig.json').contents).toMatchSnapshot();
+    expect(root.file('src/index.ts').contents).toMatchSnapshot();
+    expect(root.file('src/hooks/register-tasks.ts').contents).toMatchSnapshot();
+    expect(root.file('src/types/index.ts').contents).toMatchSnapshot();
+    expect(root.directory('__tests__').contents).toMatchSnapshot();
+    expect(root.directory('src/results').contents).toMatchSnapshot();
+    expect(root.directory('src/tasks').contents).toMatchSnapshot();
+  });
+
   it('generates plugin with JavaScript defaults', async () => {
     let dir = await generatePlugin({ defaults: false }, { typescript: false });
 

--- a/packages/cli/__tests__/generators/generate-task-test.ts
+++ b/packages/cli/__tests__/generators/generate-task-test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/expect-expect */
 
 import * as helpers from 'yeoman-test';
+import { resolve } from 'path';
 
 import TaskGenerator from '../../src/generators/task';
 import { generatePlugin } from '../__utils__/generate-plugin';
@@ -29,6 +30,21 @@ describe('task generator', () => {
       .withOptions({
         name: 'my-foo',
         defaults: true,
+      });
+
+    assertTaskFiles('my-foo', dir);
+    assertPluginFiles(dir);
+  });
+
+  it('generates correct files with TypeScript for defaults in custom path', async () => {
+    let baseDir = await generatePlugin({ path: './lib' });
+    let dir = await helpers
+      .run(TaskGenerator, { namespace: 'checkup:task' })
+      .cd(resolve(baseDir, '../..'))
+      .withOptions({
+        name: 'my-foo',
+        defaults: true,
+        path: './lib/checkup-plugin-my-plugin',
       });
 
     assertTaskFiles('my-foo', dir);

--- a/packages/cli/__tests__/generators/generate-task-test.ts
+++ b/packages/cli/__tests__/generators/generate-task-test.ts
@@ -38,7 +38,7 @@ describe('task generator', () => {
 
   it('generates correct files with TypeScript for defaults in custom path', async () => {
     let baseDir = await generatePlugin({ path: './lib' });
-    let dir = await helpers
+    await helpers
       .run(TaskGenerator, { namespace: 'checkup:task' })
       .cd(resolve(baseDir, '../..'))
       .withOptions({
@@ -47,8 +47,8 @@ describe('task generator', () => {
         path: './lib/checkup-plugin-my-plugin',
       });
 
-    assertTaskFiles('my-foo', dir);
-    assertPluginFiles(dir);
+    assertTaskFiles('my-foo', baseDir);
+    assertPluginFiles(baseDir);
   });
 
   it('generates multiple correct files with TypeScript for defaults', async () => {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -44,7 +44,6 @@ export default class GenerateCommand extends BaseCommand {
     {
       name: 'name',
       description: 'name of the entity (kebab-case)',
-      optional: true,
     },
   ];
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -14,7 +14,7 @@ const VALID_GENERATORS = ['config', 'plugin', 'task'];
 export interface Options {
   type: string;
   name: string;
-  path: string;
+  path?: string;
   defaults?: boolean;
   force?: boolean;
 }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -28,6 +28,11 @@ export default class GenerateCommand extends BaseCommand {
     defaults: flags.boolean({ description: 'use defaults for every setting' }),
     options: flags.string({ description: '(typescript)' }),
     force: flags.boolean({ description: 'overwrite existing files' }),
+    path: flags.string({
+      default: '.',
+      char: 'p',
+      description: 'The path referring to the directory that the generator will run in',
+    }),
   };
 
   static args = [
@@ -39,11 +44,7 @@ export default class GenerateCommand extends BaseCommand {
     {
       name: 'name',
       description: 'name of the entity (kebab-case)',
-    },
-    {
-      name: 'path',
-      description: 'The path referring to the directory that the generator will run in',
-      default: '.',
+      optional: true,
     },
   ];
 
@@ -69,13 +70,13 @@ export default class GenerateCommand extends BaseCommand {
 
     await this.generate(args.type, {
       name: args.name,
-      path: args.path,
+      path: flags.path,
       defaults: flags.defaults,
       force: flags.force,
     } as Options);
   }
 
-  async generate(type: string, generatorOptions: object = {}) {
+  async generate(type: string, generatorOptions: Options) {
     this.debug('generatorOptions', generatorOptions);
 
     const env = createEnv();

--- a/packages/cli/src/generators/base-generator.ts
+++ b/packages/cli/src/generators/base-generator.ts
@@ -1,9 +1,27 @@
 import * as Generator from 'yeoman-generator';
 import * as chalk from 'chalk';
 
+import { Options } from '../commands/generate';
+
 import { getVersion } from '../helpers/get-version';
+import { resolve } from 'path';
+import { existsSync, mkdirSync } from 'fs';
 
 export default class GeneratorBase extends Generator {
+  constructor(args: string | string[], options: Options) {
+    super(args, options);
+
+    if (options.path !== '.') {
+      let resolvedPath = resolve(options.path);
+
+      if (!existsSync(resolvedPath)) {
+        mkdirSync(resolvedPath);
+      }
+
+      this.destinationRoot(options.path);
+    }
+  }
+
   headline(name: string) {
     this.log(`Generating ${chalk.bold.white(name)} ${chalk.dim(`(checkup v${getVersion()})`)}`);
   }

--- a/packages/cli/src/generators/base-generator.ts
+++ b/packages/cli/src/generators/base-generator.ts
@@ -18,7 +18,7 @@ export default class GeneratorBase extends Generator {
         mkdirSync(resolvedPath);
       }
 
-      this.destinationRoot(options.path);
+      this.destinationRoot(resolvedPath);
     }
   }
 

--- a/packages/cli/src/generators/base-generator.ts
+++ b/packages/cli/src/generators/base-generator.ts
@@ -11,7 +11,7 @@ export default class GeneratorBase extends Generator {
   constructor(args: string | string[], options: Options) {
     super(args, options);
 
-    if (options.path !== '.') {
+    if (options.path && options.path !== '.') {
       let resolvedPath = resolve(options.path);
 
       if (!existsSync(resolvedPath)) {


### PR DESCRIPTION
Fixes generators to correctly generate in a specified path. Changes the path arg to a flag.

```bash
checkup generate config --path ./lib
```

TODO:

- [x] Add tests