### PR TITLE
Moving consoleMessage to properties

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
@@ -48,13 +48,11 @@ Array [
   },
   Object {
     "message": Object {
-      "properties": Object {
-        "consoleMessage": "ember addon devDependencies",
-      },
       "text": "No results found",
     },
     "properties": Object {
       "category": "dependencies",
+      "consoleMessage": "ember addon devDependencies",
       "group": "ember",
       "taskDisplayName": "Ember Dependencies",
     },

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -189,7 +189,7 @@ function getTaskReporter(taskResult: Result[]) {
 
 export function renderEmptyResult(taskResult: Result) {
   ui.value({
-    title: taskResult.message.properties?.consoleMessage || taskResult.properties?.taskDisplayName,
+    title: taskResult.properties?.consoleMessage || taskResult.properties?.taskDisplayName,
     count: 0,
   });
 }

--- a/packages/core/src/data/builders.ts
+++ b/packages/core/src/data/builders.ts
@@ -88,7 +88,8 @@ export function buildResultFromLintResult(
 export function buildResultFromPathArray(paths: string[], message: string): Result {
   if (paths.length === 0) {
     return {
-      message: { text: NO_RESULTS_FOUND, properties: { consoleMessage: message } },
+      message: { text: NO_RESULTS_FOUND },
+      properties: { consoleMessage: message },
     };
   }
 
@@ -107,7 +108,8 @@ export function buildResultFromPathArray(paths: string[], message: string): Resu
 export function buildResultFromProperties(data: any[], message: string): Result {
   if (data.length === 0) {
     return {
-      message: { text: NO_RESULTS_FOUND, properties: { consoleMessage: message } },
+      message: { text: NO_RESULTS_FOUND },
+      properties: { consoleMessage: message },
     };
   }
 


### PR DESCRIPTION
`consoleMessage` is what renders to the console when there are 0 results of a check. This was at `message.properties.consoleMessage` for some of the builders, but not the others. Moving all to `properties.consoleMessage` for consistency with reporters