### PR TITLE
Extends error output to include stack traces

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -6,7 +6,8 @@ exports[`task generator generates correct files with JavaScript 1`] = `
 export default class MyFooTask extends BaseTask {
   taskName = 'my-foo';
   taskDisplayName = 'My Foo';
-  category = '';
+  category = 'foo';
+  group = 'bar';
 
 
   async run() {

--- a/packages/cli/__tests__/generators/generate-task-test.ts
+++ b/packages/cli/__tests__/generators/generate-task-test.ts
@@ -83,6 +83,8 @@ describe('task generator', () => {
       })
       .withPrompts({
         typescript: false,
+        category: 'foo',
+        group: 'bar',
       });
 
     assertTaskFiles('my-foo', dir, 'js');

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -2,6 +2,8 @@ import TaskList from '../src/task-list';
 import { getTaskContext } from '@checkup/test-helpers';
 import { BaseTask, Task, TaskContext, TaskResult } from '@checkup/core';
 
+const STABLE_ERROR = new Error('Something went wrong in this task');
+
 class InsightsTaskHigh extends BaseTask implements Task {
   taskName = 'insights-task-high';
   taskDisplayName = 'Insights Task High';
@@ -95,7 +97,7 @@ class ErrorTask extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<TaskResult> {
-    throw new Error('Something went wrong in this task');
+    throw STABLE_ERROR;
   }
 }
 
@@ -300,6 +302,6 @@ describe('TaskList', () => {
     expect(results).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].taskName).toEqual('fake/error-task');
-    expect(errors[0].error).toEqual('Something went wrong in this task');
+    expect(errors[0].error).toEqual(STABLE_ERROR);
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
     "@oclif/plugin-help": "^3",
     "@types/sloc": "^0.2.0",
     "chalk": "^4.0.0",
+    "clean-stack": "^3.0.0",
     "convert-hrtime": "^3.0.0",
     "date-and-time": "^0.14.1",
     "debug": "^4.1.1",

--- a/packages/cli/src/meta-task-list.ts
+++ b/packages/cli/src/meta-task-list.ts
@@ -40,7 +40,7 @@ export default class MetaTaskList {
     try {
       result = await task.run();
     } catch (error) {
-      this.addError(task.meta.taskName, error.message);
+      this.addError(task.meta.taskName, error);
     }
 
     this.debug('%s run done', task.meta.taskName);
@@ -56,7 +56,7 @@ export default class MetaTaskList {
       try {
         result = await task.run();
       } catch (error) {
-        this.addError(task.meta.taskName, error.message);
+        this.addError(task.meta.taskName, error);
       }
 
       this.debug('%s run done', task.meta.taskName);
@@ -72,7 +72,7 @@ export default class MetaTaskList {
     return pMap([...this._entries.values()], fn);
   }
 
-  private addError(taskName: TaskName, error: string) {
+  private addError(taskName: TaskName, error: Error) {
     this._errors.push({ taskName, error });
   }
 }

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -15,6 +15,7 @@ import {
 } from '@checkup/core';
 import { yellow, bold } from 'chalk';
 import TaskList from '../task-list';
+import * as cleanStack from 'clean-stack';
 
 let outputMap: { [taskName: string]: (taskResult: TaskResult) => void } = {
   'ember-test-types': function (taskResult: TaskResult) {
@@ -229,7 +230,15 @@ function renderInfo(info: CheckupResult['info']) {
 
 function renderErrors(errors: TaskError[]) {
   if (errors.length > 0) {
-    ui.table(errors, { taskName: {}, error: {} });
+    ui.table(
+      errors.map((taskError) => {
+        return {
+          taskName: taskError.taskName,
+          stack: cleanStack(taskError.error.stack || ''),
+        };
+      }),
+      { taskName: {}, stack: { header: 'Error' } }
+    );
   }
 }
 

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -129,7 +129,7 @@ export default class TaskList {
     try {
       result = await this._runTask(task);
     } catch (error) {
-      this.addError(task.fullyQualifiedTaskName, error.message);
+      this.addError(task.fullyQualifiedTaskName, error);
     }
 
     this.debug('%s run done', task.fullyQualifiedTaskName);
@@ -152,7 +152,7 @@ export default class TaskList {
       try {
         result = await this._runTask(task);
       } catch (error) {
-        this.addError(task.fullyQualifiedTaskName, error.message);
+        this.addError(task.fullyQualifiedTaskName, error);
       }
 
       this.debug('%s run done', task.fullyQualifiedTaskName);
@@ -222,7 +222,7 @@ export default class TaskList {
     return values;
   }
 
-  private addError(taskName: TaskName, error: string) {
+  private addError(taskName: TaskName, error: Error) {
     this._errors.push({ taskName, error });
   }
 }

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -56,7 +56,7 @@ export interface Action {
 
 export type TaskError = {
   taskName: TaskName;
-  error: string;
+  error: Error;
 };
 
 export interface TaskContext {


### PR DESCRIPTION
The console error output, when a task throws an error, only contained the error message. This change extends that to include the error stack, which allows for easier debugging of failing tasks.

![Screen Shot 2020-09-15 at 8 54 17 AM](https://user-images.githubusercontent.com/180990/93234404-1a01b880-f731-11ea-9d34-5c075ba1bf28.png)
 
Implements #522 