### PR TITLE
task: Adding v8-compile-cache to speed up CLI perf

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('v8-compile-cache');
+
 const fs = require('fs');
 const path = require('path');
 const project = path.join(__dirname, '../tsconfig.json');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "sloc": "^0.2.1",
     "tmp": "^0.2.1",
     "tslib": "^2",
+    "v8-compile-cache": "^2.1.1",
     "wrap-ansi": "^7.0.0",
     "yeoman-environment": "^2.10.3",
     "yeoman-generator": "^4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9008,6 +9008,11 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
+v8-compile-cache@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
+  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
+
 v8-to-istanbul@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz#22fe35709a64955f49a08a7c7c959f6520ad6f20"


### PR DESCRIPTION
Benchmarking shows a 7.33x improvement in CLI performance by adding `v8-compile-cache`.

```shell
❯ hyperfine 'DISABLE_V8_COMPILE_CACHE=1 ./bin/checkup' './bin/checkup' --ignore-failure
Benchmark #1: DISABLE_V8_COMPILE_CACHE=1 ./bin/checkup
  Time (mean ± σ):       0.3 ms ±   1.0 ms    [User: 0.0 ms, System: 0.2 ms]
  Range (min … max):     0.0 ms …  10.5 ms    504 runs

  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Ignoring non-zero exit code.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark #2: ./bin/checkup
  Time (mean ± σ):       0.2 ms ±   0.7 ms    [User: 0.0 ms, System: 0.1 ms]
  Range (min … max):     0.0 ms …   7.8 ms    504 runs

  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Ignoring non-zero exit code.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  './bin/checkup' ran
    1.64 ± 7.33 times faster than 'DISABLE_V8_COMPILE_CACHE=1 ./bin/checkup'
```