### PR TITLE
Adding count of files checkup operated on to the project-meta task

### DIFF
--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -76,7 +76,7 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
         \\"age\\": \\"0 days\\",
         \\"activeDays\\": \\"0 days\\"
       },
-      \\"filesAnalyzed\\": 6
+      \\"analyzedFilesCount\\": 6
     },
     \\"checkup\\": {
       \\"configHash\\": \\"3720546166a5955def89f6bf69895976\\",

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`@checkup/cli normal cli output if excludePaths are provided by both the config and command line, use command line 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (4 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -23,7 +23,7 @@ config da25c78e31bb71ef06c3641e8846f64e
 
 exports[`@checkup/cli normal cli output if excludePaths are provided by both the config and command line, use command line 2`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -44,7 +44,7 @@ config da25c78e31bb71ef06c3641e8846f64e
 
 exports[`@checkup/cli normal cli output should output checkup result 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -75,7 +75,8 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
         \\"totalFiles\\": 0,
         \\"age\\": \\"0 days\\",
         \\"activeDays\\": \\"0 days\\"
-      }
+      },
+      \\"filesAnalyzed\\": 6
     },
     \\"checkup\\": {
       \\"configHash\\": \\"3720546166a5955def89f6bf69895976\\",
@@ -150,7 +151,7 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
 
 exports[`@checkup/cli normal cli output should run a single task if the task option is specified 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -160,7 +161,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 exports[`@checkup/cli normal cli output should run the tasks on the globs passed into checkup, if provided, instead of entire app 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (3 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -181,7 +182,7 @@ config 3720546166a5955def89f6bf69895976
 
 exports[`@checkup/cli normal cli output should run the tasks on the globs passed into checkup, if provided, instead of entire app 2`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (9 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -203,7 +204,7 @@ config 3720546166a5955def89f6bf69895976
 
 exports[`@checkup/cli normal cli output should use the config at the config path if provided 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -225,7 +226,7 @@ config 3720546166a5955def89f6bf69895976
 
 exports[`@checkup/cli normal cli output should use the excludePaths provided by the command line 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (3 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -245,7 +246,7 @@ config 3720546166a5955def89f6bf69895976
 
 exports[`@checkup/cli normal cli output should use the excludePaths provided by the command line 2`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -266,7 +267,7 @@ config 3720546166a5955def89f6bf69895976
 
 exports[`@checkup/cli normal cli output should use the excludePaths provided by the config 1`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -287,7 +288,7 @@ config da25c78e31bb71ef06c3641e8846f64e
 
 exports[`@checkup/cli normal cli output should use the excludePaths provided by the config 2`] = `
 "
-Checkup report generated for checkup-app v0.0.0
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -54,6 +54,7 @@ describe('project-meta-task', () => {
       expect(taskResult.toJson()).toMatchInlineSnapshot(`
         Object {
           "project": Object {
+            "filesAnalyzed": 0,
             "name": "checkup-app",
             "repository": Object {
               "activeDays": "0 days",

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -54,7 +54,7 @@ describe('project-meta-task', () => {
       expect(taskResult.toJson()).toMatchInlineSnapshot(`
         Object {
           "project": Object {
-            "filesAnalyzed": 0,
+            "analyzedFilesCount": 0,
             "name": "checkup-app",
             "repository": Object {
               "activeDays": "0 days",

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -8,7 +8,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
   name!: string;
   version!: string;
   repository!: RepositoryInfo;
-  filesForCheckup!: string[];
+  analyzedFiles!: string[];
 
   toConsole() {
     let filesForCheckupString =

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -11,7 +11,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
   analyzedFiles!: string[];
 
   toConsole() {
-    let filesForCheckupString =
+    let analyzedFilesMessage =
       this.repository.totalFiles !== this.analyzedFiles.length
         ? ` (${ui.emphasize(`${this.analyzedFiles.length.toString()} files`)} analyzed)`
         : '';

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -39,7 +39,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
         name: this.name,
         version: this.version,
         repository: this.repository,
-        filesAnalyzed: this.filesForCheckup.length,
+        analyzedFilesCount: this.analyzedFiles.length,
       },
     };
   }

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -12,8 +12,8 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
 
   toConsole() {
     let filesForCheckupString =
-      this.repository.totalFiles !== this.filesForCheckup.length
-        ? ` (${ui.emphasize(`${this.filesForCheckup.length.toString()} files`)} analyzed)`
+      this.repository.totalFiles !== this.analyzedFiles.length
+        ? ` (${ui.emphasize(`${this.analyzedFiles.length.toString()} files`)} analyzed)`
         : '';
 
     ui.blankLine();

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -20,7 +20,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
     ui.log(
       `Checkup report generated for ${ui.emphasize(
         `${this.name} v${this.version}`
-      )}${filesForCheckupString}`
+      )}${analyzedFilesMessage}`
     );
     ui.blankLine();
     ui.log(

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -8,10 +8,20 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
   name!: string;
   version!: string;
   repository!: RepositoryInfo;
+  filesForCheckup!: string[];
 
   toConsole() {
+    let filesForCheckupString =
+      this.repository.totalFiles !== this.filesForCheckup.length
+        ? ` (${ui.emphasize(`${this.filesForCheckup.length.toString()} files`)} analyzed)`
+        : '';
+
     ui.blankLine();
-    ui.log(`Checkup report generated for ${ui.emphasize(`${this.name} v${this.version}`)}`);
+    ui.log(
+      `Checkup report generated for ${ui.emphasize(
+        `${this.name} v${this.version}`
+      )}${filesForCheckupString}`
+    );
     ui.blankLine();
     ui.log(
       `This project is ${ui.emphasize(`${this.repository.age} old`)}, with ${ui.emphasize(
@@ -29,6 +39,7 @@ export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements
         name: this.name,
         version: this.version,
         repository: this.repository,
+        filesAnalyzed: this.filesForCheckup.length,
       },
     };
   }

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -18,7 +18,7 @@ export default class ProjectMetaTask extends BaseTask implements MetaTask {
     result.name = package_.name || '';
     result.version = package_.version || '';
     result.repository = repositoryInfo;
-    result.filesForCheckup = this.context.paths;
+    result.analyzedFiles = this.context.paths;
 
     return result;
   }

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -13,10 +13,12 @@ export default class ProjectMetaTask extends BaseTask implements MetaTask {
   async run(): Promise<MetaTaskResult> {
     let result: ProjectMetaTaskResult = new ProjectMetaTaskResult(this.meta);
     let package_ = this.context.pkg;
+    let repositoryInfo = await getRepositoryInfo(this.context.cliFlags.cwd);
 
     result.name = package_.name || '';
     result.version = package_.version || '';
-    result.repository = await getRepositoryInfo(this.context.cliFlags.cwd);
+    result.repository = repositoryInfo;
+    result.filesForCheckup = this.context.paths;
 
     return result;
   }

--- a/packages/core/src/utils/get-paths.ts
+++ b/packages/core/src/utils/get-paths.ts
@@ -15,6 +15,8 @@ const PATHS_TO_IGNORE: string[] = [
   'build/**',
   'vendor/**',
   '.git/**',
+  '**/*.log',
+  '*.log',
 ];
 
 /**


### PR DESCRIPTION
If checkup is run on a subset of the files in an app, reflect that in the report. 

Examples: 
```
➜  travis-web git:(checkup) checkup '**/app**'

Checkup report generated for travis v0.0.1 (14 files analyzed)

This project is 8 years old, with 1380 active days, 5870 commits and 1538 files.
```

```
➜  travis-web git:(checkup) checkup

Checkup report generated for travis v0.0.1

This project is 8 years old, with 1380 active days, 5870 commits and 1538 files.
```