### PR TITLE
Getting paths in CLI via threads

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -12,12 +12,13 @@ import {
   registerParser,
   registerActions,
   registerTaskReporter,
-  getFilePaths,
+  getFilePathsAsync,
   getConfigPath,
   readConfig,
   getRegisteredParsers,
   getRegisteredActions,
   ui,
+  FilePathArray,
 } from '@checkup/core';
 
 import { BaseCommand } from '../base-command';
@@ -229,7 +230,9 @@ export default class RunCommand extends BaseCommand {
       parsers: getRegisteredParsers(),
       config: this.checkupConfig,
       pkg: getPackageJson(this.runFlags.cwd),
-      paths: getFilePaths(this.runFlags.cwd, this.runArgs, excludePaths),
+      paths: FilePathArray.from(
+        await getFilePathsAsync(this.runFlags.cwd, this.runArgs, excludePaths)
+      ) as FilePathArray,
     });
 
     await this.registerDefaultTasks(taskContext);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export { default as AstTransformer } from './ast/ast-transformer';
 export { getPluginName, normalizePackageName, getShorthandName } from './utils/plugin-name';
 export { exec } from './utils/exec';
 export { ui } from './utils/ui';
-export { getFilePaths } from './utils/get-paths';
+export { getFilePaths, getFilePathsAsync } from './utils/get-paths';
 export { FilePathArray } from './utils/file-path-array';
 
 export { byRuleId, byRuleIds, bySeverity } from './data/filters';


### PR DESCRIPTION
The UI is frozen when running the CLI, which gives the impression that things are stalled. This defeats the entire purpose of the UI spinner, which is supposed to indicate that work is in progress.

Adding a worker thread for the walkSync where we expand globs helps with this.