### PR TITLE
Adding actions generator

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-actions-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-actions-test.ts.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actions generator generates correct files with JavaScript 1`] = `
+"import { ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult, taskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}"
+`;
+
+exports[`actions generator generates correct files with JavaScript 2`] = `
+"import { Hook } from '@oclif/config';
+import { getPluginName } from '@checkup/core';
+
+const hook = async function({ context, tasks }) {
+  let pluginName = getPluginName(__dirname);
+};
+
+export default hook;
+"
+`;
+
+exports[`actions generator generates correct files with TypeScript 1`] = `
+"import { TaskResult, TaskConfig, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult, taskConfig: TaskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}"
+`;
+
+exports[`actions generator generates correct files with TypeScript 2`] = `
+"import { Hook } from '@oclif/config';
+import { getPluginName, RegisterTaskArgs } from '@checkup/core';
+
+const hook: Hook<RegisterTaskArgs> = async function({ context, tasks }: RegisterTaskArgs) {
+  let pluginName = getPluginName(__dirname);
+};
+
+export default hook;
+"
+`;
+
+exports[`actions generator generates correct files with TypeScript in custom path 1`] = `
+"import { TaskResult, TaskConfig, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult, taskConfig: TaskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}"
+`;
+
+exports[`actions generator generates correct files with TypeScript in custom path 2`] = `
+"import { Hook } from '@oclif/config';
+import { getPluginName, RegisterTaskArgs } from '@checkup/core';
+
+const hook: Hook<RegisterTaskArgs> = async function({ context, tasks }: RegisterTaskArgs) {
+  let pluginName = getPluginName(__dirname);
+};
+
+export default hook;
+"
+`;
+
+exports[`actions generator generates multiple correct files with TypeScript 1`] = `
+"import { TaskResult, TaskConfig, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult, taskConfig: TaskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}"
+`;
+
+exports[`actions generator generates multiple correct files with TypeScript 2`] = `
+"import { TaskResult, TaskConfig, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult, taskConfig: TaskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}"
+`;
+
+exports[`actions generator generates multiple correct files with TypeScript 3`] = `
+"import { Hook } from '@oclif/config';
+import { getPluginName, RegisterTaskArgs } from '@checkup/core';
+
+const hook: Hook<RegisterTaskArgs> = async function({ context, tasks }: RegisterTaskArgs) {
+  let pluginName = getPluginName(__dirname);
+};
+
+export default hook;
+"
+`;

--- a/packages/cli/__tests__/generators/generate-actions-test.ts
+++ b/packages/cli/__tests__/generators/generate-actions-test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable jest/expect-expect */
+
+import * as helpers from 'yeoman-test';
+import { resolve } from 'path';
+
+import ActionsGenerator from '../../src/generators/actions';
+import { generatePlugin } from '../__utils__/generate-plugin';
+import { testRoot } from '@checkup/test-helpers';
+
+function assertActionsFiles(name: string, dir: string, extension: string = 'ts') {
+  let root = testRoot(dir);
+
+  expect(root.file(`src/actions/${name}-actions.${extension}`).contents).toMatchSnapshot();
+}
+
+function assertPluginFiles(dir: string, extension: string = 'ts') {
+  let root = testRoot(dir);
+
+  expect(root.file(`src/hooks/register-tasks.${extension}`).contents).toMatchSnapshot();
+}
+
+describe('actions generator', () => {
+  it('generates correct files with TypeScript', async () => {
+    let baseDir = await generatePlugin();
+    let dir = await helpers
+      .run(ActionsGenerator, { namespace: 'checkup:actions' })
+      .cd(baseDir)
+      .withOptions({
+        name: 'my-foo',
+      })
+      .withPrompts({
+        taskName: 'foo',
+        typescript: true,
+      });
+
+    assertActionsFiles('my-foo', dir);
+    assertPluginFiles(dir);
+  });
+
+  it('generates correct files with TypeScript in custom path', async () => {
+    let baseDir = await generatePlugin({ path: './lib' });
+    await helpers
+      .run(ActionsGenerator, { namespace: 'checkup:actions' })
+      .cd(resolve(baseDir, '../..'))
+      .withOptions({
+        name: 'my-foo',
+        path: './lib/checkup-plugin-my-plugin',
+      })
+      .withPrompts({
+        taskName: 'foo',
+        typescript: true,
+      });
+
+    assertActionsFiles('my-foo', baseDir);
+    assertPluginFiles(baseDir);
+  });
+
+  it('generates multiple correct files with TypeScript', async () => {
+    let baseDir = await generatePlugin();
+    let dir = await helpers
+      .run(ActionsGenerator, { namespace: 'checkup:actions' })
+      .cd(baseDir)
+      .withOptions({
+        name: 'my-foo',
+      })
+      .withPrompts({
+        taskName: 'foo',
+        typescript: true,
+      });
+
+    dir = await helpers
+      .run(ActionsGenerator, { namespace: 'checkup:actions' })
+      .cd(baseDir)
+      .withOptions({
+        name: 'my-bar',
+      })
+      .withPrompts({
+        taskName: 'foo',
+        typescript: true,
+      });
+
+    assertActionsFiles('my-foo', dir);
+    assertActionsFiles('my-bar', dir);
+    assertPluginFiles(dir);
+  });
+
+  it('generates correct files with JavaScript', async () => {
+    let baseDir = await generatePlugin(
+      { name: 'my-plugin', defaults: false },
+      { typescript: false }
+    );
+    let dir = await helpers
+      .run(ActionsGenerator, { namespace: 'checkup:actions' })
+      .cd(baseDir)
+      .withOptions({
+        name: 'my-foo',
+      })
+      .withPrompts({
+        taskName: 'foo',
+        typescript: false,
+      });
+
+    assertActionsFiles('my-foo', dir, 'js');
+    assertPluginFiles(dir, 'js');
+  });
+});

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -10,7 +10,7 @@ import { createEnv } from 'yeoman-environment';
 import { flags } from '@oclif/command';
 import { CheckupError } from '@checkup/core';
 
-const VALID_GENERATORS = ['config', 'plugin', 'task'];
+const VALID_GENERATORS = ['config', 'plugin', 'task', 'actions'];
 
 export interface Options {
   type: string;
@@ -40,7 +40,7 @@ export default class GenerateCommand extends BaseCommand {
     {
       name: 'type',
       required: true,
-      description: 'type of generator to run (config, plugin, task)',
+      description: 'type of generator to run (config, plugin, task, actions)',
     },
     {
       name: 'name',

--- a/packages/cli/src/generators/actions.ts
+++ b/packages/cli/src/generators/actions.ts
@@ -1,0 +1,109 @@
+import * as _ from 'lodash';
+import * as t from '@babel/types';
+import * as recast from 'recast';
+
+import traverse from '@babel/traverse';
+import { Answers } from 'inquirer';
+import BaseGenerator from './base-generator';
+import { Options } from '../commands/generate';
+import { join } from 'path';
+import { AstTransformer } from '@checkup/core';
+
+interface ActionOptions extends Options {
+  taskName: string;
+  pascalCaseName: string;
+  typescript: boolean;
+}
+
+export default class ActionsGenerator extends BaseGenerator {
+  answers!: Answers;
+
+  constructor(args: any, public options: ActionOptions) {
+    super(args, options);
+  }
+
+  async prompting() {
+    this.headline(`${this.options.name}-actions`);
+
+    const defaults = {
+      typescript: true,
+    };
+
+    if (this.options.defaults) {
+      this.answers = defaults;
+    } else {
+      this.answers = await this.prompt([
+        {
+          type: 'confirm',
+          name: 'typescript',
+          message: 'TypeScript',
+          default: () => true,
+        },
+        {
+          type: 'input',
+          name: 'taskName',
+          message: `Enter the task name that these actions will be associated with (the string value in the taskName property of the task class).`,
+        },
+      ]);
+    }
+
+    this.options.taskName = this.answers.taskName;
+    this.options.pascalCaseName = _.upperFirst(_.camelCase(this.options.name));
+    this.options.typescript = this.answers.typescript;
+  }
+
+  writing() {
+    this.sourceRoot(join(__dirname, '../../templates/src/actions'));
+
+    if (!this.fs.exists(this.destinationPath(`src/hooks/register-actions.${this._ext}`))) {
+      this.fs.copy(
+        this.templatePath(`src/hooks/register-actions.${this._ext}.ejs`),
+        this.destinationPath(`src/hooks/register-actions.${this._ext}`)
+      );
+    }
+
+    this.fs.copyTpl(
+      this.templatePath(`src/actions/actions.${this._ext}.ejs`),
+      this.destinationPath(`src/actions/${this.options.name}-actions.${this._ext}`),
+      this.options
+    );
+
+    this._transformHooks();
+  }
+
+  private _transformHooks() {
+    let hooksDestinationPath = this.destinationPath(`src/hooks/register-actions.${this._ext}`);
+
+    let registerActionsSource = this.fs.read(hooksDestinationPath);
+    let registerActionStatement = t.expressionStatement(
+      t.callExpression(t.identifier('registerActions'), [
+        t.stringLiteral(this.options.taskName),
+        t.identifier(`evaluate${this.options.pascalCaseName}Actions`),
+      ])
+    );
+
+    let newActionImportSpecifier = t.importSpecifier(
+      t.identifier(`evaluate${this.options.pascalCaseName}Actions`),
+      t.identifier('evaluateActions')
+    );
+    let tasksImportDeclaration: t.ImportDeclaration = t.importDeclaration(
+      [newActionImportSpecifier],
+      t.stringLiteral(`../actions/${this.options.name}-actions`)
+    );
+
+    let code = new AstTransformer(registerActionsSource, recast.parse, traverse, {
+      parser: require('recast/parsers/typescript'),
+    })
+      .traverse({
+        Program(path) {
+          path.node.body.splice(1, 0, tasksImportDeclaration);
+        },
+        BlockStatement(path) {
+          path.node.body.push(registerActionStatement);
+        },
+      })
+      .generate();
+
+    this.fs.write(hooksDestinationPath, code);
+  }
+}

--- a/packages/cli/src/generators/base-generator.ts
+++ b/packages/cli/src/generators/base-generator.ts
@@ -8,6 +8,10 @@ import { resolve } from 'path';
 import { existsSync, mkdirSync } from 'fs';
 
 export default class GeneratorBase extends Generator {
+  protected get _ext() {
+    return this.options.typescript ? 'ts' : 'js';
+  }
+
   constructor(args: string | string[], options: Options) {
     super(args, options);
 

--- a/packages/cli/src/generators/plugin.ts
+++ b/packages/cli/src/generators/plugin.ts
@@ -11,10 +11,6 @@ const PLUGIN_DIR_PATTERN = /checkup-plugin-.*/;
 export default class PluginGenerator extends BaseGenerator {
   answers!: Answers;
 
-  private get _ext() {
-    return this.options.typescript ? 'ts' : 'js';
-  }
-
   private get _destinationPath() {
     let cwd = process.cwd();
 

--- a/packages/cli/src/generators/task.ts
+++ b/packages/cli/src/generators/task.ts
@@ -23,10 +23,6 @@ export default class TaskGenerator extends BaseGenerator {
   packageJson!: PackageJson;
   answers!: Answers;
 
-  private get _ext() {
-    return this.options.typescript ? 'ts' : 'js';
-  }
-
   constructor(args: any, public options: TaskOptions) {
     super(args, options);
   }

--- a/packages/cli/templates/src/actions/src/actions/actions.js.ejs
+++ b/packages/cli/templates/src/actions/src/actions/actions.js.ejs
@@ -1,0 +1,7 @@
+import { ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult, taskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}

--- a/packages/cli/templates/src/actions/src/actions/actions.ts.ejs
+++ b/packages/cli/templates/src/actions/src/actions/actions.ts.ejs
@@ -1,0 +1,7 @@
+import { TaskResult, TaskConfig, ActionsEvaluator } from '@checkup/core';
+
+export function evaluateActions(taskResult: TaskResult, taskConfig: TaskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  return actionsEvaluator.evaluate(taskConfig);
+}

--- a/packages/cli/templates/src/actions/src/hooks/register-actions.js.ejs
+++ b/packages/cli/templates/src/actions/src/hooks/register-actions.js.ejs
@@ -1,0 +1,6 @@
+import { Hook } from '@oclif/config';
+
+const hook = async function ({ registerActions }) {
+};
+
+export default hook;

--- a/packages/cli/templates/src/actions/src/hooks/register-actions.ts.ejs
+++ b/packages/cli/templates/src/actions/src/hooks/register-actions.ts.ejs
@@ -1,0 +1,7 @@
+import { Hook } from '@oclif/config';
+import { RegisterActionsArgs } from '@checkup/core';
+
+const hook: Hook<RegisterActionsArgs> = async function ({ registerActions }: RegisterActionsArgs) {
+};
+
+export default hook;


### PR DESCRIPTION
Allows for generating actions hooks and associated actions files.

```shell
❯ checkup generate actions my-foo
Generating my-foo-actions (checkup v0.3.2)
? TypeScript Yes
? Enter the task name that these actions will be associated with (the string value in the taskName property of the task class)
. foo
 conflict src/hooks/register-actions.ts
? Overwrite src/hooks/register-actions.ts? overwrite
    force src/hooks/register-actions.ts
   create src/actions/my-foo-actions.ts
```