### PR TITLE
Prioritizing cli args for turning tasks on

### DIFF
--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -163,6 +163,25 @@ File Count Task
 "
 `;
 
+exports[`@checkup/cli normal cli output should run a task if its passed in via command line, even if it is turned "off" in config 1`] = `
+"
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
+
+This project is 0 days old, with 0 days active days, 0 commits and 0 files.
+
+checkup v0.0.0
+config c88c290095f76e0b55cc190c876eaa8f
+
+=== Fake
+
+File Count Task
+
+
+
+
+"
+`;
+
 exports[`@checkup/cli normal cli output should run multiple tasks if the tasks option is specified with multiple tasks 1`] = `
 "
 Checkup report generated for checkup-app v0.0.0 (6 files analyzed)

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -134,6 +134,23 @@ describe('@checkup/cli', () => {
       _resetTasksForTesting();
     });
 
+    it(
+      'should run a task if its passed in via command line, even if it is turned "off" in config',
+      async () => {
+        _registerTaskForTesting(new FileCountTask(getTaskContext()));
+
+        project.addCheckupConfig({ tasks: { 'fake/file-count': 'off' } });
+        project.writeSync();
+
+        await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir]);
+
+        expect(stdout()).toMatchSnapshot();
+        project.dispose();
+        _resetTasksForTesting();
+      },
+      TEST_TIMEOUT
+    );
+
     it('should use the config at the config path if provided', async () => {
       const anotherProject = new CheckupProject('another-project');
 

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -16,7 +16,7 @@ export default abstract class BaseTask {
 
   _pluginName: string;
   _config!: TaskConfig;
-  _enabled!: boolean;
+  _enabledViaConfig!: boolean;
 
   constructor(pluginName: string, context: TaskContext) {
     this._pluginName = getShorthandName(pluginName);
@@ -34,7 +34,11 @@ export default abstract class BaseTask {
   get enabled() {
     this._parseConfig();
 
-    return this._enabled;
+    let enabledViaFlag = this.context.cliFlags.task?.includes(this.fullyQualifiedTaskName) || false;
+    let enabled = this._enabledViaConfig || enabledViaFlag;
+
+    this.debug('%s enabled: %s', this.fullyQualifiedTaskName, enabled);
+    return enabled;
   }
 
   get fullyQualifiedTaskName() {
@@ -64,10 +68,9 @@ export default abstract class BaseTask {
 
     let [enabled, taskConfig] = parseConfigTuple<TaskConfig>(config);
 
-    this._enabled = enabled;
+    this._enabledViaConfig = enabled;
     this._config = taskConfig;
 
-    this.debug('%s enabled: %s', this.fullyQualifiedTaskName, this._enabled);
     this.debug('%s task config: %O', this.fullyQualifiedTaskName, this._config);
   }
 }


### PR DESCRIPTION
Currently, if a task `foo` is set to "off" in config, but checkup is run via `checkup --task foo` the task doesnt run. The command line args override config for excludepaths, and it should work the same way for tasks. Now, if a task is passed in via command line arg, it will always run, regardless of config value