### PR TITLE
Fixing missing dep in checkup-plugin-javascript

### DIFF
--- a/packages/checkup-plugin-javascript/package.json
+++ b/packages/checkup-plugin-javascript/package.json
@@ -5,6 +5,7 @@
   "author": "Cara Kessler @carakessler",
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
+    "@babel/parser": "^7.11.3",
     "@checkup/core": "^0.7.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
https://github.com/checkupjs/checkup/pull/651
^^ this introduced a dependency on @babel/parser but didnt add it to package.json

When running the eslint-disables task now, it throws an error :
```
Taskname        Error
eslint-disables Cannot find module 'recast/parsers/babel'
                Require stack:
                - /Users/ckessler/voyager-web_trunk/node_modules/checkup-plugin-javascript/lib/tasks/eslint-disable-task.js
                - /Users/ckessler/voyager-web_trunk/node_modules/checkup-plugin-javascript/lib/hooks/register-tasks.js
                - /Users/ckessler/voyager-web_trunk/node_modules/@oclif/config/lib/config.js
                - /Users/ckessler/voyager-web_trunk/node_modules/@oclif/config/lib/index.js
                - /Users/ckessler/voyager-web_trunk/node_modules/@oclif/command/lib/command.js
                - /Users/ckessler/voyager-web_trunk/node_modules/@oclif/command/lib/index.js
                - /Users/ckessler/voyager-web_trunk/node_modules/@checkup/cli/lib/index.js
                - /Users/ckessler/voyager-web_trunk/scripts/checkup/generate-checkup-report.js

```
This fixes that