### PR TITLE
Adding actions registration system to decouple from task results

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
@@ -1,6 +1,7 @@
 import { CheckupProject, getTaskContext } from '@checkup/test-helpers';
 
 import TemplateLintDisableTask from '../src/tasks/ember-template-lint-disable-task';
+import { evaluateActions } from '../src/actions/ember-template-lint-disable-actions';
 
 describe('ember-template-lint-disable-task', () => {
   let project: CheckupProject;
@@ -88,8 +89,10 @@ describe('ember-template-lint-disable-task', () => {
       })
     ).run();
 
-    expect(result.actions).toHaveLength(1);
-    expect(result.actions).toMatchInlineSnapshot(`
+    let actions = evaluateActions(result);
+
+    expect(actions).toHaveLength(1);
+    expect(actions).toMatchInlineSnapshot(`
       Array [
         Object {
           "defaultThreshold": 2,

--- a/packages/checkup-plugin-ember/__tests__/ember-test-type-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-test-type-task-test.ts
@@ -2,6 +2,7 @@ import { EmberProject, stdout, getTaskContext } from '@checkup/test-helpers';
 import { getPluginName } from '@checkup/core';
 
 import EmberTestTypesTask from '../src/tasks/ember-test-types-task';
+import { evaluateActions } from '../src/actions/ember-test-types-actions';
 
 const TESTS = {
   application: {
@@ -149,8 +150,10 @@ describe('ember-test-types-task', () => {
       })
     ).run();
 
-    expect(result.actions).toHaveLength(1);
-    expect(result.actions).toMatchInlineSnapshot(`
+    let actions = evaluateActions(result);
+
+    expect(actions).toHaveLength(1);
+    expect(actions).toMatchInlineSnapshot(`
       Array [
         Object {
           "defaultThreshold": 0.01,

--- a/packages/checkup-plugin-ember/package.json
+++ b/packages/checkup-plugin-ember/package.json
@@ -36,7 +36,8 @@
       "@oclif/plugin-help"
     ],
     "hooks": {
-      "register-tasks": "./lib/hooks/register-tasks"
+      "register-tasks": "./lib/hooks/register-tasks",
+      "register-actions": "./lib/hooks/register-actions"
     }
   },
   "publishConfig": {

--- a/packages/checkup-plugin-ember/src/actions/ember-template-lint-disable-actions.ts
+++ b/packages/checkup-plugin-ember/src/actions/ember-template-lint-disable-actions.ts
@@ -1,0 +1,18 @@
+import { TaskResult, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult) {
+  let actionsEvaluator = new ActionsEvaluator();
+  let summaryResult = taskResult.data[0];
+  let templateLintDisableUsages = summaryResult.count;
+
+  actionsEvaluator.add({
+    name: 'reduce-template-lint-disable-usages',
+    summary: 'Reduce number of template-lint-disable usages',
+    details: `${templateLintDisableUsages} usages of template-lint-disable`,
+    defaultThreshold: 2,
+    items: [`Total template-lint-disable usages: ${templateLintDisableUsages}`],
+    input: templateLintDisableUsages,
+  });
+
+  return actionsEvaluator.evaluate(taskResult.config);
+}

--- a/packages/checkup-plugin-ember/src/actions/ember-test-types-actions.ts
+++ b/packages/checkup-plugin-ember/src/actions/ember-test-types-actions.ts
@@ -1,0 +1,25 @@
+import { TaskResult, ActionsEvaluator, MultiValueResult, toPercent } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult) {
+  let actionsEvaluator = new ActionsEvaluator();
+  let totalSkippedTests = taskResult.data.reduce(
+    (total: number, result: MultiValueResult) => total + result.dataSummary.values.skip,
+    0
+  );
+  let totalTests = taskResult.data.reduce(
+    (total: number, result: MultiValueResult) => total + result.dataSummary.total,
+    0
+  );
+
+  actionsEvaluator.add({
+    name: 'reduce-skipped-tests',
+    summary: 'Reduce number of skipped tests',
+    details: `${toPercent(totalSkippedTests, totalTests)} of tests are skipped`,
+    defaultThreshold: 0.01,
+
+    items: [`Total skipped tests: ${totalSkippedTests}`],
+    input: totalSkippedTests / totalTests,
+  });
+
+  return actionsEvaluator.evaluate(taskResult.config);
+}

--- a/packages/checkup-plugin-ember/src/hooks/register-actions.ts
+++ b/packages/checkup-plugin-ember/src/hooks/register-actions.ts
@@ -1,0 +1,11 @@
+import { Hook } from '@oclif/config';
+import { RegisterActionsArgs } from '@checkup/core';
+import { evaluateActions as evaluateTemplateLint } from '../actions/ember-template-lint-disable-actions';
+import { evaluateActions as evaluateTestTypes } from '../actions/ember-test-types-actions';
+
+const hook: Hook<RegisterActionsArgs> = async function ({ registerActions }: RegisterActionsArgs) {
+  registerActions('ember-template-lint-disables', evaluateTemplateLint);
+  registerActions('ember-test-types', evaluateTestTypes);
+};
+
+export default hook;

--- a/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-dependencies-task-result.ts
@@ -6,8 +6,4 @@ export default class EmberDependenciesTaskResult extends BaseTaskResult implemen
   process(data: SummaryResult[]) {
     this.data = data;
   }
-
-  get hasDependencies() {
-    return this.data.some((dependency) => dependency.count > 0);
-  }
 }

--- a/packages/checkup-plugin-ember/src/results/ember-template-lint-disable-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-template-lint-disable-task-result.ts
@@ -1,27 +1,10 @@
-import { BaseTaskResult, TaskResult, ActionsEvaluator, Action, SummaryResult } from '@checkup/core';
+import { BaseTaskResult, TaskResult, SummaryResult } from '@checkup/core';
 
 export default class EmberTemplateLintDisableTaskResult extends BaseTaskResult
   implements TaskResult {
-  actions: Action[] = [];
-
   data: SummaryResult[] = [];
 
   process(data: SummaryResult[]) {
     this.data = data;
-
-    let actionsEvaluator = new ActionsEvaluator();
-    let summaryResult = this.data[0];
-    let templateLintDisableUsages = summaryResult.count;
-
-    actionsEvaluator.add({
-      name: 'reduce-template-lint-disable-usages',
-      summary: 'Reduce number of template-lint-disable usages',
-      details: `${templateLintDisableUsages} usages of template-lint-disable`,
-      defaultThreshold: 2,
-      items: [`Total template-lint-disable usages: ${templateLintDisableUsages}`],
-      input: templateLintDisableUsages,
-    });
-
-    this.actions = actionsEvaluator.evaluate(this.config);
   }
 }

--- a/packages/checkup-plugin-ember/src/results/ember-test-types-task-result.ts
+++ b/packages/checkup-plugin-ember/src/results/ember-test-types-task-result.ts
@@ -1,38 +1,9 @@
-import {
-  BaseTaskResult,
-  TaskResult,
-  ActionsEvaluator,
-  Action,
-  toPercent,
-  MultiValueResult,
-} from '@checkup/core';
+import { BaseTaskResult, TaskResult, MultiValueResult } from '@checkup/core';
 
 export default class EmberTestTypesTaskResult extends BaseTaskResult implements TaskResult {
-  actions: Action[] = [];
   data: MultiValueResult[] = [];
-  rawData: [] = [];
 
   process(data: MultiValueResult[]) {
     this.data = data;
-    this.rawData = this.data.flatMap((datum) => datum.data) as [];
-
-    let actionsEvaluator = new ActionsEvaluator();
-    let totalSkippedTests = this.data.reduce(
-      (total, result) => total + result.dataSummary.values.skip,
-      0
-    );
-    let totalTests = this.data.reduce((total, result) => total + result.dataSummary.total, 0);
-
-    actionsEvaluator.add({
-      name: 'reduce-skipped-tests',
-      summary: 'Reduce number of skipped tests',
-      details: `${toPercent(totalSkippedTests, totalTests)} of tests are skipped`,
-      defaultThreshold: 0.01,
-
-      items: [`Total skipped tests: ${totalSkippedTests}`],
-      input: totalSkippedTests / totalTests,
-    });
-
-    this.actions = actionsEvaluator.evaluate(this.config);
   }
 }

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -2,6 +2,7 @@ import { getPluginName } from '@checkup/core';
 import { CheckupProject, getTaskContext } from '@checkup/test-helpers';
 
 import EslintDisableTask from '../src/tasks/eslint-disable-task';
+import { evaluateActions } from '../src/actions/eslint-disable-actions';
 
 describe('eslint-disable-task', () => {
   let project: CheckupProject;
@@ -88,8 +89,10 @@ describe('eslint-disable-task', () => {
       })
     ).run();
 
-    expect(result.actions).toHaveLength(1);
-    expect(result.actions![0]).toMatchInlineSnapshot(`
+    let actions = evaluateActions(result);
+
+    expect(actions).toHaveLength(1);
+    expect(actions![0]).toMatchInlineSnapshot(`
       Object {
         "defaultThreshold": 2,
         "details": "3 usages of template-lint-disable",

--- a/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
@@ -4,6 +4,7 @@ import {
   readEslintConfig,
   ACCEPTED_ESLINT_CONFIG_FILES,
 } from '../src/tasks/eslint-summary-task';
+import { evaluateActions } from '../src/actions/eslint-summary-actions';
 import { PackageJson } from 'type-fest';
 import { getPluginName, TaskResult } from '@checkup/core';
 
@@ -62,8 +63,10 @@ describe('eslint-summary-task', () => {
   });
 
   it('returns correct action items if there are too many warnings or errors', async () => {
-    expect(result.actions).toHaveLength(2);
-    expect(result.actions).toMatchInlineSnapshot(`
+    let actions = evaluateActions(result);
+
+    expect(actions).toHaveLength(2);
+    expect(actions).toMatchInlineSnapshot(`
       Array [
         Object {
           "defaultThreshold": 20,

--- a/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
@@ -1,6 +1,7 @@
 import { CheckupProject, getTaskContext } from '@checkup/test-helpers';
 import { getPluginName, TaskResult } from '@checkup/core';
 import OutdatedDependenciesTask from '../src/tasks/outdated-dependencies-task';
+import { evaluateActions } from '../src/actions/outdated-dependency-actions';
 
 // this test actually checks if dependencies are out of date, and will fail if new versions of react and react-dom are released.
 describe('outdated-dependencies-task', () => {
@@ -36,8 +37,10 @@ describe('outdated-dependencies-task', () => {
   });
 
   it('returns correct action items if too many dependencies are out of date (and additional actions for minor/major out of date)', async () => {
-    expect(result.actions).toHaveLength(3);
-    expect(result.actions).toMatchInlineSnapshot(`
+    let actions = evaluateActions(result);
+
+    expect(actions).toHaveLength(3);
+    expect(actions).toMatchInlineSnapshot(`
       Array [
         Object {
           "defaultThreshold": 0.05,

--- a/packages/checkup-plugin-javascript/package.json
+++ b/packages/checkup-plugin-javascript/package.json
@@ -36,7 +36,8 @@
       "@oclif/plugin-help"
     ],
     "hooks": {
-      "register-tasks": "./lib/hooks/register-tasks"
+      "register-tasks": "./lib/hooks/register-tasks",
+      "register-actions": "./lib/hooks/register-actions"
     }
   },
   "publishConfig": {

--- a/packages/checkup-plugin-javascript/src/actions/eslint-disable-actions.ts
+++ b/packages/checkup-plugin-javascript/src/actions/eslint-disable-actions.ts
@@ -1,0 +1,18 @@
+import { TaskResult, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult) {
+  let actionsEvaluator = new ActionsEvaluator();
+  let summaryResult = taskResult.data[0];
+  let eslintDisableUsages = summaryResult.count;
+
+  actionsEvaluator.add({
+    name: 'reduce-eslint-disable-usages',
+    summary: 'Reduce number of eslint-disable usages',
+    details: `${eslintDisableUsages} usages of template-lint-disable`,
+    defaultThreshold: 2,
+    items: [`Total eslint-disable usages: ${eslintDisableUsages}`],
+    input: eslintDisableUsages,
+  });
+
+  return actionsEvaluator.evaluate(taskResult.config);
+}

--- a/packages/checkup-plugin-javascript/src/actions/eslint-summary-actions.ts
+++ b/packages/checkup-plugin-javascript/src/actions/eslint-summary-actions.ts
@@ -1,0 +1,33 @@
+import { TaskResult, ActionsEvaluator, MultiValueResult } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  let errors = taskResult.data.find((result: MultiValueResult) => result.key === 'eslint-errors')!;
+  let warnings = taskResult.data.find(
+    (result: MultiValueResult) => result.key === 'eslint-warnings'
+  )!;
+
+  let errorCount = errors.dataSummary.total;
+  let warningCount = warnings.dataSummary.total;
+
+  actionsEvaluator.add({
+    name: 'reduce-eslint-errors',
+    summary: 'Reduce number of eslint errors',
+    details: `${errorCount} total errors`,
+    defaultThreshold: 20,
+    items: [`Total eslint errors: ${errorCount}`],
+    input: errorCount,
+  });
+
+  actionsEvaluator.add({
+    name: 'reduce-eslint-warnings',
+    summary: 'Reduce number of eslint warnings',
+    details: `${warningCount} total warnings`,
+    defaultThreshold: 20,
+    items: [`Total eslint warnings: ${warningCount}`],
+    input: warningCount,
+  });
+
+  return actionsEvaluator.evaluate(taskResult.config);
+}

--- a/packages/checkup-plugin-javascript/src/actions/outdated-dependency-actions.ts
+++ b/packages/checkup-plugin-javascript/src/actions/outdated-dependency-actions.ts
@@ -1,0 +1,37 @@
+import { TaskResult, ActionsEvaluator, toPercent } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult) {
+  let { values: dependenciesCount, total: totalDependencies } = taskResult.data[0].dataSummary;
+  let outdatedCount = Object.values<number>(dependenciesCount).reduce(
+    (total: number, count: number) => total + count,
+    0
+  );
+  let actionsEvaluator = new ActionsEvaluator();
+
+  actionsEvaluator.add({
+    name: 'reduce-outdated-major-dependencies',
+    summary: 'Update outdated major versions',
+    details: `${dependenciesCount.major} major versions outdated`,
+    defaultThreshold: 0.05,
+    items: [],
+    input: dependenciesCount.major / totalDependencies,
+  });
+  actionsEvaluator.add({
+    name: 'reduce-outdated-minor-dependencies',
+    summary: 'Update outdated minor versions',
+    details: `${dependenciesCount.minor} minor versions outdated`,
+    defaultThreshold: 0.05,
+    items: [],
+    input: dependenciesCount.minor / totalDependencies,
+  });
+  actionsEvaluator.add({
+    name: 'reduce-outdated-dependencies',
+    summary: 'Update outdated versions',
+    details: `${toPercent(outdatedCount / totalDependencies)} of versions outdated`,
+    defaultThreshold: 0.2,
+    items: [],
+    input: outdatedCount / totalDependencies,
+  });
+
+  return actionsEvaluator.evaluate(taskResult.config);
+}

--- a/packages/checkup-plugin-javascript/src/hooks/register-actions.ts
+++ b/packages/checkup-plugin-javascript/src/hooks/register-actions.ts
@@ -1,0 +1,14 @@
+import { Hook } from '@oclif/config';
+import { RegisterActionsArgs } from '@checkup/core';
+
+import { evaluateActions as evaluateESLintDisables } from '../actions/eslint-disable-actions';
+import { evaluateActions as evaluateESLintSummary } from '../actions/eslint-summary-actions';
+import { evaluateActions as evaluateOutdatedDependencies } from '../actions/outdated-dependency-actions';
+
+const hook: Hook<RegisterActionsArgs> = async function ({ registerActions }: RegisterActionsArgs) {
+  registerActions('eslint-disables', evaluateESLintDisables);
+  registerActions('eslint-summary', evaluateESLintSummary);
+  registerActions('outdated-dependencies', evaluateOutdatedDependencies);
+};
+
+export default hook;

--- a/packages/checkup-plugin-javascript/src/results/eslint-disable-task-result.ts
+++ b/packages/checkup-plugin-javascript/src/results/eslint-disable-task-result.ts
@@ -1,25 +1,9 @@
-import { BaseTaskResult, TaskResult, ActionsEvaluator, Action, SummaryResult } from '@checkup/core';
+import { BaseTaskResult, TaskResult, SummaryResult } from '@checkup/core';
 
 export default class EslintDisableTaskResult extends BaseTaskResult implements TaskResult {
-  actions: Action[] = [];
   data: SummaryResult[] = [];
 
   process(data: SummaryResult[]) {
     this.data = data;
-
-    let actionsEvaluator = new ActionsEvaluator();
-    let summaryResult = this.data[0];
-    let eslintDisableUsages = summaryResult.count;
-
-    actionsEvaluator.add({
-      name: 'reduce-eslint-disable-usages',
-      summary: 'Reduce number of eslint-disable usages',
-      details: `${eslintDisableUsages} usages of template-lint-disable`,
-      defaultThreshold: 2,
-      items: [`Total eslint-disable usages: ${eslintDisableUsages}`],
-      input: eslintDisableUsages,
-    });
-
-    this.actions = actionsEvaluator.evaluate(this.config);
   }
 }

--- a/packages/checkup-plugin-javascript/src/results/eslint-summary-task-result.ts
+++ b/packages/checkup-plugin-javascript/src/results/eslint-summary-task-result.ts
@@ -1,44 +1,9 @@
-import {
-  BaseTaskResult,
-  TaskResult,
-  ActionsEvaluator,
-  Action,
-  MultiValueResult,
-} from '@checkup/core';
+import { BaseTaskResult, TaskResult, MultiValueResult } from '@checkup/core';
 
 export default class EslintSummaryTaskResult extends BaseTaskResult implements TaskResult {
-  actions: Action[] = [];
   data: MultiValueResult[] = [];
 
   process(data: MultiValueResult[]) {
     this.data = data;
-
-    let actionsEvaluator = new ActionsEvaluator();
-
-    let errors = this.data.find((result) => result.key === 'eslint-errors')!;
-    let warnings = this.data.find((result) => result.key === 'eslint-warnings')!;
-
-    let errorCount = errors.dataSummary.total;
-    let warningCount = warnings.dataSummary.total;
-
-    actionsEvaluator.add({
-      name: 'reduce-eslint-errors',
-      summary: 'Reduce number of eslint errors',
-      details: `${errorCount} total errors`,
-      defaultThreshold: 20,
-      items: [`Total eslint errors: ${errorCount}`],
-      input: errorCount,
-    });
-
-    actionsEvaluator.add({
-      name: 'reduce-eslint-warnings',
-      summary: 'Reduce number of eslint warnings',
-      details: `${warningCount} total warnings`,
-      defaultThreshold: 20,
-      items: [`Total eslint warnings: ${warningCount}`],
-      input: warningCount,
-    });
-
-    this.actions = actionsEvaluator.evaluate(this.config);
   }
 }

--- a/packages/checkup-plugin-javascript/src/results/outdated-dependencies-task-result.ts
+++ b/packages/checkup-plugin-javascript/src/results/outdated-dependencies-task-result.ts
@@ -1,48 +1,9 @@
-import {
-  BaseTaskResult,
-  TaskResult,
-  toPercent,
-  ActionsEvaluator,
-  Action,
-  MultiValueResult,
-} from '@checkup/core';
+import { BaseTaskResult, TaskResult, MultiValueResult } from '@checkup/core';
 
 export default class OutdatedDependenciesTaskResult extends BaseTaskResult implements TaskResult {
-  actions: Action[] = [];
   data: MultiValueResult[] = [];
 
   process(data: MultiValueResult[]) {
     this.data = data;
-
-    let { values: dependenciesCount, total: totalDependencies } = this.data[0].dataSummary;
-    let outdatedCount = Object.values(dependenciesCount).reduce((total, count) => total + count, 0);
-    let actionsEvaluator = new ActionsEvaluator();
-
-    actionsEvaluator.add({
-      name: 'reduce-outdated-major-dependencies',
-      summary: 'Update outdated major versions',
-      details: `${dependenciesCount.major} major versions outdated`,
-      defaultThreshold: 0.05,
-      items: [],
-      input: dependenciesCount.major / totalDependencies,
-    });
-    actionsEvaluator.add({
-      name: 'reduce-outdated-minor-dependencies',
-      summary: 'Update outdated minor versions',
-      details: `${dependenciesCount.minor} minor versions outdated`,
-      defaultThreshold: 0.05,
-      items: [],
-      input: dependenciesCount.minor / totalDependencies,
-    });
-    actionsEvaluator.add({
-      name: 'reduce-outdated-dependencies',
-      summary: 'Update outdated versions',
-      details: `${toPercent(outdatedCount / totalDependencies)} of versions outdated`,
-      defaultThreshold: 0.2,
-      items: [],
-      input: outdatedCount / totalDependencies,
-    });
-
-    this.actions = actionsEvaluator.evaluate(this.config);
   }
 }

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -9,7 +9,6 @@ import {
 } from '@checkup/core';
 import { MetaTaskResult, ReporterArguments } from '../types';
 import { startCase } from 'lodash';
-import { getActions } from './get-actions';
 import ProjectMetaTaskResult from '../results/project-meta-task-result';
 
 let outputMap: { [taskName: string]: (taskResult: TaskResult) => void } = {
@@ -193,7 +192,7 @@ let outputMap: { [taskName: string]: (taskResult: TaskResult) => void } = {
 export function report(args: ReporterArguments) {
   renderMetaTaskResults(args.info);
   renderPluginTaskResults(args.results);
-  renderActionItems(getActions(args.results));
+  renderActionItems(args.actions);
   renderErrors(args.errors);
 }
 

--- a/packages/cli/src/reporters/get-actions.ts
+++ b/packages/cli/src/reporters/get-actions.ts
@@ -1,7 +1,0 @@
-import { Action, TaskResult } from '@checkup/core';
-
-export function getActions(results: TaskResult[]) {
-  return results
-    .filter((taskResult) => taskResult.actions)
-    .flatMap((taskResult) => taskResult.actions) as Action[];
-}

--- a/packages/cli/src/reporters/json-reporter.ts
+++ b/packages/cli/src/reporters/json-reporter.ts
@@ -2,7 +2,6 @@ import { ReporterArguments } from '../types';
 import { ui } from '@checkup/core';
 import { dirname, isAbsolute, resolve } from 'path';
 import { existsSync, mkdirpSync, writeJsonSync } from 'fs-extra';
-import { getActions } from './get-actions';
 
 const date = require('date-and-time');
 
@@ -14,7 +13,7 @@ export function report(args: ReporterArguments) {
     info: Object.assign({}, ...args.info.map((result) => result.toJson())),
     results: args.results.map((result) => result.toJson()),
     errors: args.errors,
-    actions: getActions(args.results),
+    actions: args.actions,
   };
   let { outputFile, cwd } = args.flags!;
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,4 +1,11 @@
-import { JsonMetaTaskResult, TaskIdentifier, RunFlags, TaskResult, TaskError } from '@checkup/core';
+import {
+  JsonMetaTaskResult,
+  TaskIdentifier,
+  RunFlags,
+  TaskResult,
+  TaskError,
+  Action,
+} from '@checkup/core';
 
 export default {};
 
@@ -7,6 +14,7 @@ export interface ReporterArguments {
   info: MetaTaskResult[];
   results: TaskResult[];
   errors: TaskError[];
+  actions: Action[];
 }
 
 export interface MetaTask {

--- a/packages/core/__tests__/actions-evaluator-test.ts
+++ b/packages/core/__tests__/actions-evaluator-test.ts
@@ -1,4 +1,4 @@
-import ActionsEvaluator from '../src/actions-evaluator';
+import ActionsEvaluator from '../src/actions/actions-evaluator';
 
 describe('actions-evaluator', () => {
   it('can add an action to actions', () => {

--- a/packages/core/src/actions/actions-evaluator.ts
+++ b/packages/core/src/actions/actions-evaluator.ts
@@ -1,6 +1,6 @@
-import { TaskConfig, ActionConfig } from './types/config';
-import { parseConfigTuple } from './config';
-import { Action } from './types/tasks';
+import { TaskConfig, ActionConfig } from '../types/config';
+import { parseConfigTuple } from '../config';
+import { Action } from '../types/tasks';
 
 export default class ActionsEvaluator {
   private actions: Action[] = [];

--- a/packages/core/src/actions/registered-actions.ts
+++ b/packages/core/src/actions/registered-actions.ts
@@ -1,0 +1,11 @@
+import { TaskName, TaskResult, Action, ActionsEvaluationResult } from '../types/tasks';
+
+const registeredActions = new Map<TaskName, (taskResult: TaskResult) => Action[]>();
+
+export function getRegisteredActions() {
+  return registeredActions;
+}
+
+export function registerActions(taskName: TaskName, evaluate: ActionsEvaluationResult) {
+  registeredActions.set(taskName, evaluate);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,8 @@ export { default as BaseTaskResult } from './base-task-result';
 
 export { getRegisteredParsers, registerParser } from './parsers/registered-parsers';
 export { createParser as createEslintParser } from './parsers/eslint-parser';
-export { default as ActionsEvaluator } from './actions-evaluator';
+export { getRegisteredActions, registerActions } from './actions/registered-actions';
+export { default as ActionsEvaluator } from './actions/actions-evaluator';
 
 export { loadPlugins } from './loaders/plugin-loader';
 export {

--- a/packages/core/src/parsers/registered-parsers.ts
+++ b/packages/core/src/parsers/registered-parsers.ts
@@ -14,7 +14,7 @@ registeredParsers.set('ember-template-lint', createEmberTemplateLintParser);
 /**
  *
  */
-export function getRegisteredParsers(): Map<ParserName, CreateParser<any, any>> {
+export function getRegisteredParsers() {
   return registeredParsers;
 }
 

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -1,7 +1,7 @@
 import { CreateParser, Parser, ParserName, ParserOptions, ParserReport } from './parsers';
 import { JsonObject, PackageJson } from 'type-fest';
 
-import { CheckupConfig } from './config';
+import { CheckupConfig, TaskConfig } from './config';
 import { FilePathArray } from '../utils/file-path-array';
 import { RunFlags } from './cli';
 
@@ -9,6 +9,12 @@ export type RegisterTaskArgs = {
   context: TaskContext;
   tasks: TaskList;
 };
+
+export type RegisterActionsArgs = {
+  registerActions: (taskName: TaskName, evaluate: ActionsEvaluationResult) => void;
+};
+
+export type ActionsEvaluationResult = (taskResult: TaskResult) => Action[];
 
 interface TaskList {
   registerTask(task: Task): void;
@@ -43,11 +49,16 @@ export interface Action {
 
 export interface TaskResult {
   meta: TaskMetaData;
+  config: TaskConfig;
   data: Record<string, any>;
-  actions?: Action[];
 
   process(data: Record<string, any>): void;
   toJson: () => JsonMetaTaskResult | JsonTaskResult;
+}
+
+export interface NewTaskResult {
+  info: TaskMetaData | TaskIdentifier;
+  result: Record<string, any>;
 }
 
 export type TaskError = {


### PR DESCRIPTION
Part of https://github.com/checkupjs/checkup/issues/558.

Refactors actions to move them out of the `TaskResult` classes in preparation for them to be deleted. 

This wires actions up to run in the same way that task and parser registration works - via hooks.

- Adds a new `register-actions` hook, and allows hooks to register a set of registered actions for tasks
- Evaluates the actions post-task results, which operations more like a pipeline (thanks, @rwjblue!)
- Allows actions to be authored separately from tasks
- Allows for better decoupling and testing of actions
