### PR TITLE
Ensuring colors in graphs are visually distinct

### DIFF
--- a/packages/core/src/utils/ui.ts
+++ b/packages/core/src/utils/ui.ts
@@ -109,7 +109,7 @@ export const ui = Object.assign(ux, {
     const colors = this.colors();
 
     segments.forEach((segment, i) => {
-      segment.color = colors[i];
+      segment.color = colors[i + 3];
     });
 
     const { completedSegments, incompleteSegments } = calculateSectionBar(segments, total, width);
@@ -148,7 +148,7 @@ export const ui = Object.assign(ux, {
     return colors[Math.floor(Math.random() * colors.length)];
   },
 
-  colors(range: number = 50) {
+  colors(range: number = 70) {
     const ANSI_CODE_START = 33;
 
     // eslint-disable-next-line unicorn/no-useless-undefined


### PR DESCRIPTION
Previously, the colors that rendered the graphs were being incremented by 1 in a color palette. this led to the colors often not being visually distinct. fixed that by incrementing colors by 3

Before (hard to distinguish between greens on the graph) 
<img width="546" alt="Screen Shot 2020-08-17 at 4 43 29 PM" src="https://user-images.githubusercontent.com/3287102/90706594-57664980-e24a-11ea-96ca-54d28398c9b6.png">

After
<img width="587" alt="Screen Shot 2020-08-19 at 6 32 58 PM" src="https://user-images.githubusercontent.com/3287102/90706646-78c73580-e24a-11ea-9b68-546459fa3c6d.png">
