### PR TITLE
Adds a specific type for a config value

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/ember-test-type-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-test-type-task-test.ts
@@ -184,7 +184,19 @@ describe('ember-test-types-task', () => {
         paths: project.filePaths,
         config: {
           tasks: {
-            'ember/ember-test-types': { actions: { 'ratio-application-tests': { threshold: 3 } } },
+            'ember/ember-test-types': [
+              'on',
+              {
+                actions: {
+                  'ratio-application-tests': [
+                    'on',
+                    {
+                      threshold: 3,
+                    },
+                  ],
+                },
+              },
+            ],
           },
         },
       })

--- a/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/tasks/eslint-summary-task';
 import EslintSummaryTaskResult from '../src/results/eslint-summary-task-result';
 import { PackageJson } from 'type-fest';
-import { getPluginName, getShorthandName } from '@checkup/core';
+import { getPluginName } from '@checkup/core';
 
 describe('eslint-summary-task', () => {
   let project: CheckupProject;
@@ -40,12 +40,15 @@ describe('eslint-summary-task', () => {
         paths: project.filePaths,
         config: {
           tasks: {
-            [`${getShorthandName(pluginName)}/eslint-summary`]: {
-              actions: {
-                'num-eslint-errors': { threshold: 0 },
-                'num-eslint-warnings': { threshold: 0 },
+            [`javascript/eslint-summary`]: [
+              'on',
+              {
+                actions: {
+                  'num-eslint-errors': ['on', { threshold: 0 }],
+                  'num-eslint-warnings': ['on', { threshold: 0 }],
+                },
               },
-            },
+            ],
           },
         },
       })
@@ -68,13 +71,13 @@ describe('eslint-summary-task', () => {
 
       Errors
 
-      Rule name Failures             
-      semi      1 errors (1 fixable) 
+      Rule name Failures
+      semi      1 errors (1 fixable)
 
       Warnings
 
-      Rule name Failures               
-      no-var    1 warnings (1 fixable) 
+      Rule name Failures
+      no-var    1 warnings (1 fixable)
 
       "
     `);

--- a/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
@@ -71,13 +71,13 @@ describe('eslint-summary-task', () => {
 
       Errors
 
-      Rule name Failures
-      semi      1 errors (1 fixable)
+      Rule name Failures             
+      semi      1 errors (1 fixable) 
 
       Warnings
 
-      Rule name Failures
-      no-var    1 warnings (1 fixable)
+      Rule name Failures               
+      no-var    1 warnings (1 fixable) 
 
       "
     `);

--- a/packages/core/__tests__/action-list-test.ts
+++ b/packages/core/__tests__/action-list-test.ts
@@ -71,7 +71,7 @@ describe('ActionList', () => {
 
   it('you can get enabledActions with a config has a custom threshold', async () => {
     const actionList = new ActionList(actions, {
-      actions: { valueGreaterThanThreshold: { threshold: 5 } },
+      actions: { valueGreaterThanThreshold: ['on', { threshold: 5 }] },
     });
 
     let valueGreaterThanThreshold = actionList.enabledActions
@@ -89,7 +89,7 @@ describe('ActionList', () => {
   it('you can get enabledActions with a config has multiple configurations', async () => {
     const actionList = new ActionList(actions, {
       actions: {
-        valueLessThanThreshold: { threshold: 5 },
+        valueLessThanThreshold: ['off', { threshold: 5 }],
         valueGreaterThanThreshold: ['off', { threshold: 22 }],
       },
     });

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -20,7 +20,7 @@ describe('BaseTask', () => {
     let fakeTask = new FakeTask('fake', context);
 
     expect(fakeTask.context).toEqual(context);
-    expect(fakeTask.config).toBeUndefined();
+    expect(fakeTask.config).toEqual({});
     expect(fakeTask.enabled).toEqual(true);
   });
 
@@ -44,7 +44,7 @@ describe('BaseTask', () => {
       config: {
         plugins: [],
         tasks: {
-          'fake/my-fake': { 'my-fake-option': 20 },
+          'fake/my-fake': ['on', { 'my-fake-option': 20 }],
         },
       },
     });

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -1,4 +1,4 @@
-import { getConfigPath, readConfig, writeConfig, getConfigTuple } from '../src/config';
+import { getConfigPath, readConfig, writeConfig, parseConfigTuple } from '../src/config';
 import { readJsonSync, writeJsonSync } from 'fs-extra';
 
 import { DEFAULT_CONFIG } from '../lib';
@@ -98,38 +98,38 @@ describe('config', () => {
     });
   });
 
-  describe('getConfigTuple', () => {
+  describe('parseConfigTuple', () => {
     it('returns correct defaults when undefined', () => {
       let config;
-      let [enabled, value] = getConfigTuple(config);
+      let [enabled, value] = parseConfigTuple(config);
 
       expect(enabled).toEqual(true);
       expect(value).toEqual({});
     });
 
     it('returns correct defaults when "on"', () => {
-      let [enabled, value] = getConfigTuple('on');
+      let [enabled, value] = parseConfigTuple('on');
 
       expect(enabled).toEqual(true);
       expect(value).toEqual({});
     });
 
     it('returns correct defaults when "off"', () => {
-      let [enabled, value] = getConfigTuple('off');
+      let [enabled, value] = parseConfigTuple('off');
 
       expect(enabled).toEqual(false);
       expect(value).toEqual({});
     });
 
     it('returns correct defaults when a tuple and "on"', () => {
-      let [enabled, value] = getConfigTuple(['on', { foo: true }]);
+      let [enabled, value] = parseConfigTuple(['on', { foo: true }]);
 
       expect(enabled).toEqual(true);
       expect(value).toEqual({ foo: true });
     });
 
     it('returns correct defaults when a tuple and "off"', () => {
-      let [enabled, value] = getConfigTuple(['off', { foo: true }]);
+      let [enabled, value] = parseConfigTuple(['off', { foo: true }]);
 
       expect(enabled).toEqual(false);
       expect(value).toEqual({ foo: true });

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -1,4 +1,4 @@
-import { getConfigPath, readConfig, writeConfig } from '../src/config';
+import { getConfigPath, readConfig, writeConfig, getConfigTuple } from '../src/config';
 import { readJsonSync, writeJsonSync } from 'fs-extra';
 
 import { DEFAULT_CONFIG } from '../lib';
@@ -95,6 +95,44 @@ describe('config', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('getConfigTuple', () => {
+    it('returns correct defaults when undefined', () => {
+      let config;
+      let [enabled, value] = getConfigTuple(config);
+
+      expect(enabled).toEqual(true);
+      expect(value).toEqual({});
+    });
+
+    it('returns correct defaults when "on"', () => {
+      let [enabled, value] = getConfigTuple('on');
+
+      expect(enabled).toEqual(true);
+      expect(value).toEqual({});
+    });
+
+    it('returns correct defaults when "off"', () => {
+      let [enabled, value] = getConfigTuple('off');
+
+      expect(enabled).toEqual(false);
+      expect(value).toEqual({});
+    });
+
+    it('returns correct defaults when a tuple and "on"', () => {
+      let [enabled, value] = getConfigTuple(['on', { foo: true }]);
+
+      expect(enabled).toEqual(true);
+      expect(value).toEqual({ foo: true });
+    });
+
+    it('returns correct defaults when a tuple and "off"', () => {
+      let [enabled, value] = getConfigTuple(['off', { foo: true }]);
+
+      expect(enabled).toEqual(false);
+      expect(value).toEqual({ foo: true });
     });
   });
 });

--- a/packages/core/src/action-list.ts
+++ b/packages/core/src/action-list.ts
@@ -1,5 +1,6 @@
-import { ActionConfig, TaskConfig, ActionConfigValue } from './types/config';
+import { ActionConfig, TaskConfig, ConfigValue } from './types/config';
 import { Action } from './types/tasks';
+import { getConfigTuple } from './config';
 
 /**
  * @class ActionList
@@ -34,11 +35,11 @@ export default class ActionList {
     return this._defaultActions
       .map((action: Action) => {
         if (this._actionConfig[action.name]) {
-          let configuredAction = this._applyConfigForAction(
+          let [enabled, configuredAction] = this._applyConfigForAction(
             action,
             this._actionConfig[action.name]
           );
-          return configuredAction?.enabled ? configuredAction : undefined;
+          return enabled ? configuredAction : undefined;
         }
 
         if (action.enabled) {
@@ -50,18 +51,14 @@ export default class ActionList {
 
   private _applyConfigForAction(
     action: Action,
-    actionConfig: ActionConfigValue
-  ): Action | undefined {
-    if (actionConfig === 'off') {
-      return;
-    } else if (Array.isArray(actionConfig)) {
-      let [enabled] = actionConfig;
-      if (enabled === 'off') {
-        return;
-      }
-    } else {
-      action.threshold = actionConfig.threshold;
-      return action;
+    actionConfig: ConfigValue<{ threshold: number }>
+  ): [boolean, Action] {
+    let [enabled, value] = getConfigTuple<{ threshold: number }>(actionConfig);
+
+    if (typeof value.threshold === 'number') {
+      action.threshold = value.threshold;
     }
+
+    return [enabled, action];
   }
 }

--- a/packages/core/src/action-list.ts
+++ b/packages/core/src/action-list.ts
@@ -1,6 +1,6 @@
 import { ActionConfig, TaskConfig, ConfigValue } from './types/config';
 import { Action } from './types/tasks';
-import { getConfigTuple } from './config';
+import { parseConfigTuple } from './config';
 
 /**
  * @class ActionList
@@ -53,7 +53,7 @@ export default class ActionList {
     action: Action,
     actionConfig: ConfigValue<{ threshold: number }>
   ): [boolean, Action] {
-    let [enabled, value] = getConfigTuple<{ threshold: number }>(actionConfig);
+    let [enabled, value] = parseConfigTuple<{ threshold: number }>(actionConfig);
 
     if (typeof value.threshold === 'number') {
       action.threshold = value.threshold;

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -4,7 +4,7 @@ import { TaskContext, TaskIdentifier, TaskMetaData } from './types/tasks';
 
 import { TaskConfig, ConfigValue } from './types/config';
 import { getShorthandName } from './utils/plugin-name';
-import { getConfigTuple } from './config';
+import { parseConfigTuple } from './config';
 
 export default abstract class BaseTask {
   context: TaskContext;
@@ -49,7 +49,7 @@ export default abstract class BaseTask {
       this.fullyQualifiedTaskName
     ];
 
-    let [enabled, taskConfig] = getConfigTuple<TaskConfig>(config);
+    let [enabled, taskConfig] = parseConfigTuple<TaskConfig>(config);
 
     this.#enabled = enabled;
     this.#config = taskConfig;

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -2,8 +2,9 @@ import * as debug from 'debug';
 
 import { TaskContext, TaskIdentifier, TaskMetaData } from './types/tasks';
 
-import { TaskConfig } from './types/config';
+import { TaskConfig, ConfigValue } from './types/config';
 import { getShorthandName } from './utils/plugin-name';
+import { getConfigTuple } from './config';
 
 export default abstract class BaseTask {
   context: TaskContext;
@@ -12,7 +13,7 @@ export default abstract class BaseTask {
 
   #pluginName: string;
   #config!: TaskConfig;
-  #enabled!: string;
+  #enabled!: boolean;
 
   constructor(pluginName: string, context: TaskContext) {
     this.#pluginName = getShorthandName(pluginName);
@@ -32,7 +33,7 @@ export default abstract class BaseTask {
   get enabled() {
     this._parseConfig();
 
-    return this.#enabled === 'on';
+    return this.#enabled;
   }
 
   private get fullyQualifiedTaskName() {
@@ -44,22 +45,14 @@ export default abstract class BaseTask {
       return;
     }
 
-    let config: 'off' | ['off', TaskConfig] | TaskConfig | undefined = this.context.config.tasks[
+    let config: ConfigValue<TaskConfig> | undefined = this.context.config.tasks[
       this.fullyQualifiedTaskName
     ];
 
-    this.#enabled = 'on';
+    let [enabled, taskConfig] = getConfigTuple<TaskConfig>(config);
 
-    if (typeof config === 'string') {
-      this.#enabled = config;
-    } else if (Array.isArray(config)) {
-      let [enabled, taskConfig] = config;
-
-      this.#enabled = enabled;
-      this.#config = taskConfig;
-    } else {
-      this.#config = config;
-    }
+    this.#enabled = enabled;
+    this.#config = taskConfig;
 
     this.debug('%s enabled: %s', this.constructor.name, this.#enabled);
     this.debug('%s task config: %o', this.constructor.name, this.#config);

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -85,7 +85,7 @@ export function validateConfig(config: CheckupConfig, configPath: string) {
   }
 }
 
-export function getConfigTuple<T extends {}>(configValue: ConfigValue<T>): [boolean, T] {
+export function getConfigTuple<T>(configValue: ConfigValue<T> | undefined): [boolean, T] {
   let enabled: boolean = true;
   let value: T = {} as T;
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -85,7 +85,7 @@ export function validateConfig(config: CheckupConfig, configPath: string) {
   }
 }
 
-export function getConfigTuple<T>(configValue: ConfigValue<T> | undefined): [boolean, T] {
+export function parseConfigTuple<T>(configValue: ConfigValue<T> | undefined): [boolean, T] {
   let enabled: boolean = true;
   let value: T = {} as T;
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -3,7 +3,7 @@ import * as Ajv from 'ajv';
 import { existsSync, readJsonSync, writeJsonSync } from 'fs-extra';
 import { join, resolve } from 'path';
 
-import { CheckupConfig } from '../types/config';
+import { CheckupConfig, ConfigValue } from '../types/config';
 import CheckupError from '../errors/checkup-error';
 import { white } from 'chalk';
 import { normalizePackageName } from '../utils/plugin-name';
@@ -83,4 +83,19 @@ export function validateConfig(config: CheckupConfig, configPath: string) {
       `See ${CONFIG_DOCS_URL} for more information on correct config formats.`
     );
   }
+}
+
+export function getConfigTuple<T extends {}>(configValue: ConfigValue<T>): [boolean, T] {
+  let enabled: boolean = true;
+  let value: T = {} as T;
+
+  if (typeof configValue === 'string') {
+    enabled = configValue === 'on';
+  } else if (Array.isArray(configValue)) {
+    let [enabledStr, val] = configValue;
+    enabled = enabledStr === 'on';
+    value = val;
+  }
+
+  return [enabled, value];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,14 @@ export { getRegisteredParsers, registerParser } from './parsers/registered-parse
 export { createParser as createEslintParser } from './parsers/eslint-parser';
 
 export { loadPlugins } from './loaders/plugin-loader';
-export { readConfig, writeConfig, getConfigPath, mergeConfig, DEFAULT_CONFIG } from './config';
+export {
+  readConfig,
+  writeConfig,
+  getConfigPath,
+  mergeConfig,
+  parseConfigTuple,
+  DEFAULT_CONFIG,
+} from './config';
 
 export { default as CheckupError } from './errors/checkup-error';
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,8 +1,8 @@
-export type ActionConfigValue = { threshold: number } | 'off' | ['off', { threshold: number }];
-export type ActionConfig = Record<string, ActionConfigValue>;
+export type ConfigValue<T extends {}> = 'on' | 'off' | ['on' | 'off', T];
+export type ActionConfig = Record<string, ConfigValue<{ threshold: number }>>;
 export type TaskConfig = { actions?: ActionConfig; [key: string]: any };
 export type CheckupConfig = {
   excludePaths: string[];
   plugins: string[];
-  tasks: Record<string, 'off' | ['off', TaskConfig] | TaskConfig>;
+  tasks: Record<string, ConfigValue<TaskConfig>>;
 };


### PR DESCRIPTION
This PR adds a specific type to represent the common config value pattern we use:

```typescript
type ConfigValue<T extends {}> = 'on' | 'off' | ['on' | 'off', T];
```

This allows us to better represent this common pattern when used in code.

Additionally, I've added a method to handle the common parsing of this type of value:

```typescript
function getConfigTuple<T>(configValue: ConfigValue<T> | undefined): [boolean, T]
```

This allows us to parse the config tuple in a consistent manner, without repeating our code everywhere.

**Note**: This reverses changes to some of the types we made recently, namely the removal of the `'on'` value in config. This is mainly to allow for us to release new tasks/actions etc without having them explicitly enabled. A future PR will introduce the concept of default configuration for tasks, which will allow us to specify whether a task should be enabled by default or not.