### PR TITLE
Fixing checkup-result types and ensuring results use typed output

### DIFF
--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -84,19 +84,23 @@ exports[`@checkup/cli normal cli output should output checkup result in JSON 1`]
       },
       \\"version\\": \\"0.0.0\\",
       \\"schema\\": 1,
+      \\"args\\": {
+        \\"paths\\": []
+      },
       \\"flags\\": {
         \\"format\\": \\"json\\",
         \\"outputFile\\": \\"\\"
       }
     },
-    \\"analyzedFilesCount\\": [
+    \\"analyzedFiles\\": [
       \\"/.checkuprc\\",
       \\"/.eslintrc.js\\",
       \\"/index.hbs\\",
       \\"/index.js\\",
       \\"/package-lock.json\\",
       \\"/package.json\\"
-    ]
+    ],
+    \\"analyzedFilesCount\\": 6
   },
   \\"results\\": [
     {

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -35,8 +35,12 @@ describe('project-meta-task', () => {
 
       expect(taskResult.toJson()).toMatchInlineSnapshot(`
         Object {
-          "analyzedFilesCount": FilePathArray [],
+          "analyzedFiles": FilePathArray [],
+          "analyzedFilesCount": 0,
           "cli": Object {
+            "args": Object {
+              "paths": Array [],
+            },
             "config": Object {
               "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
               "excludePaths": Array [],
@@ -85,8 +89,12 @@ describe('project-meta-task', () => {
 
       expect(result.toJson()).toMatchInlineSnapshot(`
         Object {
-          "analyzedFilesCount": FilePathArray [],
+          "analyzedFiles": FilePathArray [],
+          "analyzedFilesCount": 0,
           "cli": Object {
+            "args": Object {
+              "paths": Array [],
+            },
             "config": Object {
               "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
               "excludePaths": Array [],

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -19,6 +19,7 @@ import {
   getRegisteredActions,
   ui,
   FilePathArray,
+  CheckupResult,
 } from '@checkup/core';
 
 import { BaseCommand } from '../base-command';
@@ -30,7 +31,8 @@ import { getPackageJson } from '../utils/get-package-json';
 import { getReporter } from '../reporters/get-reporter';
 import LinesOfCodeTask from '../tasks/lines-of-code-task';
 import ProjectMetaTask from '../tasks/project-meta-task';
-import * as chalk from 'chalk';
+import { getCheckupResult } from '../get-checkup-result';
+import { reportAvailableTasks } from '../reporters/console-reporter';
 
 let __tasksForTesting: Set<Task> = new Set<Task>();
 
@@ -249,23 +251,17 @@ export default class RunCommand extends BaseCommand {
 
   private report() {
     let errors = [...this.metaTaskErrors, ...this.pluginTaskErrors];
-    let generateReport = getReporter(this.runFlags.format as OutputFormat);
-    generateReport({
-      flags: this.runFlags,
-      info: this.metaTaskResults,
-      results: this.pluginTaskResults,
+    let checkupResult: CheckupResult = getCheckupResult(
+      this.metaTaskResults,
+      this.pluginTaskResults,
       errors,
-      actions: this.actions,
-    });
+      this.actions
+    );
+    let generateReport = getReporter(this.runFlags.format as OutputFormat);
+    generateReport(checkupResult, this.runFlags);
   }
 
   private printAvailableTasks() {
-    ui.blankLine();
-    ui.log(chalk.bold.white('AVAILABLE TASKS'));
-    ui.blankLine();
-    this.pluginTasks.fullyQualifiedTaskNames.forEach((taskName) => {
-      ui.log(`  ${taskName}`);
-    });
-    ui.blankLine();
+    reportAvailableTasks(this.pluginTasks);
   }
 }

--- a/packages/cli/src/get-checkup-result.ts
+++ b/packages/cli/src/get-checkup-result.ts
@@ -1,0 +1,16 @@
+import { CheckupResult, TaskResult, TaskError, Action } from '@checkup/core';
+import { MetaTaskResult } from './types';
+
+export function getCheckupResult(
+  info: MetaTaskResult[],
+  results: TaskResult[],
+  errors: TaskError[],
+  actions: Action[]
+): CheckupResult {
+  return {
+    info: Object.assign({}, ...info.map((result) => result.toJson())),
+    results,
+    errors,
+    actions,
+  };
+}

--- a/packages/cli/src/reporters/json-reporter.ts
+++ b/packages/cli/src/reporters/json-reporter.ts
@@ -1,5 +1,4 @@
-import { ReporterArguments } from '../types';
-import { ui } from '@checkup/core';
+import { ui, CheckupResult, RunFlags } from '@checkup/core';
 import { dirname, isAbsolute, resolve } from 'path';
 import { existsSync, mkdirpSync, writeJsonSync } from 'fs-extra';
 
@@ -8,23 +7,17 @@ const date = require('date-and-time');
 export const TODAY = date.format(new Date(), 'YYYY-MM-DD-HH_mm_ss');
 export const DEFAULT_OUTPUT_FILENAME = `checkup-report-${TODAY}`;
 
-export function report(args: ReporterArguments) {
-  let resultJson = {
-    info: Object.assign({}, ...args.info.map((result) => result.toJson())),
-    results: args.results,
-    errors: args.errors,
-    actions: args.actions,
-  };
-  let { outputFile, cwd } = args.flags!;
+export function report(result: CheckupResult, flags?: RunFlags) {
+  let { outputFile, cwd } = flags!;
 
   if (outputFile) {
     let outputPath = getOutputPath(outputFile, cwd);
 
-    writeJsonSync(outputPath, resultJson);
+    writeJsonSync(outputPath, result);
 
     ui.log(outputPath);
   } else {
-    ui.styledJSON(resultJson);
+    ui.styledJSON(result);
   }
 }
 

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -1,27 +1,11 @@
-import { MetaTaskResult, RepositoryInfo } from '../types';
+import { MetaTaskResult } from '../types';
 
 import BaseMetaTaskResult from '../base-meta-task-result';
-import { CheckupConfig, RunFlags } from '@checkup/core';
+import { CheckupResult } from '@checkup/core';
 import { JsonObject } from 'type-fest';
 
 export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
-  data!: {
-    project: {
-      name: string;
-      version: string;
-      repository: RepositoryInfo;
-    };
-
-    cli: {
-      configHash: string;
-      config: CheckupConfig;
-      version: string;
-      schema: number;
-      flags: Partial<RunFlags>;
-    };
-
-    analyzedFilesCount: string[];
-  };
+  data!: CheckupResult['info'];
 
   toJson() {
     return this.data as JsonObject;

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -42,6 +42,7 @@ export default class ProjectMetaTask implements MetaTask {
     let repositoryInfo = await getRepositoryInfo(this.context.cliFlags.cwd);
 
     let { config, task, format, outputFile, excludePaths } = this.context.cliFlags;
+    let analyzedFiles = normalizePaths(this.context.paths, this.context.cliFlags.cwd);
 
     result.data = {
       project: {
@@ -55,6 +56,9 @@ export default class ProjectMetaTask implements MetaTask {
         config: this.context.config,
         version: getVersion(),
         schema: 1,
+        args: {
+          paths: this.context.cliArguments,
+        },
         flags: {
           config,
           task,
@@ -64,7 +68,8 @@ export default class ProjectMetaTask implements MetaTask {
         },
       },
 
-      analyzedFilesCount: normalizePaths(this.context.paths, this.context.cliFlags.cwd),
+      analyzedFiles,
+      analyzedFilesCount: analyzedFiles.length,
     };
 
     return result;

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,21 +1,6 @@
-import {
-  JsonMetaTaskResult,
-  TaskIdentifier,
-  RunFlags,
-  TaskError,
-  Action,
-  TaskResult,
-} from '@checkup/core';
+import { JsonMetaTaskResult, TaskIdentifier } from '@checkup/core';
 
 export default {};
-
-export interface ReporterArguments {
-  flags?: RunFlags;
-  info: MetaTaskResult[];
-  results: TaskResult[];
-  errors: TaskError[];
-  actions: Action[];
-}
 
 export interface MetaTask {
   meta: TaskIdentifier;

--- a/packages/core/src/types/checkup-result.ts
+++ b/packages/core/src/types/checkup-result.ts
@@ -64,10 +64,18 @@ export interface CheckupResult {
       configHash: string;
       config: CheckupConfig;
       version: string;
+      args: {
+        paths: string[];
+      };
       flags: {
-        paths: [];
+        config?: string;
+        task?: string[];
+        format: string;
+        outputFile?: string;
+        excludePaths?: string[];
       };
     };
+    analyzedFiles: string[];
     analyzedFilesCount: number;
   };
   results: TaskResult[];


### PR DESCRIPTION
Some cleanup around the result type. There were some misalignments with the `CheckupResult` and the actual output. This change cleans that up, and fixes some oddly named output properties.