### PR TITLE
Adding HTTP support for config loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash": "^4.14.162",
     "@types/node": "^14",
+    "@types/node-fetch": "^2.5.7",
     "@types/tmp": "^0.2.0",
     "@types/yeoman-assert": "^3.1.1",
     "@types/yeoman-test": "^2.0.4",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -13,6 +13,7 @@ import {
   registerTaskReporter,
   getFilePathsAsync,
   getConfigPath,
+  getConfigPathFromOptions,
   readConfig,
   getRegisteredParsers,
   getRegisteredActions,
@@ -197,7 +198,8 @@ export default class RunCommand extends BaseCommand {
     let configPath;
 
     try {
-      configPath = this.runFlags.config || getConfigPath(this.runFlags.cwd);
+      configPath =
+        (await getConfigPathFromOptions(this.runFlags.config)) || getConfigPath(this.runFlags.cwd);
       this.checkupConfig = readConfig(configPath);
 
       let plugins = await loadPlugins(this.checkupConfig.plugins, this.runFlags.cwd);

--- a/packages/core/__tests__/__fixtures__/.checkuprc.json
+++ b/packages/core/__tests__/__fixtures__/.checkuprc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+  "excludePaths": ["**/foo"],
+  "plugins": ["@foo/checkup-plugin-bar"],
+  "tasks": {}
+}

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -1,8 +1,22 @@
-import { getConfigPath, readConfig, writeConfig, parseConfigTuple } from '../src/config';
+import {
+  getConfigPath,
+  readConfig,
+  writeConfig,
+  parseConfigTuple,
+  getConfigPathFromOptions,
+  CONFIG_SCHEMA_URL,
+} from '../src/config';
 import { readJsonSync, writeJsonSync, writeFileSync } from 'fs-extra';
 
 import { DEFAULT_CONFIG } from '../src';
 import { createTmpDir } from '@checkup/test-helpers';
+
+const REMOTE_CONFIG = {
+  $schema: CONFIG_SCHEMA_URL,
+  excludePaths: ['**/foo'],
+  plugins: ['@foo/checkup-plugin-bar'],
+  tasks: {},
+};
 
 describe('config', () => {
   let tmp: string;
@@ -65,6 +79,15 @@ describe('config', () => {
       let config = readConfig(configPath);
 
       expect(config).toEqual(DEFAULT_CONFIG);
+    });
+
+    it('can load a config from an HTTP endpoint', async () => {
+      let configPath = await getConfigPathFromOptions(
+        'https://raw.githubusercontent.com/checkupjs/checkup/http-config/packages/core/__tests__/__fixtures__/.checkuprc.json'
+      );
+      let config = readConfig(configPath!);
+
+      expect(config).toEqual(REMOTE_CONFIG);
     });
 
     it('throws if config with invalid task config string value set invalid string', () => {

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -14,5 +14,5 @@ module.exports = {
       statements: 100,
     },
   },
-  testPathIgnorePatterns: ['/__utils__/'],
+  testPathIgnorePatterns: ['/__fixtures__/'],
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,10 +20,12 @@
     "is-valid-glob": "^1.0.0",
     "lodash": "^4.17.19",
     "micromatch": "^4.0.2",
+    "node-fetch": "^2.3.0",
     "pkg-up": "^3.1.0",
     "recast": "^0.20.4",
     "resolve": "^1.17.0",
     "strip-ansi": "^6.0.0",
+    "tmp": "^0.2.1",
     "type-fest": "^0.16.0",
     "walk-sync": "^2.2.0",
     "wrap-ansi": "^7.0.0"

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -49,7 +49,7 @@ export async function getConfigPathFromOptions(configPath: string | undefined) {
 async function downloadFile(url: string) {
   let response = await fetch(url);
 
-  return JSON.parse(await response.text());
+  return response.json();
 }
 
 export function readConfig(configPath: string) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,7 @@
 import * as Ajv from 'ajv';
-
-import { existsSync, readJsonSync, writeJsonSync } from 'fs-extra';
+import fetch from 'node-fetch';
+import * as tmp from 'tmp';
+import { existsSync, readJsonSync, writeJsonSync, writeJSON } from 'fs-extra';
 import { join, resolve } from 'path';
 
 import { CheckupConfig, ConfigValue } from './types/config';
@@ -26,6 +27,29 @@ export const DEFAULT_CONFIG: CheckupConfig = {
 
 export function getConfigPath(path: string = '') {
   return join(resolve(path), '.checkuprc');
+}
+
+export async function getConfigPathFromOptions(configPath: string | undefined) {
+  if (!configPath) {
+    return;
+  }
+
+  if (configPath.startsWith('http')) {
+    const contents = await downloadFile(configPath);
+    const filePath = tmp.fileSync();
+
+    await writeJSON(filePath.name, contents);
+
+    return filePath.name;
+  } else {
+    configPath;
+  }
+}
+
+async function downloadFile(url: string) {
+  let response = await fetch(url);
+
+  return JSON.parse(await response.text());
 }
 
 export function readConfig(configPath: string) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export {
   readConfig,
   writeConfig,
   getConfigPath,
+  getConfigPathFromOptions,
   mergeConfig,
   parseConfigTuple,
   DEFAULT_CONFIG,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*", "@types/node@>= 8", "@types/node@^14":
   version "14.11.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
@@ -4016,7 +4024,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@3.0.0:
+form-data@3.0.0, form-data@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==


### PR DESCRIPTION
This PR adds support to load configs from HTTP endpoints.

```shell
checkup --config http://my-config-endpoint ...
```

Related to https://github.com/checkupjs/rfcs/pull/3