### PR TITLE
Fixing eslint-disable-task to use recast (with correct babel plugins) vs. raw babel

### DIFF
--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -50,6 +50,13 @@ describe('eslint-disable-task', () => {
             "count": 3,
             "data": Array [
               Object {
+                "column": 19,
+                "filePath": "/index.js",
+                "line": 6,
+                "message": "eslint-disable is not allowed",
+                "ruleId": "no-eslint-disable",
+              },
+              Object {
                 "column": 4,
                 "filePath": "/index.js",
                 "line": 2,
@@ -60,13 +67,6 @@ describe('eslint-disable-task', () => {
                 "column": 4,
                 "filePath": "/index.js",
                 "line": 3,
-                "message": "eslint-disable is not allowed",
-                "ruleId": "no-eslint-disable",
-              },
-              Object {
-                "column": 19,
-                "filePath": "/index.js",
-                "line": 6,
                 "message": "eslint-disable is not allowed",
                 "ruleId": "no-eslint-disable",
               },

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -21,6 +21,17 @@ describe('eslint-disable-task', () => {
     }
     `;
 
+    project.files['decorator.js'] = `
+      /* eslint-disable */
+
+      @decorated
+      export default class Bar {
+        barBaz() {
+          return baz.toLowerCase();
+        }
+      }
+    `;
+
     project.writeSync();
   });
 
@@ -47,8 +58,15 @@ describe('eslint-disable-task', () => {
         },
         "result": Array [
           Object {
-            "count": 3,
+            "count": 4,
             "data": Array [
+              Object {
+                "column": 6,
+                "filePath": "/decorator.js",
+                "line": 2,
+                "message": "eslint-disable is not allowed",
+                "ruleId": "no-eslint-disable",
+              },
               Object {
                 "column": 19,
                 "filePath": "/index.js",
@@ -95,10 +113,10 @@ describe('eslint-disable-task', () => {
     expect(actions![0]).toMatchInlineSnapshot(`
       Object {
         "defaultThreshold": 2,
-        "details": "3 usages of template-lint-disable",
-        "input": 3,
+        "details": "4 usages of template-lint-disable",
+        "input": 4,
         "items": Array [
-          "Total eslint-disable usages: 3",
+          "Total eslint-disable usages: 4",
         ],
         "name": "reduce-eslint-disable-usages",
         "summary": "Reduce number of eslint-disable usages",

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -10,7 +10,6 @@ import {
 
 import * as t from '@babel/types';
 import { parse, visit } from 'recast';
-import { parse as babelParser } from '@babel/parser';
 import { Visitor } from 'ast-types';
 
 const fs = require('fs');
@@ -70,9 +69,7 @@ async function getEslintDisables(filePaths: string[], cwd: string) {
           parse,
           visit,
           {
-            parser: {
-              parse: babelParser,
-            },
+            parser: require('recast/parsers/babel'),
           }
         );
 


### PR DESCRIPTION
Using babel parse/traverse requires us to configure the babel plugins manually. Recast already does this automatically, so switching back to using that.