### PR TITLE
Implements new node API to allow for programmatic invocation of Checkup

### DIFF
--- a/packages/cli/__tests__/__snapshots__/checkup-node-api-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/checkup-node-api-test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@checkup/cli node API output should output checkup result 1`] = `
+Object {
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "properties": Object {
+    "actions": Array [],
+    "analyzedFiles": FilePathArray [
+      ".checkuprc",
+      ".eslintrc.js",
+      "index.hbs",
+      "index.js",
+      "package-lock.json",
+      "package.json",
+    ],
+    "analyzedFilesCount": 6,
+    "cli": Object {
+      "args": Object {
+        "paths": Array [],
+      },
+      "config": Object {
+        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+        "excludePaths": Array [],
+        "plugins": Array [],
+        "tasks": Object {},
+      },
+      "configHash": "395b15f7dea0dee193db593e1c6cfb5b",
+      "flags": Object {
+        "config": undefined,
+        "excludePaths": undefined,
+        "format": "stdout",
+        "outputFile": "",
+        "task": undefined,
+      },
+      "schema": 1,
+      "version": "0.0.0",
+    },
+    "project": Object {
+      "name": "checkup-app",
+      "repository": Object {
+        "activeDays": "0 days",
+        "age": "0 days",
+        "linesOfCode": Object {
+          "total": 3,
+          "types": Array [
+            Object {
+              "extension": "js",
+              "total": 2,
+            },
+            Object {
+              "extension": "hbs",
+              "total": 1,
+            },
+          ],
+        },
+        "totalCommits": 0,
+        "totalFiles": 0,
+      },
+      "version": "0.0.0",
+    },
+    "timings": Object {},
+  },
+  "runs": Any<Array>,
+  "version": "2.1.0",
+}
+`;

--- a/packages/cli/__tests__/checkup-node-api-test.ts
+++ b/packages/cli/__tests__/checkup-node-api-test.ts
@@ -1,0 +1,44 @@
+import { Checkup } from '@checkup/cli';
+import { CheckupProject } from '@checkup/test-helpers';
+import { _registerTaskForTesting, _resetTasksForTesting } from '../src/commands/run';
+
+const TEST_TIMEOUT = 100000;
+
+describe('@checkup/cli', () => {
+  describe('node API output', () => {
+    let project: CheckupProject;
+
+    beforeEach(function () {
+      project = new CheckupProject('checkup-app', '0.0.0', (project) => {
+        project.addDependency('react', '^15.0.0');
+        project.addDependency('react-dom', '^15.0.0');
+      });
+      project.files['index.js'] = 'module.exports = {};';
+      project.files['index.hbs'] = '<div>Checkup App</div>';
+
+      project.addCheckupConfig({
+        plugins: [],
+        tasks: {},
+      });
+      project.writeSync();
+      project.gitInit();
+      project.install();
+    });
+
+    afterEach(function () {
+      project.dispose();
+    });
+
+    it(
+      'should output checkup result',
+      async () => {
+        let result = await Checkup.run(['--cwd', project.baseDir]);
+
+        expect(result).toMatchSnapshot({
+          runs: expect.any(Array),
+        });
+      },
+      TEST_TIMEOUT
+    );
+  });
+});

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -50,22 +50,65 @@ config 395b15f7dea0dee193db593e1c6cfb5b
 `;
 
 exports[`@checkup/cli normal cli output should output checkup result in JSON 1`] = `
-Array [
-  Array [
-    Object {
-      "arguments": Array [],
-      "endTimeUtc": "",
-      "environmentVariables": Object {
-        "cwd": "checkup-app",
+Object {
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "properties": Object {
+    "actions": Array [],
+    "analyzedFiles": Array [
+      ".checkuprc",
+      ".eslintrc.js",
+      "index.hbs",
+      "index.js",
+      "package-lock.json",
+      "package.json",
+    ],
+    "analyzedFilesCount": 6,
+    "cli": Object {
+      "args": Object {
+        "paths": Array [],
+      },
+      "config": Object {
+        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+        "excludePaths": Array [],
+        "plugins": Array [],
+        "tasks": Object {},
+      },
+      "configHash": "395b15f7dea0dee193db593e1c6cfb5b",
+      "flags": Object {
         "format": "json",
         "outputFile": "",
       },
-      "executionSuccessful": true,
-      "startTimeUtc": "",
-      "toolExecutionNotifications": Array [],
+      "schema": 1,
+      "version": "0.0.0",
     },
-  ],
-]
+    "project": Object {
+      "name": "checkup-app",
+      "repository": Object {
+        "activeDays": "0 days",
+        "age": "0 days",
+        "linesOfCode": Object {
+          "total": 3,
+          "types": Array [
+            Object {
+              "extension": "js",
+              "total": 2,
+            },
+            Object {
+              "extension": "hbs",
+              "total": 1,
+            },
+          ],
+        },
+        "totalCommits": 0,
+        "totalFiles": 0,
+      },
+      "version": "0.0.0",
+    },
+    "timings": Object {},
+  },
+  "runs": Any<Array>,
+  "version": "2.1.0",
+}
 `;
 
 exports[`@checkup/cli normal cli output should run a single task if the tasks option is specified with a single task 1`] = `

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -68,7 +68,7 @@ describe('@checkup/cli', () => {
     it(
       'should output checkup result',
       async () => {
-        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
+        await runCommand(['run', '--cwd', project.baseDir]);
 
         expect(stdout()).toMatchSnapshot();
       },
@@ -76,10 +76,12 @@ describe('@checkup/cli', () => {
     );
 
     it('should output checkup result in JSON', async () => {
-      await runCommand(['run', '--format', 'json', '--cwd', project.baseDir], { testing: true });
+      await runCommand(['run', '--format', 'json', '--cwd', project.baseDir]);
 
       let output = JSON.parse(normalizePath(stdout().trim(), project.baseDir)) as Log;
-      expect(normalizeInvocationForTesting(output)).toMatchSnapshot();
+      expect(output).toMatchSnapshot({
+        runs: expect.any(Array),
+      });
     });
 
     it(
@@ -208,7 +210,7 @@ describe('@checkup/cli', () => {
 
         clearStdout();
 
-        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
+        await runCommand(['run', '--cwd', project.baseDir]);
         let unFilteredRun = stdout();
         expect(unFilteredRun).toMatchSnapshot();
 
@@ -224,7 +226,7 @@ describe('@checkup/cli', () => {
         project.addCheckupConfig({ excludePaths: ['**/*.hbs'] });
         project.writeSync();
 
-        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
+        await runCommand(['run', '--cwd', project.baseDir]);
         let filteredRun = stdout();
         expect(filteredRun).toMatchSnapshot();
 
@@ -233,7 +235,7 @@ describe('@checkup/cli', () => {
         project.addCheckupConfig({ excludePaths: [] });
         project.writeSync();
 
-        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
+        await runCommand(['run', '--cwd', project.baseDir]);
         let unFilteredRun = stdout();
         expect(unFilteredRun).toMatchSnapshot();
 
@@ -286,7 +288,7 @@ describe('@checkup/cli', () => {
 
         clearStdout();
 
-        await runCommand(['run', '--cwd', project.baseDir], { testing: true });
+        await runCommand(['run', '--cwd', project.baseDir]);
 
         let hbsFilteredRun = stdout();
         expect(hbsFilteredRun).toMatchSnapshot();
@@ -297,17 +299,3 @@ describe('@checkup/cli', () => {
     );
   });
 });
-
-function normalizeInvocationForTesting(output: Log) {
-  return output.runs.map((run) => {
-    return run.invocations?.map((invocation) => {
-      invocation.endTimeUtc = '';
-      if (invocation.environmentVariables) {
-        invocation.environmentVariables.cwd =
-          invocation.environmentVariables?.cwd?.split('/').pop() || '';
-      }
-      invocation.startTimeUtc = '';
-      return invocation;
-    });
-  });
-}

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -192,6 +192,7 @@ export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
   taskDisplayName = 'My Foo';
   category = 'foo';
+  group = 'bar';
 
   async run(): Promise<Result[]> {
     return this.toJson([]);
@@ -307,14 +308,15 @@ export default hook;
 "
 `;
 
-exports[`task generator generates correct files with type 1`] = `
+exports[`task generator generates correct files with typescript 1`] = `
 "import { BaseTask, Task } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
   taskName = 'my-foo';
   taskDisplayName = 'My Foo';
-  category = '';
+  category = 'foo';
+  group = 'bar';
 
   async run(): Promise<Result[]> {
     return this.toJson([]);
@@ -323,7 +325,7 @@ export default class MyFooTask extends BaseTask implements Task {
 "
 `;
 
-exports[`task generator generates correct files with type 2`] = `
+exports[`task generator generates correct files with typescript 2`] = `
 "import { CheckupProject, stdout, getTaskContext } from '@checkup/test-helpers';
 import { getPluginName } from '@checkup/core';
 import MyFooTask from '../src/tasks/my-foo-task';
@@ -354,7 +356,7 @@ describe('my-foo-task', () => {
 "
 `;
 
-exports[`task generator generates correct files with type 3`] = `
+exports[`task generator generates correct files with typescript 3`] = `
 "import { Hook } from '@oclif/config';
 import MyFooTask from '../tasks/my-foo-task';
 import { getPluginName, RegisterTaskArgs } from '@checkup/core';

--- a/packages/cli/__tests__/generators/generate-task-test.ts
+++ b/packages/cli/__tests__/generators/generate-task-test.ts
@@ -91,7 +91,7 @@ describe('task generator', () => {
     assertPluginFiles(dir, 'js');
   });
 
-  it('generates correct files with type', async () => {
+  it('generates correct files with typescript', async () => {
     let baseDir = await generatePlugin();
     let dir = await helpers
       .run(TaskGenerator, { namespace: 'checkup:task' })
@@ -100,7 +100,8 @@ describe('task generator', () => {
         name: 'my-foo',
       })
       .withPrompts({
-        type: 'Insights',
+        category: 'foo',
+        group: 'bar',
       });
 
     assertTaskFiles('my-foo', dir);
@@ -117,6 +118,7 @@ describe('task generator', () => {
       })
       .withPrompts({
         category: 'foo',
+        group: 'bar',
       });
 
     assertTaskFiles('my-foo', dir);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,6 @@
     "recast": "^0.20.4",
     "shorthash": "^0.0.2",
     "sloc": "^0.2.1",
-    "stdout-monkey": "^1.1.0",
     "strip-ansi": "^6.0.0",
     "tmp": "^0.2.1",
     "tslib": "^2",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -112,6 +112,7 @@ export default class RunCommand extends BaseCommand {
   startTime: string = '';
   actions: Action[] = [];
   checkupConfig!: CheckupConfig;
+  cliModeEnabled: boolean = true;
 
   public async init() {
     let { argv, flags } = this.parse(RunCommand);
@@ -126,6 +127,7 @@ export default class RunCommand extends BaseCommand {
     this.startTime = new Date().toJSON();
     this.runArgs = argv;
     this.runFlags = flags;
+    this.cliModeEnabled = process.env.CHECKUP_CLI === '1';
   }
 
   public async run() {
@@ -136,7 +138,7 @@ export default class RunCommand extends BaseCommand {
     if (this.runFlags.listTasks) {
       this.printAvailableTasks();
     } else {
-      if (process.env.CHECKUP_CLI === '1') {
+      if (this.cliModeEnabled) {
         ui.action.start('Checking up on your project');
       }
 
@@ -153,7 +155,7 @@ export default class RunCommand extends BaseCommand {
         this.pluginTasks
       );
 
-      if (process.env.CHECKUP_CLI === '1') {
+      if (this.cliModeEnabled) {
         this.report(log);
         ui.action.stop();
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,11 @@ export function run() {
     args.unshift(DEFAULT_COMMAND);
   }
 
+  process.env.CHECKUP_CLI = '1';
+
   return oclifRun(args);
 }
 
 export { runCommand } from './run-command';
+
+export { default as Checkup } from './commands/run';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,8 @@ export function run() {
     args.unshift(DEFAULT_COMMAND);
   }
 
+  // Used to signal to the oclif commands that we're invoking in
+  // CLI mode - prevents any stdout when invoking Checkup programmatically
   process.env.CHECKUP_CLI = '1';
 
   return oclifRun(args);

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -1,5 +1,4 @@
 import * as Config from '@oclif/config';
-import * as stdout from 'stdout-monkey';
 
 const castArray = <T>(input?: T | T[]): T[] => {
   if (input === undefined) return [];
@@ -9,16 +8,9 @@ const castArray = <T>(input?: T | T[]): T[] => {
 let root = require.resolve('.');
 
 export async function runCommand(args: string[] | string, opts: loadConfig.Options = {}) {
-  let output: string;
-  let patch;
-
+  // Used to signal to the oclif commands that we're invoking in
+  // CLI mode - prevents any stdout when invoking Checkup programmatically
   process.env.CHECKUP_CLI = '1';
-
-  if (!opts.testing) {
-    patch = stdout((str: string) => {
-      output += str;
-    });
-  }
 
   let config = await Config.load(opts.root || root);
 
@@ -27,12 +19,6 @@ export async function runCommand(args: string[] | string, opts: loadConfig.Optio
   const [id, ...extra] = args;
   await config.runHook('init', { id, argv: extra });
   await config.runCommand(id, extra);
-
-  if (!opts.testing) {
-    patch.restore();
-
-    return { stdout: output! };
-  }
 
   return;
 }

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -12,6 +12,8 @@ export async function runCommand(args: string[] | string, opts: loadConfig.Optio
   let output: string;
   let patch;
 
+  process.env.CHECKUP_CLI = '1';
+
   if (!opts.testing) {
     patch = stdout((str: string) => {
       output += str;

--- a/types/stdout-monkey.d.ts
+++ b/types/stdout-monkey.d.ts
@@ -1,1 +1,0 @@
-declare module 'stdout-monkey';


### PR DESCRIPTION
The stop-gap API implemented in (#705) is superseded by this PR. This uses the standard APIs that oclif provides, and allows for correct invocation of Checkup via node.

TODO

- [ ] Add tests