### PR TITLE
Changes file extension of outputFile to sarif

### DIFF
--- a/packages/cli/src/reporters/json-reporter.ts
+++ b/packages/cli/src/reporters/json-reporter.ts
@@ -29,7 +29,7 @@ export function getOutputPath(outputFile: string, cwd: string = '') {
 
   let outputPath = isAbsolute(outputFile)
     ? outputFile
-    : resolve(cwd, outputFile || `${DEFAULT_OUTPUT_FILENAME}.json`);
+    : resolve(cwd, outputFile || `${DEFAULT_OUTPUT_FILENAME}.sarif`);
 
   let dir = dirname(outputPath);
 


### PR DESCRIPTION
Since we're now outputting fully compliant SARIF format, we should save to a file with a `.sarif` extension vs. JSON, since native SARIF readers will recognize this extension.