### PR TITLE
Bug fixes

### DIFF
--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -187,7 +187,7 @@ function getTaskReporter(taskResult: Result[]) {
   return reporter;
 }
 
-function renderEmptyResult(taskResult: Result) {
+export function renderEmptyResult(taskResult: Result) {
   ui.value({
     title: taskResult.message.properties?.consoleMessage || taskResult.properties?.taskDisplayName,
     count: 0,

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -1,6 +1,5 @@
 import * as Config from '@oclif/config';
 import * as stdout from 'stdout-monkey';
-const stripAnsi = require('strip-ansi');
 
 const castArray = <T>(input?: T | T[]): T[] => {
   if (input === undefined) return [];
@@ -15,7 +14,7 @@ export async function runCommand(args: string[] | string, opts: loadConfig.Optio
 
   if (!opts.testing) {
     patch = stdout((str: string) => {
-      output = stripAnsi(str);
+      output += str;
     });
   }
 

--- a/packages/core/src/data/builders.ts
+++ b/packages/core/src/data/builders.ts
@@ -1,6 +1,6 @@
-import { ESLintMessage, ESLintReport } from '../types/parsers';
+import { ESLintMessage, ESLintReport, ESLintResult } from '../types/parsers';
 import { LintResult, TaskError } from '../types/tasks';
-import { TemplateLintMessage } from '../types/ember-template-lint';
+import { TemplateLintMessage, TemplateLintResult } from '../types/ember-template-lint';
 import { Result, Location, Notification } from 'sarif';
 
 export const NO_RESULTS_FOUND = 'No results found';
@@ -147,6 +147,21 @@ export function buildLintResultDataItem(
     column: message.column,
     ...additionalData,
   };
+}
+
+export function buildLintResultsFromEslintOrTemplateLint(
+  lintResults: (ESLintResult | TemplateLintResult)[],
+  cwd: string
+): LintResult[] {
+  return lintResults.reduce((resultDataItems, lintingResults) => {
+    const messages = (<any>lintingResults.messages).map(
+      (lintMessage: ESLintMessage | TemplateLintMessage) => {
+        return buildLintResultDataItem(lintMessage, cwd, lintingResults.filePath);
+      }
+    );
+    resultDataItems.push(...messages);
+    return resultDataItems;
+  }, [] as LintResult[]);
 }
 
 function getLintRuleId(message: any) {

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -19,7 +19,7 @@ export type TaskActionsEvaluator = (taskResults: Result[], taskConfig: TaskConfi
 export type RegisterTaskReporterArgs = {
   registerTaskReporter: (taskName: TaskName, report: TaskReporter) => void;
 };
-export type TaskReporter = (taskResult: Result) => void;
+export type TaskReporter = (taskResults: Result[]) => void;
 
 interface TaskList {
   registerTask(task: Task): void;


### PR DESCRIPTION
1. Fix runCommand so it captures all of stdout, rather than just last line
2. Export function renderEmptyResult so other reporters can use it
3. TaskReporter takes in array of Results, not just one Result
4. Adding additional helper used a lot in an upgrade of another plugin