### PR TITLE
Fixes node API to return stdout from runCommand

### DIFF
--- a/packages/cli/__tests__/commands/run-error-test.ts
+++ b/packages/cli/__tests__/commands/run-error-test.ts
@@ -18,7 +18,7 @@ describe('@checkup/cli', () => {
 
     it('should correctly report error when no config detected', async () => {
       await expect(
-        runCommand(['run', '--cwd', project.baseDir])
+        runCommand(['run', '--cwd', project.baseDir], { testing: true })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Could not find a checkup config in the given path: ${project.baseDir}/.checkuprc."`
       );
@@ -31,7 +31,9 @@ describe('@checkup/cli', () => {
       });
       project.writeSync();
 
-      await expect(runCommand(['run', '--cwd', project.baseDir])).rejects.toThrow(
+      await expect(
+        runCommand(['run', '--cwd', project.baseDir], { testing: true })
+      ).rejects.toThrow(
         `Config in ${project.baseDir}/.checkuprc is invalid.
 
 ${white.bold('Details')}: data should have required property 'tasks'.`
@@ -45,7 +47,9 @@ ${white.bold('Details')}: data should have required property 'tasks'.`
       });
       project.writeSync();
 
-      await expect(runCommand(['run', '--cwd', project.baseDir])).rejects.toThrow(
+      await expect(
+        runCommand(['run', '--cwd', project.baseDir], { testing: true })
+      ).rejects.toThrow(
         `Config in ${project.baseDir}/.checkuprc is invalid.
 
 ${white.bold('Details')}: data.tasks should be object.`
@@ -57,7 +61,7 @@ ${white.bold('Details')}: data.tasks should be object.`
       project.writeSync();
 
       await expect(
-        runCommand(['run', '--task', 'foo', '--cwd', project.baseDir])
+        runCommand(['run', '--task', 'foo', '--cwd', project.baseDir], { testing: true })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Cannot find the foo task."`);
     });
   });

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -67,7 +67,7 @@ describe('@checkup/cli', () => {
     it(
       'should output checkup result',
       async () => {
-        await runCommand(['run', '--cwd', project.baseDir]);
+        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
 
         expect(stdout()).toMatchSnapshot();
       },
@@ -75,7 +75,7 @@ describe('@checkup/cli', () => {
     );
 
     it('should output checkup result in JSON', async () => {
-      await runCommand(['run', '--format', 'json', '--cwd', project.baseDir]);
+      await runCommand(['run', '--format', 'json', '--cwd', project.baseDir], { testing: true });
 
       let output = normalizePath(stdout().trim(), project.baseDir);
 
@@ -93,15 +93,18 @@ describe('@checkup/cli', () => {
       async () => {
         let tmp = createTmpDir();
 
-        await runCommand([
-          'run',
-          '--format',
-          'json',
-          `--outputFile`,
-          join(tmp, 'my-checkup-file.json'),
-          '--cwd',
-          project.baseDir,
-        ]);
+        await runCommand(
+          [
+            'run',
+            '--format',
+            'json',
+            `--outputFile`,
+            join(tmp, 'my-checkup-file.json'),
+            '--cwd',
+            project.baseDir,
+          ],
+          { testing: true }
+        );
 
         let outputPath = stdout().trim();
 
@@ -116,7 +119,9 @@ describe('@checkup/cli', () => {
     it('should run a single task if the tasks option is specified with a single task', async () => {
       _registerTaskForTesting(new FileCountTask(getTaskContext()));
 
-      await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir]);
+      await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir], {
+        testing: true,
+      });
 
       expect(stdout()).toMatchSnapshot();
       _resetTasksForTesting();
@@ -126,7 +131,9 @@ describe('@checkup/cli', () => {
       _registerTaskForTesting(new FileCountTask(getTaskContext()));
 
       process.env.CHECKUP_TIMING = '1';
-      await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir]);
+      await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir], {
+        testing: true,
+      });
 
       expect(stdout()).toContain('Task Timings');
       process.env.CHECKUP_TIMING = undefined;
@@ -137,15 +144,10 @@ describe('@checkup/cli', () => {
       _registerTaskForTesting(new FileCountTask(getTaskContext()));
       _registerTaskForTesting(new FooTask(getTaskContext()));
 
-      await runCommand([
-        'run',
-        '--task',
-        'fake/file-count',
-        '--task',
-        'fake/foo',
-        '--cwd',
-        project.baseDir,
-      ]);
+      await runCommand(
+        ['run', '--task', 'fake/file-count', '--task', 'fake/foo', '--cwd', project.baseDir],
+        { testing: true }
+      );
 
       expect(stdout()).toMatchSnapshot();
       _resetTasksForTesting();
@@ -159,7 +161,9 @@ describe('@checkup/cli', () => {
         project.addCheckupConfig({ tasks: { 'fake/file-count': 'off' } });
         project.writeSync();
 
-        await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir]);
+        await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir], {
+          testing: true,
+        });
 
         expect(stdout()).toMatchSnapshot();
         project.dispose();
@@ -174,13 +178,10 @@ describe('@checkup/cli', () => {
       anotherProject.addCheckupConfig();
       anotherProject.writeSync();
 
-      await runCommand([
-        'run',
-        '--config',
-        join(anotherProject.baseDir, '.checkuprc'),
-        '--cwd',
-        project.baseDir,
-      ]);
+      await runCommand(
+        ['run', '--config', join(anotherProject.baseDir, '.checkuprc'), '--cwd', project.baseDir],
+        { testing: true }
+      );
 
       expect(stdout()).toMatchSnapshot();
       anotherProject.dispose();
@@ -204,21 +205,16 @@ describe('@checkup/cli', () => {
         });
 
         project.writeSync();
-        await runCommand([
-          'run',
-          '**/*.hbs',
-          '**baz/**',
-          '--tasks',
-          'file-count',
-          '--cwd',
-          project.baseDir,
-        ]);
+        await runCommand(
+          ['run', '**/*.hbs', '**baz/**', '--tasks', 'file-count', '--cwd', project.baseDir],
+          { testing: true }
+        );
         let filteredRun = stdout();
         expect(filteredRun).toMatchSnapshot();
 
         clearStdout();
 
-        await runCommand(['run', '--cwd', project.baseDir]);
+        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
         let unFilteredRun = stdout();
         expect(unFilteredRun).toMatchSnapshot();
 
@@ -234,7 +230,7 @@ describe('@checkup/cli', () => {
         project.addCheckupConfig({ excludePaths: ['**/*.hbs'] });
         project.writeSync();
 
-        await runCommand(['run', '--cwd', project.baseDir]);
+        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
         let filteredRun = stdout();
         expect(filteredRun).toMatchSnapshot();
 
@@ -243,7 +239,7 @@ describe('@checkup/cli', () => {
         project.addCheckupConfig({ excludePaths: [] });
         project.writeSync();
 
-        await runCommand(['run', '--cwd', project.baseDir]);
+        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
         let unFilteredRun = stdout();
         expect(unFilteredRun).toMatchSnapshot();
 
@@ -257,14 +253,10 @@ describe('@checkup/cli', () => {
     it(
       'should use the excludePaths provided by the command line',
       async () => {
-        await runCommand([
-          'run',
-          '--cwd',
-          project.baseDir,
-          '--excludePaths',
-          '**/*.hbs',
-          '**/*.js',
-        ]);
+        await runCommand(
+          ['run', '--cwd', project.baseDir, '--excludePaths', '**/*.hbs', '**/*.js'],
+          { testing: true }
+        );
 
         let hbsJsFilteredRun = stdout();
 
@@ -272,7 +264,9 @@ describe('@checkup/cli', () => {
 
         clearStdout();
 
-        await runCommand(['run', '--cwd', project.baseDir, '--excludePaths', '**/*.hbs']);
+        await runCommand(['run', '--cwd', project.baseDir, '--excludePaths', '**/*.hbs'], {
+          testing: true,
+        });
 
         let hbsFilteredRun = stdout();
         expect(hbsFilteredRun).toMatchSnapshot();
@@ -288,7 +282,9 @@ describe('@checkup/cli', () => {
         project.addCheckupConfig({ excludePaths: ['**/*.hbs'] });
         project.writeSync();
 
-        await runCommand(['run', '--cwd', project.baseDir, '--excludePaths', '**/*.js']);
+        await runCommand(['run', '--cwd', project.baseDir, '--excludePaths', '**/*.js'], {
+          testing: true,
+        });
 
         let jsFilteredRun = stdout();
 
@@ -296,7 +292,7 @@ describe('@checkup/cli', () => {
 
         clearStdout();
 
-        await runCommand(['run', '--cwd', project.baseDir]);
+        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
 
         let hbsFilteredRun = stdout();
         expect(hbsFilteredRun).toMatchSnapshot();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,8 @@
     "recast": "^0.20.3",
     "shorthash": "^0.0.2",
     "sloc": "^0.2.1",
+    "stdout-monkey": "^1.1.0",
+    "strip-ansi": "^6.0.0",
     "tmp": "^0.2.1",
     "tslib": "^2",
     "v8-compile-cache": "^2.1.1",

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -11,10 +11,13 @@ let root = require.resolve('.');
 
 export async function runCommand(args: string[] | string, opts: loadConfig.Options = {}) {
   let output: string;
+  let patch;
 
-  let patch = stdout((str: string) => {
-    output = stripAnsi(str);
-  });
+  if (!opts.testing) {
+    patch = stdout((str: string) => {
+      output = stripAnsi(str);
+    });
+  }
 
   let config = await Config.load(opts.root || root);
 
@@ -24,9 +27,13 @@ export async function runCommand(args: string[] | string, opts: loadConfig.Optio
   await config.runHook('init', { id, argv: extra });
   await config.runCommand(id, extra);
 
-  patch.restore();
+  if (!opts.testing) {
+    patch.restore();
 
-  return { stdout: output! };
+    return { stdout: output! };
+  }
+
+  return;
 }
 
 export namespace loadConfig {
@@ -34,5 +41,6 @@ export namespace loadConfig {
   export interface Options {
     root?: string;
     reset?: boolean;
+    testing?: boolean;
   }
 }

--- a/types/stdout-monkey.d.ts
+++ b/types/stdout-monkey.d.ts
@@ -1,0 +1,1 @@
+declare module 'stdout-monkey';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6122,10 +6122,98 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash._basebind@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basebind/-/lodash._basebind-2.4.1.tgz#e940b9ebdd27c327e0a8dab1b55916c5341e9575"
+  integrity sha1-6UC5690nwyfgqNqxtVkWxTQelXU=
+  dependencies:
+    lodash._basecreate "~2.4.1"
+    lodash._setbinddata "~2.4.1"
+    lodash._slice "~2.4.1"
+    lodash.isobject "~2.4.1"
+
+lodash._basecreate@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz#f8e6f5b578a9e34e541179b56b8eeebf4a287e08"
+  integrity sha1-+Ob1tXip405UEXm1a47uv0oofgg=
+  dependencies:
+    lodash._isnative "~2.4.1"
+    lodash.isobject "~2.4.1"
+    lodash.noop "~2.4.1"
+
+lodash._basecreatecallback@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz#7d0b267649cb29e7a139d0103b7c11fae84e4851"
+  integrity sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=
+  dependencies:
+    lodash._setbinddata "~2.4.1"
+    lodash.bind "~2.4.1"
+    lodash.identity "~2.4.1"
+    lodash.support "~2.4.1"
+
+lodash._basecreatewrapper@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz#4d31f2e7de7e134fbf2803762b8150b32519666f"
+  integrity sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=
+  dependencies:
+    lodash._basecreate "~2.4.1"
+    lodash._setbinddata "~2.4.1"
+    lodash._slice "~2.4.1"
+    lodash.isobject "~2.4.1"
+
+lodash._createwrapper@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz#51d6957973da4ed556e37290d8c1a18c53de1607"
+  integrity sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=
+  dependencies:
+    lodash._basebind "~2.4.1"
+    lodash._basecreatewrapper "~2.4.1"
+    lodash._slice "~2.4.1"
+    lodash.isfunction "~2.4.1"
+
+lodash._isnative@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._isnative/-/lodash._isnative-2.4.1.tgz#3ea6404b784a7be836c7b57580e1cdf79b14832c"
+  integrity sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=
+
+lodash._objecttypes@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz#7c0b7f69d98a1f76529f890b0cdb1b4dfec11c11"
+  integrity sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
+lodash._setbinddata@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz#f7c200cd1b92ef236b399eecf73c648d17aa94d2"
+  integrity sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=
+  dependencies:
+    lodash._isnative "~2.4.1"
+    lodash.noop "~2.4.1"
+
+lodash._shimisplainobject@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._shimisplainobject/-/lodash._shimisplainobject-2.4.1.tgz#01ec93b2ee63e59f1aa83899ac6fa0905ac7596f"
+  integrity sha1-AeyTsu5j5Z8aqDiZrG+gkFrHWW8=
+  dependencies:
+    lodash.forin "~2.4.1"
+    lodash.isfunction "~2.4.1"
+
+lodash._slice@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._slice/-/lodash._slice-2.4.1.tgz#745cf41a53597b18f688898544405efa2b06d90f"
+  integrity sha1-dFz0GlNZexj2iImFREBe+isG2Q8=
+
+lodash.bind@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-2.4.1.tgz#5d19fa005c8c4d236faf4742c7b7a1fcabe29267"
+  integrity sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=
+  dependencies:
+    lodash._createwrapper "~2.4.1"
+    lodash._slice "~2.4.1"
 
 lodash.camelcase@4.3.0:
   version "4.3.0"
@@ -6137,10 +6225,43 @@ lodash.find@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
   integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
 
+lodash.forin@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-2.4.1.tgz#8089eaed7d25b08672b7c66fd07ac55d062320eb"
+  integrity sha1-gInq7X0lsIZyt8Zv0HrFXQYjIOs=
+  dependencies:
+    lodash._basecreatecallback "~2.4.1"
+    lodash._objecttypes "~2.4.1"
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.identity@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.identity/-/lodash.identity-2.4.1.tgz#6694cffa65fef931f7c31ce86c74597cf560f4f1"
+  integrity sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE=
+
+lodash.isfunction@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz#2cfd575c73e498ab57e319b77fa02adef13a94d1"
+  integrity sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=
+
+lodash.isobject@^2.4.1, lodash.isobject@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
+  integrity sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=
+  dependencies:
+    lodash._objecttypes "~2.4.1"
+
+lodash.isplainobject@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-2.4.1.tgz#ac7385e2ea9ac0321f30dc3b8032a6d2231a8011"
+  integrity sha1-rHOF4uqawDIfMNw7gDKm0iMagBE=
+  dependencies:
+    lodash._isnative "~2.4.1"
+    lodash._shimisplainobject "~2.4.1"
 
 lodash.kebabcase@4.1.1, lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -6152,6 +6273,11 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.noop@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-2.4.1.tgz#4fb54f816652e5ae10e8f72f717a388c7326538a"
+  integrity sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=
+
 lodash.snakecase@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
@@ -6161,6 +6287,13 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.support@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.support/-/lodash.support-2.4.1.tgz#320e0b67031673c28d7a2bb5d9e0331a45240515"
+  integrity sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=
+  dependencies:
+    lodash._isnative "~2.4.1"
 
 lodash.template@^4.4.0:
   version "4.5.0"
@@ -8508,6 +8641,13 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
+stdout-monkey@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stdout-monkey/-/stdout-monkey-1.1.0.tgz#661c2a2368341bb7fc264abd3f28bb0db95d76c6"
+  integrity sha1-ZhwqI2g0G7f8Jkq9Pyi7DblddsY=
+  dependencies:
+    utils-type "^0.5.2"
+
 stdout-stderr@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/stdout-stderr/-/stdout-stderr-0.1.13.tgz#54e3450f3d4c54086a49c0c7f8786a44d1844b6f"
@@ -9045,10 +9185,25 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.11.0, type-fest@^0.13.1, type-fest@^0.16.0, type-fest@^0.6.0, type-fest@^0.8.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
-  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860"
+  integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -9231,6 +9386,14 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+utils-type@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/utils-type/-/utils-type-0.5.2.tgz#b49557d35198c2d2925d34f49cfdda5f369a384d"
+  integrity sha1-tJVX01GYwtKSXTT0nP3aXzaaOE0=
+  dependencies:
+    lodash.isobject "^2.4.1"
+    lodash.isplainobject "^2.4.1"
 
 uuid@8.3.0:
   version "8.3.0"


### PR DESCRIPTION
The current (albeit rudamentary) Node API's `runCommand` function doesn't return stdout, so doesn't 'feel' like a real API. This PR fixes that so that it correctly returns a value. 

This is effectively a temporary solution to enable the Node API until a full refactor can take place. There are non-trivial issues to address with a refactor, as there's some tight coupling with oclif's APIs.