### PR TITLE
Adding ability to register custom console reporter

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -5,7 +5,7 @@ exports[`task generator generates correct files with JavaScript 1`] = `
 
 export default class MyFooTask extends BaseTask {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = '';
 
 
@@ -66,7 +66,7 @@ exports[`task generator generates correct files with TypeScript for defaults 1`]
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = '';
 
   async run(): Promise<TaskResult> {
@@ -126,7 +126,7 @@ exports[`task generator generates correct files with TypeScript for defaults in 
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = '';
 
   async run(): Promise<TaskResult> {
@@ -186,7 +186,7 @@ exports[`task generator generates correct files with category 1`] = `
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = 'foo';
 
   async run(): Promise<TaskResult> {
@@ -246,7 +246,7 @@ exports[`task generator generates correct files with group 1`] = `
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = 'foo';
   group = 'bar';
 
@@ -307,7 +307,7 @@ exports[`task generator generates correct files with type 1`] = `
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = '';
 
   async run(): Promise<TaskResult> {
@@ -367,7 +367,7 @@ exports[`task generator generates multiple correct files with TypeScript for def
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
-  friendlyTaskName = 'My Foo';
+  taskDisplayName = 'My Foo';
   category = '';
 
   async run(): Promise<TaskResult> {
@@ -413,7 +413,7 @@ exports[`task generator generates multiple correct files with TypeScript for def
 
 export default class MyBarTask extends BaseTask implements Task {
   taskName = 'my-bar';
-  friendlyTaskName = 'My Bar';
+  taskDisplayName = 'My Bar';
   category = '';
 
   async run(): Promise<TaskResult> {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,20 +3,21 @@ import {
   CheckupError,
   OutputFormat,
   RunFlags,
-  TaskContext,
-  TaskError,
-  getConfigPath,
-  getRegisteredParsers,
-  loadPlugins,
-  readConfig,
-  registerParser,
-  registerActions,
-  ui,
-  getFilePaths,
-  Action,
-  getRegisteredActions,
   Task,
   TaskResult,
+  TaskContext,
+  TaskError,
+  Action,
+  loadPlugins,
+  registerParser,
+  registerActions,
+  registerTaskReporter,
+  getFilePaths,
+  getConfigPath,
+  readConfig,
+  getRegisteredParsers,
+  getRegisteredActions,
+  ui,
 } from '@checkup/core';
 
 import { BaseCommand } from '../base-command';
@@ -203,6 +204,10 @@ export default class RunCommand extends BaseCommand {
 
     await this.config.runHook('register-actions', {
       registerActions,
+    });
+
+    await this.config.runHook('register-task-reporter', {
+      registerTaskReporter,
     });
 
     // if excludePaths are provided both via the command line and config, the command line is prioritized

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -226,7 +226,7 @@ function getTaskReporter(taskName: TaskName) {
   if (typeof reporter === 'undefined') {
     throw new CheckupError(
       `Unable to find a console reporter for ${taskName}`,
-      'Add a console reporter using a `register-reporter` hook'
+      'Add a console task reporter using a `register-task-reporter` hook'
     );
   }
 

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -6,6 +6,9 @@ import {
   MultiValueResult,
   DataSummary,
   TaskResult,
+  getRegisteredTaskReporters,
+  TaskName,
+  CheckupError,
 } from '@checkup/core';
 import { MetaTaskResult, ReporterArguments } from '../types';
 import { startCase } from 'lodash';
@@ -209,9 +212,25 @@ function renderPluginTaskResults(pluginTaskResults: TaskResult[]): void {
       currentCategory = taskCategory;
     }
 
-    outputMap[taskResult.info.taskName](taskResult);
+    let reporter = getTaskReporter(taskResult.info.taskName);
+
+    reporter(taskResult);
   });
   ui.blankLine();
+}
+
+function getTaskReporter(taskName: TaskName) {
+  let registeredTaskReporters = getRegisteredTaskReporters();
+  let reporter = outputMap[taskName] || registeredTaskReporters.get(taskName);
+
+  if (typeof reporter === 'undefined') {
+    throw new CheckupError(
+      `Unable to find a console reporter for ${taskName}`,
+      'Add a console reporter using a `register-reporter` hook'
+    );
+  }
+
+  return reporter;
 }
 
 function renderActionItems(actions: Action[]): void {

--- a/packages/cli/templates/src/task/src/tasks/task.js.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.js.ejs
@@ -2,7 +2,7 @@ import { BaseTask } from '@checkup/core';
 
 export default class <%- taskClass %> extends BaseTask {
   taskName = '<%- name %>';
-  friendlyTaskName = '<%- _.startCase(name.split('-').join(' ')) %>';
+  taskDisplayName = '<%- _.startCase(name.split('-').join(' ')) %>';
   category = '<%- category %>';
   <%_ if (group) { _%>
   group = '<%- group %>';

--- a/packages/cli/templates/src/task/src/tasks/task.ts.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.ts.ejs
@@ -2,7 +2,7 @@ import { BaseTask, Task, TaskResult } from '@checkup/core';
 
 export default class <%- taskClass %> extends BaseTask implements Task {
   taskName = '<%- name %>';
-  friendlyTaskName = '<%- _.startCase(name.split('-').join(' ')) %>';
+  taskDisplayName = '<%- _.startCase(name.split('-').join(' ')) %>';
   category = '<%- category %>';
   <%_ if (group) { _%>
   group = '<%- group %>';

--- a/packages/core/src/actions/registered-actions.ts
+++ b/packages/core/src/actions/registered-actions.ts
@@ -1,16 +1,11 @@
-import { TaskName, Action, ActionsEvaluationResult } from '../types/tasks';
-import { TaskResult } from '../types/checkup-result';
-import { TaskConfig } from '../types/config';
+import { TaskName, TaskActionsEvaluator } from '../types/tasks';
 
-const registeredActions = new Map<
-  TaskName,
-  (taskResult: TaskResult, taskConfig: TaskConfig) => Action[]
->();
+const registeredActions = new Map<TaskName, TaskActionsEvaluator>();
 
 export function getRegisteredActions() {
   return registeredActions;
 }
 
-export function registerActions(taskName: TaskName, evaluate: ActionsEvaluationResult) {
+export function registerActions(taskName: TaskName, evaluate: TaskActionsEvaluator) {
   registeredActions.set(taskName, evaluate);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,10 @@ export { getRegisteredParsers, registerParser } from './parsers/registered-parse
 export { createParser as createEslintParser } from './parsers/eslint-parser';
 export { getRegisteredActions, registerActions } from './actions/registered-actions';
 export { default as ActionsEvaluator } from './actions/actions-evaluator';
+export {
+  getRegisteredTaskReporters,
+  registerTaskReporter,
+} from './task-reporters/registered-task-reporters';
 
 export { loadPlugins } from './loaders/plugin-loader';
 export {

--- a/packages/core/src/task-reporters/registered-task-reporters.ts
+++ b/packages/core/src/task-reporters/registered-task-reporters.ts
@@ -1,0 +1,11 @@
+import { TaskName, TaskReporter } from '../types/tasks';
+
+const registeredTaskReporters = new Map<TaskName, TaskReporter>();
+
+export function getRegisteredTaskReporters() {
+  return registeredTaskReporters;
+}
+
+export function registerTaskReporter(taskName: TaskName, report: TaskReporter) {
+  registeredTaskReporters.set(taskName, report);
+}

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -12,10 +12,14 @@ export type RegisterTaskArgs = {
 };
 
 export type RegisterActionsArgs = {
-  registerActions: (taskName: TaskName, evaluate: ActionsEvaluationResult) => void;
+  registerActions: (taskName: TaskName, evaluate: TaskActionsEvaluator) => void;
 };
+export type TaskActionsEvaluator = (taskResult: TaskResult, taskConfig: TaskConfig) => Action[];
 
-export type ActionsEvaluationResult = (taskResult: TaskResult, taskConfig: TaskConfig) => Action[];
+export type RegisterTaskReporterArgs = {
+  registerTaskReporter: (taskName: TaskName, report: TaskReporter) => void;
+};
+export type TaskReporter = (taskResult: TaskResult) => void;
 
 interface TaskList {
   registerTask(task: Task): void;


### PR DESCRIPTION
In order to support backwards compatibility while we move towards component-based console output, and to support any power-user use cases for reporting, we're adding support for registering and defining your own task reporter. Reporters are registered for that task only, and are looked up via `TaskName`.