### PR TITLE
Exporting getReporters API in order to provide reporting for Node API

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,4 +28,5 @@ export function run() {
 
 export { runCommand } from './run-command';
 
+export { getReporter } from './reporters/get-reporter';
 export { default as Checkup } from './commands/run';


### PR DESCRIPTION
Usage:

```ts
import { getReporter } from '@checkup/cli';
import { OutputFormat } from '@checkup/core';

//...

let result = await Checkup.run([\\...]);
let reporter = getReporter(OutputFormat.stdout);

reporter.report();
```