### PR TITLE
[bugfix] Fixing eslint-summary task so it only lints files passed in

### DIFF
--- a/packages/checkup-plugin-javascript/__tests__/__snapshots__/eslint-summary-task-test.ts.snap
+++ b/packages/checkup-plugin-javascript/__tests__/__snapshots__/eslint-summary-task-test.ts.snap
@@ -13,7 +13,7 @@ Object {
       "data": Array [
         Object {
           "column": 32,
-          "filePath": "/foo.js",
+          "filePath": "/included-path.js",
           "line": 2,
           "message": "Missing semicolon.",
           "ruleId": "semi",
@@ -34,7 +34,7 @@ Object {
       "data": Array [
         Object {
           "column": 9,
-          "filePath": "/foo.js",
+          "filePath": "/included-path.js",
           "line": 2,
           "message": "Unexpected var, use let or const instead.",
           "ruleId": "no-var",

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -49,7 +49,7 @@ export class EslintSummaryTask extends BaseTask implements Task {
   }
 
   async run(): Promise<TaskResult> {
-    let report = await this._eslintParser.execute([this.context.cliFlags.cwd]);
+    let report = await this._eslintParser.execute(this.context.paths.filterByGlob('**/*.js'));
     let transformedData = buildLintResultData(report, this.context.cliFlags.cwd);
 
     let errorsResult = buildDerivedValueResult(


### PR DESCRIPTION
There was a bug in eslint-summary task where it was linting all files, not just the paths passed in