### PR TITLE
Fixing SARIF log so that each location is mapped to one Result

### DIFF
--- a/packages/checkup-plugin-ember-octane/__tests__/tasks/__snapshots__/ember-octane-migration-status-task-test.ts.snap
+++ b/packages/checkup-plugin-ember-octane/__tests__/tasks/__snapshots__/ember-octane-migration-status-task-test.ts.snap
@@ -15,6 +15,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Native JS classes should be used instead of classic classes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-classes",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -26,6 +42,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Native JS classes should be used instead of classic classes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-classes",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -37,6 +69,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Native JS classes should be used instead of classic classes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-classes",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -52,7 +100,7 @@ Array [
     "message": Object {
       "text": "Native JS classes should be used instead of classic classes",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -75,6 +123,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use ES5 getters (\`this.property\`) instead of Ember's \`get\` function",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-get",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -86,6 +150,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use ES5 getters (\`this.property\`) instead of Ember's \`get\` function",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-get",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -101,7 +181,7 @@ Array [
     "message": Object {
       "text": "Use ES5 getters (\`this.property\`) instead of Ember's \`get\` function",
     },
-    "occurrenceCount": 3,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -124,6 +204,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use the @action decorator instead of declaring an actions hash",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-actions-hash",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -139,7 +235,7 @@ Array [
     "message": Object {
       "text": "Use the @action decorator instead of declaring an actions hash",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -162,6 +258,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Please switch to a tagless component by setting \`tagName: ''\` or converting to a Glimmer component",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/require-tagless-components",
+      "resultGroup": "Tagless Components",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -177,7 +289,7 @@ Array [
     "message": Object {
       "text": "Please switch to a tagless component by setting \`tagName: ''\` or converting to a Glimmer component",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -200,6 +312,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-components",
+      "resultGroup": "Glimmer Components",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -215,7 +343,7 @@ Array [
     "message": Object {
       "text": "Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -238,6 +366,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "You are using the component {{my-component}} with curly component syntax. You should use <MyComponent> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['my-component'] }\`.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-curly-component-invocation",
+      "resultGroup": "Angle Brackets Syntax",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -249,6 +393,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "You are using the component {{other-component}} with curly component syntax. You should use <OtherComponent> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['other-component'] }\`.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-curly-component-invocation",
+      "resultGroup": "Angle Brackets Syntax",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -260,6 +420,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "You are using the component {{someProp}} with curly component syntax. You should use <SomeProp> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['someProp'] }\`.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-curly-component-invocation",
+      "resultGroup": "Angle Brackets Syntax",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -273,9 +449,9 @@ Array [
       },
     ],
     "message": Object {
-      "text": "You are using the component {{my-component}} with curly component syntax. You should use <MyComponent> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['my-component'] }\`.",
+      "text": "You are using the component {{someProp}} with curly component syntax. You should use <SomeProp> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['someProp'] }\`.",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -298,6 +474,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-implicit-this",
+      "resultGroup": "Own Properties",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -309,6 +501,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Ambiguous path 'bar' is not allowed. Use '@bar' if it is a named argument or 'this.bar' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['bar'] }.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-implicit-this",
+      "resultGroup": "Own Properties",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -320,6 +528,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Ambiguous path 'someProp' is not allowed. Use '@someProp' if it is a named argument or 'this.someProp' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['someProp'] }.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-implicit-this",
+      "resultGroup": "Own Properties",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -333,9 +557,9 @@ Array [
       },
     ],
     "message": Object {
-      "text": "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
+      "text": "Ambiguous path 'someProp' is not allowed. Use '@someProp' if it is a named argument or 'this.someProp' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['someProp'] }.",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -390,6 +614,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Native JS classes should be used instead of classic classes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-classes",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -401,6 +641,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Native JS classes should be used instead of classic classes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-classes",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -412,6 +668,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Native JS classes should be used instead of classic classes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-classes",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -427,7 +699,7 @@ Array [
     "message": Object {
       "text": "Native JS classes should be used instead of classic classes",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -450,6 +722,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use ES5 getters (\`this.property\`) instead of Ember's \`get\` function",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-get",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -461,6 +749,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use ES5 getters (\`this.property\`) instead of Ember's \`get\` function",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-get",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -476,7 +780,7 @@ Array [
     "message": Object {
       "text": "Use ES5 getters (\`this.property\`) instead of Ember's \`get\` function",
     },
-    "occurrenceCount": 3,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -499,6 +803,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use the @action decorator instead of declaring an actions hash",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-actions-hash",
+      "resultGroup": "Native Classes",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -514,7 +834,7 @@ Array [
     "message": Object {
       "text": "Use the @action decorator instead of declaring an actions hash",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -537,6 +857,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Please switch to a tagless component by setting \`tagName: ''\` or converting to a Glimmer component",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/require-tagless-components",
+      "resultGroup": "Tagless Components",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -552,7 +888,7 @@ Array [
     "message": Object {
       "text": "Please switch to a tagless component by setting \`tagName: ''\` or converting to a Glimmer component",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -575,6 +911,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "ember/no-classic-components",
+      "resultGroup": "Glimmer Components",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -590,7 +942,7 @@ Array [
     "message": Object {
       "text": "Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -613,6 +965,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "You are using the component {{my-component}} with curly component syntax. You should use <MyComponent> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['my-component'] }\`.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-curly-component-invocation",
+      "resultGroup": "Angle Brackets Syntax",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -624,6 +992,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "You are using the component {{other-component}} with curly component syntax. You should use <OtherComponent> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['other-component'] }\`.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-curly-component-invocation",
+      "resultGroup": "Angle Brackets Syntax",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -635,6 +1019,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "You are using the component {{someProp}} with curly component syntax. You should use <SomeProp> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['someProp'] }\`.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-curly-component-invocation",
+      "resultGroup": "Angle Brackets Syntax",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -648,9 +1048,9 @@ Array [
       },
     ],
     "message": Object {
-      "text": "You are using the component {{my-component}} with curly component syntax. You should use <MyComponent> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['my-component'] }\`.",
+      "text": "You are using the component {{someProp}} with curly component syntax. You should use <SomeProp> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['someProp'] }\`.",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",
@@ -673,6 +1073,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-implicit-this",
+      "resultGroup": "Own Properties",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -684,6 +1100,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Ambiguous path 'bar' is not allowed. Use '@bar' if it is a named argument or 'this.bar' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['bar'] }.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-implicit-this",
+      "resultGroup": "Own Properties",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -695,6 +1127,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "Ambiguous path 'someProp' is not allowed. Use '@someProp' if it is a named argument or 'this.someProp' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['someProp'] }.",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "migrations",
+      "group": "ember",
+      "lintRuleId": "no-implicit-this",
+      "resultGroup": "Own Properties",
+      "taskDisplayName": "Ember Octane Migration Status",
+    },
+    "ruleId": "ember-octane-migration-status",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -708,9 +1156,9 @@ Array [
       },
     ],
     "message": Object {
-      "text": "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
+      "text": "Ambiguous path 'someProp' is not allowed. Use '@someProp' if it is a named argument or 'this.someProp' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['someProp'] }.",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "migrations",
       "group": "ember",

--- a/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
@@ -1,7 +1,7 @@
 import {
   BaseTask,
   buildLintResultDataItem,
-  buildResultFromLintResult,
+  buildResultsFromLintResult,
   byRuleIds,
   ESLintMessage,
   ESLintOptions,
@@ -107,7 +107,7 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
       [...esLintReport.results, ...templateLintReport.results],
       this.context.cliFlags.cwd
     );
-    return octaneResults.map((octaneResult) => this.toJson(octaneResult));
+    return octaneResults.map((octaneResult) => this.appendCheckupProperties(octaneResult));
   }
 
   private async runEsLint(): Promise<ESLintReport> {
@@ -147,8 +147,8 @@ function buildResult(lintingResults: (ESLintResult | TemplateLintResult)[], cwd:
     { key: 'Modifiers', rules: USE_MODIFIERS_RULES },
   ].flatMap(({ rules, key }) => {
     let rulesGroupForKey = groupDataByField(byRuleIds(rawData, rules), 'lintRuleId');
-    return rulesGroupForKey.map((rulesForKey) => {
-      return buildResultFromLintResult(rulesForKey, {
+    return rulesGroupForKey.flatMap((rulesForKey) => {
+      return buildResultsFromLintResult(rulesForKey, {
         resultGroup: key,
       });
     });

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-in-repo-addons-engines-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-in-repo-addons-engines-task-test.ts.snap
@@ -11,6 +11,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "in-repo addons",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember In-Repo Addons / Engines",
+    },
+    "ruleId": "ember-in-repo-addons-engines",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -22,7 +36,7 @@ Array [
     "message": Object {
       "text": "in-repo addons",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -39,6 +53,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "in-repo engines",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember In-Repo Addons / Engines",
+    },
+    "ruleId": "ember-in-repo-addons-engines",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -50,7 +78,7 @@ Array [
     "message": Object {
       "text": "in-repo engines",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-test-type-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-test-type-task-test.ts.snap
@@ -101,6 +101,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "application",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "testing",
+      "group": "ember",
+      "lintRuleId": "test-types",
+      "method": "test",
+      "taskDisplayName": "Test Types",
+    },
+    "ruleId": "ember-test-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -116,7 +132,7 @@ Array [
     "message": Object {
       "text": "application",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "testing",
       "group": "ember",
@@ -139,6 +155,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "application",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "testing",
+      "group": "ember",
+      "lintRuleId": "test-types",
+      "method": "skip",
+      "taskDisplayName": "Test Types",
+    },
+    "ruleId": "ember-test-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -150,6 +182,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "application",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "testing",
+      "group": "ember",
+      "lintRuleId": "test-types",
+      "method": "skip",
+      "taskDisplayName": "Test Types",
+    },
+    "ruleId": "ember-test-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -161,6 +209,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "application",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "testing",
+      "group": "ember",
+      "lintRuleId": "test-types",
+      "method": "skip",
+      "taskDisplayName": "Test Types",
+    },
+    "ruleId": "ember-test-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -176,7 +240,7 @@ Array [
     "message": Object {
       "text": "application",
     },
-    "occurrenceCount": 4,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "testing",
       "group": "ember",
@@ -226,6 +290,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "rendering",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "testing",
+      "group": "ember",
+      "lintRuleId": "test-types",
+      "method": "skip",
+      "taskDisplayName": "Test Types",
+    },
+    "ruleId": "ember-test-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -241,7 +321,7 @@ Array [
     "message": Object {
       "text": "rendering",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "testing",
       "group": "ember",
@@ -291,6 +371,22 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "unit",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "testing",
+      "group": "ember",
+      "lintRuleId": "test-types",
+      "method": "skip",
+      "taskDisplayName": "Test Types",
+    },
+    "ruleId": "ember-test-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -306,7 +402,7 @@ Array [
     "message": Object {
       "text": "unit",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "testing",
       "group": "ember",

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-types-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-types-task-test.ts.snap
@@ -11,6 +11,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "components",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -22,7 +36,7 @@ Array [
     "message": Object {
       "text": "components",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -39,6 +53,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "controllers",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -50,7 +78,7 @@ Array [
     "message": Object {
       "text": "controllers",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -67,6 +95,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "helpers",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -78,7 +120,7 @@ Array [
     "message": Object {
       "text": "helpers",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -95,6 +137,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "initializers",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -106,7 +162,7 @@ Array [
     "message": Object {
       "text": "initializers",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -123,6 +179,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "instance-initializers",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -134,7 +204,7 @@ Array [
     "message": Object {
       "text": "instance-initializers",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -151,6 +221,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "mixins",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -162,7 +246,7 @@ Array [
     "message": Object {
       "text": "mixins",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -179,6 +263,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "models",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -190,7 +288,7 @@ Array [
     "message": Object {
       "text": "models",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -207,6 +305,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "routes",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -218,7 +330,7 @@ Array [
     "message": Object {
       "text": "routes",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -235,6 +347,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "services",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -246,7 +372,7 @@ Array [
     "message": Object {
       "text": "services",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",
@@ -263,6 +389,20 @@ Array [
           },
         },
       },
+    ],
+    "message": Object {
+      "text": "templates",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "metrics",
+      "group": "ember",
+      "taskDisplayName": "Ember Types",
+    },
+    "ruleId": "ember-types",
+  },
+  Object {
+    "locations": Array [
       Object {
         "physicalLocation": Object {
           "artifactLocation": Object {
@@ -274,7 +414,7 @@ Array [
     "message": Object {
       "text": "templates",
     },
-    "occurrenceCount": 2,
+    "occurrenceCount": 1,
     "properties": Object {
       "category": "metrics",
       "group": "ember",

--- a/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
@@ -51,6 +51,21 @@ describe('ember-template-lint-disable-task', () => {
                 },
               },
             },
+          ],
+          "message": Object {
+            "text": "ember-template-lint-disable usages",
+          },
+          "occurrenceCount": 1,
+          "properties": Object {
+            "category": "linting",
+            "group": "disabled-lint-rules",
+            "lintRuleId": "no-ember-template-lint-disable",
+            "taskDisplayName": "Number of template-lint-disable Usages",
+          },
+          "ruleId": "ember-template-lint-disables",
+        },
+        Object {
+          "locations": Array [
             Object {
               "physicalLocation": Object {
                 "artifactLocation": Object {
@@ -62,6 +77,21 @@ describe('ember-template-lint-disable-task', () => {
                 },
               },
             },
+          ],
+          "message": Object {
+            "text": "ember-template-lint-disable usages",
+          },
+          "occurrenceCount": 1,
+          "properties": Object {
+            "category": "linting",
+            "group": "disabled-lint-rules",
+            "lintRuleId": "no-ember-template-lint-disable",
+            "taskDisplayName": "Number of template-lint-disable Usages",
+          },
+          "ruleId": "ember-template-lint-disables",
+        },
+        Object {
+          "locations": Array [
             Object {
               "physicalLocation": Object {
                 "artifactLocation": Object {
@@ -77,7 +107,7 @@ describe('ember-template-lint-disable-task', () => {
           "message": Object {
             "text": "ember-template-lint-disable usages",
           },
-          "occurrenceCount": 3,
+          "occurrenceCount": 1,
           "properties": Object {
             "category": "linting",
             "group": "disabled-lint-rules",

--- a/packages/checkup-plugin-ember/src/actions/ember-template-lint-disable-actions.ts
+++ b/packages/checkup-plugin-ember/src/actions/ember-template-lint-disable-actions.ts
@@ -1,9 +1,9 @@
-import { ActionsEvaluator, TaskConfig } from '@checkup/core';
+import { ActionsEvaluator, TaskConfig, sumOccurrences } from '@checkup/core';
 import { Result } from 'sarif';
 
 export function evaluateActions(taskResults: Result[], taskConfig: TaskConfig) {
   let actionsEvaluator = new ActionsEvaluator();
-  let templateLintDisableUsages = taskResults[0].occurrenceCount || 0;
+  let templateLintDisableUsages = sumOccurrences(taskResults);
 
   actionsEvaluator.add({
     name: 'reduce-template-lint-disable-usages',

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -1,5 +1,5 @@
 import { BaseTask, Task } from '@checkup/core';
-import { buildResultFromProperties } from '@checkup/core';
+import { buildResultsFromProperties } from '@checkup/core';
 
 import { PackageJson } from 'type-fest';
 import { Result } from 'sarif';
@@ -18,37 +18,37 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
   async run(): Promise<Result[]> {
     let packageJson = this.context.pkg;
 
-    let coreLibraries = buildResultFromProperties(
+    let coreLibraries = buildResultsFromProperties(
       [
         findDependency(packageJson, 'ember-source'),
         findDependency(packageJson, 'ember-cli'),
         findDependency(packageJson, 'ember-data'),
       ],
       'ember core libraries'
-    );
-    let emberDependencies = buildResultFromProperties(
+    ).map((result) => this.appendCheckupProperties(result));
+    let emberDependencies = buildResultsFromProperties(
       findDependencies(packageJson.dependencies, emberAddonFilter),
       'ember addon dependencies'
-    );
-    let emberDevDependencies = buildResultFromProperties(
+    ).map((result) => this.appendCheckupProperties(result));
+    let emberDevDependencies = buildResultsFromProperties(
       findDependencies(packageJson.devDependencies, emberAddonFilter),
       'ember addon devDependencies'
-    );
-    let emberCliDependencies = buildResultFromProperties(
+    ).map((result) => this.appendCheckupProperties(result));
+    let emberCliDependencies = buildResultsFromProperties(
       findDependencies(packageJson.dependencies, emberCliAddonFilter),
       'ember-cli addon dependencies'
-    );
-    let emberCliDevDependencies = buildResultFromProperties(
+    ).map((result) => this.appendCheckupProperties(result));
+    let emberCliDevDependencies = buildResultsFromProperties(
       findDependencies(packageJson.devDependencies, emberCliAddonFilter),
       'ember-cli addon devDependencies'
-    );
+    ).map((result) => this.appendCheckupProperties(result));
 
     return [
-      this.toJson(coreLibraries),
-      this.toJson(emberDependencies),
-      this.toJson(emberDevDependencies),
-      this.toJson(emberCliDependencies),
-      this.toJson(emberCliDevDependencies),
+      ...coreLibraries,
+      ...emberDependencies,
+      ...emberDevDependencies,
+      ...emberCliDependencies,
+      ...emberCliDevDependencies,
     ];
   }
 }

--- a/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
@@ -1,5 +1,5 @@
 import { Task, BaseTask } from '@checkup/core';
-import { buildResultFromPathArray } from '@checkup/core';
+import { buildResultsFromPathArray } from '@checkup/core';
 
 import { PackageJson } from 'type-fest';
 import { readJsonSync } from 'fs-extra';
@@ -29,8 +29,12 @@ export default class EmberInRepoAddonsEnginesTask extends BaseTask implements Ta
     });
 
     return [
-      this.toJson(buildResultFromPathArray(inRepoAddons.sort(), 'in-repo addons')),
-      this.toJson(buildResultFromPathArray(inRepoEngines.sort(), 'in-repo engines')),
+      ...buildResultsFromPathArray(inRepoAddons.sort(), 'in-repo addons').map((result) =>
+        this.appendCheckupProperties(result)
+      ),
+      ...buildResultsFromPathArray(inRepoEngines.sort(), 'in-repo engines').map((result) =>
+        this.appendCheckupProperties(result)
+      ),
     ];
   }
 }

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
@@ -2,7 +2,7 @@ import {
   Task,
   BaseTask,
   LintResult,
-  buildResultFromLintResult,
+  buildResultsFromLintResult,
   normalizePath,
   AstTraverser,
 } from '@checkup/core';
@@ -23,7 +23,9 @@ export default class EmberTemplateLintDisableTask extends BaseTask implements Ta
     let hbsPaths = this.context.paths.filterByGlob('**/*.hbs');
     let templateLintDisables = await getTemplateLintDisables(hbsPaths, this.context.cliFlags.cwd);
 
-    return [this.toJson(buildResultFromLintResult(templateLintDisables))];
+    return buildResultsFromLintResult(templateLintDisables).map((result) =>
+      this.appendCheckupProperties(result)
+    );
   }
 }
 

--- a/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
@@ -5,7 +5,7 @@ import {
   Parser,
   BaseTask,
   buildLintResultDataItem,
-  buildResultFromLintResult,
+  buildResultsFromLintResult,
   LintResult,
 } from '@checkup/core';
 import { EMBER_TEST_TYPES } from '../utils/lint-configs';
@@ -33,7 +33,7 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
     let esLintReport = await this.runEsLint();
 
     let results = this.buildResult(esLintReport, this.context.cliFlags.cwd);
-    return results.map((result) => this.toJson(result));
+    return results.map((result) => this.appendCheckupProperties(result));
   }
 
   private async runEsLint(): Promise<ESLintReport> {
@@ -69,8 +69,8 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
       return testTypes;
     });
 
-    return Object.keys(testTypes).map((key) => {
-      return buildResultFromLintResult(testTypes[key], {
+    return Object.keys(testTypes).flatMap((key) => {
+      return buildResultsFromLintResult(testTypes[key], {
         method: testTypes[key][0].method,
       });
     });

--- a/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
@@ -1,4 +1,4 @@
-import { Task, BaseTask, buildResultFromPathArray, normalizePaths } from '@checkup/core';
+import { Task, BaseTask, buildResultsFromPathArray, normalizePaths } from '@checkup/core';
 import { Result } from 'sarif';
 
 const SEARCH_PATTERNS = [
@@ -21,14 +21,14 @@ export default class EmberTypesTask extends BaseTask implements Task {
   group = 'ember';
 
   async run(): Promise<Result[]> {
-    let types = SEARCH_PATTERNS.map((pattern) => {
+    let types = SEARCH_PATTERNS.flatMap((pattern) => {
       let files = this.context.paths.filterByGlob(pattern.pattern);
-      return buildResultFromPathArray(
+      return buildResultsFromPathArray(
         normalizePaths(files, this.context.cliFlags.cwd),
         pattern.patternName
-      );
+      ).map((type) => this.appendCheckupProperties(type));
     });
 
-    return types.map((type) => this.toJson(type));
+    return types;
   }
 }

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -48,7 +48,7 @@ describe('eslint-disable-task', () => {
       })
     ).run();
 
-    expect(result).toMatchInlineSnapshot(`
+    expect(result.sort()).toMatchInlineSnapshot(`
       Array [
         Object {
           "locations": Array [
@@ -63,6 +63,21 @@ describe('eslint-disable-task', () => {
                 },
               },
             },
+          ],
+          "message": Object {
+            "text": "eslint-disable usages",
+          },
+          "occurrenceCount": 1,
+          "properties": Object {
+            "category": "linting",
+            "group": "disabled-lint-rules",
+            "lintRuleId": "no-eslint-disable",
+            "taskDisplayName": "Number of eslint-disable Usages",
+          },
+          "ruleId": "eslint-disables",
+        },
+        Object {
+          "locations": Array [
             Object {
               "physicalLocation": Object {
                 "artifactLocation": Object {
@@ -74,6 +89,21 @@ describe('eslint-disable-task', () => {
                 },
               },
             },
+          ],
+          "message": Object {
+            "text": "eslint-disable usages",
+          },
+          "occurrenceCount": 1,
+          "properties": Object {
+            "category": "linting",
+            "group": "disabled-lint-rules",
+            "lintRuleId": "no-eslint-disable",
+            "taskDisplayName": "Number of eslint-disable Usages",
+          },
+          "ruleId": "eslint-disables",
+        },
+        Object {
+          "locations": Array [
             Object {
               "physicalLocation": Object {
                 "artifactLocation": Object {
@@ -85,6 +115,21 @@ describe('eslint-disable-task', () => {
                 },
               },
             },
+          ],
+          "message": Object {
+            "text": "eslint-disable usages",
+          },
+          "occurrenceCount": 1,
+          "properties": Object {
+            "category": "linting",
+            "group": "disabled-lint-rules",
+            "lintRuleId": "no-eslint-disable",
+            "taskDisplayName": "Number of eslint-disable Usages",
+          },
+          "ruleId": "eslint-disables",
+        },
+        Object {
+          "locations": Array [
             Object {
               "physicalLocation": Object {
                 "artifactLocation": Object {
@@ -100,7 +145,7 @@ describe('eslint-disable-task', () => {
           "message": Object {
             "text": "eslint-disable usages",
           },
-          "occurrenceCount": 4,
+          "occurrenceCount": 1,
           "properties": Object {
             "category": "linting",
             "group": "disabled-lint-rules",

--- a/packages/checkup-plugin-javascript/src/actions/eslint-disable-actions.ts
+++ b/packages/checkup-plugin-javascript/src/actions/eslint-disable-actions.ts
@@ -1,9 +1,9 @@
-import { ActionsEvaluator, TaskConfig } from '@checkup/core';
+import { ActionsEvaluator, TaskConfig, sumOccurrences } from '@checkup/core';
 import { Result } from 'sarif';
 
 export function evaluateActions(taskResults: Result[], taskConfig: TaskConfig) {
   let actionsEvaluator = new ActionsEvaluator();
-  let eslintDisableUsages = taskResults[0].occurrenceCount || 0;
+  let eslintDisableUsages = sumOccurrences(taskResults);
 
   actionsEvaluator.add({
     name: 'reduce-eslint-disable-usages',

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -4,7 +4,7 @@ import {
   normalizePath,
   LintResult,
   AstTraverser,
-  buildResultFromLintResult,
+  buildResultsFromLintResult,
 } from '@checkup/core';
 
 import * as t from '@babel/types';
@@ -26,7 +26,9 @@ export default class EslintDisableTask extends BaseTask implements Task {
     let jsPaths = this.context.paths.filterByGlob('**/*.js');
     let eslintDisables: LintResult[] = await getEslintDisables(jsPaths, this.context.cliFlags.cwd);
 
-    return [this.toJson(buildResultFromLintResult(eslintDisables))];
+    return buildResultsFromLintResult(eslintDisables).map((result) =>
+      this.appendCheckupProperties(result)
+    );
   }
 }
 

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -5,7 +5,7 @@ import {
   Parser,
   Task,
   TaskContext,
-  buildResultFromLintResult,
+  buildResultsFromLintResult,
   buildLintResultData,
   bySeverity,
   groupDataByField,
@@ -56,19 +56,15 @@ export class EslintSummaryTask extends BaseTask implements Task {
     let lintingErrors = groupDataByField(bySeverity(transformedData, 2), 'lintRuleId');
     let lintingWarnings = groupDataByField(bySeverity(transformedData, 1), 'lintRuleId');
 
-    let errorsResult = lintingErrors.map((lintingError) => {
-      return this.toJson(
-        buildResultFromLintResult(lintingError, {
-          type: 'error',
-        })
-      );
+    let errorsResult = lintingErrors.flatMap((lintingError) => {
+      return buildResultsFromLintResult(lintingError, {
+        type: 'error',
+      }).map((result) => this.appendCheckupProperties(result));
     });
-    let warningsResult = lintingWarnings.map((lintingWarning) => {
-      return this.toJson(
-        buildResultFromLintResult(lintingWarning, {
-          type: 'warning',
-        })
-      );
+    let warningsResult = lintingWarnings.flatMap((lintingWarning) => {
+      return buildResultsFromLintResult(lintingWarning, {
+        type: 'warning',
+      }).map((result) => this.appendCheckupProperties(result));
     });
 
     return [...errorsResult, ...warningsResult];

--- a/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
@@ -1,6 +1,6 @@
 import * as npmCheck from 'npm-check';
 
-import { BaseTask, Task, buildResultFromProperties, groupDataByField } from '@checkup/core';
+import { BaseTask, Task, buildResultsFromProperties, groupDataByField } from '@checkup/core';
 import { Result } from 'sarif';
 
 export type Dependency = {
@@ -67,8 +67,10 @@ export default class OutdatedDependenciesTask extends BaseTask implements Task {
     let outdatedDependencies = await getDependencies(this.context.cliFlags.cwd);
     let groupedDependencies = groupDataByField(outdatedDependencies, 'semverBump');
 
-    return groupedDependencies.map((dependencyGroup) =>
-      this.toJson(buildResultFromProperties(dependencyGroup, dependencyGroup[0].semverBump))
+    return groupedDependencies.flatMap((dependencyGroup) =>
+      buildResultsFromProperties(dependencyGroup, dependencyGroup[0].semverBump).map((result) =>
+        this.appendCheckupProperties(result)
+      )
     );
   }
 }

--- a/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
@@ -8,7 +8,7 @@ export default class MockMetaTaskResult extends BaseMetaTaskResult implements Me
     super(meta);
   }
 
-  toJson() {
+  appendCheckupProperties() {
     return {
       [this.meta.taskName]: this.result,
     };

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -23,7 +23,7 @@ class FooTask extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' }, occurrenceCount: 0 })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' }, occurrenceCount: 0 })];
   }
 }
 
@@ -36,7 +36,7 @@ class FileCountTask extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' }, occurrenceCount: 0 })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' }, occurrenceCount: 0 })];
   }
 }
 

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -11,7 +11,7 @@ export default class MyFooTask extends BaseTask {
 
 
   async run() {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -72,7 +72,7 @@ export default class MyFooTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -133,7 +133,7 @@ export default class MyFooTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -195,7 +195,7 @@ export default class MyFooTask extends BaseTask implements Task {
   group = 'bar';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -257,7 +257,7 @@ export default class MyFooTask extends BaseTask implements Task {
   group = 'bar';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -319,7 +319,7 @@ export default class MyFooTask extends BaseTask implements Task {
   group = 'bar';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -380,7 +380,7 @@ export default class MyFooTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "
@@ -427,7 +427,7 @@ export default class MyBarTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }
 "

--- a/packages/cli/__tests__/meta-task-list-test.ts
+++ b/packages/cli/__tests__/meta-task-list-test.ts
@@ -71,7 +71,7 @@ describe('MetaTaskList', () => {
 
     let [result, errors] = await taskList.runTask('fake-meta-task');
 
-    expect(result!.toJson()).toMatchInlineSnapshot(`
+    expect(result!.appendCheckupProperties()).toMatchInlineSnapshot(`
       Object {
         "fake-meta-task": "fake meta task is being run",
       }
@@ -87,8 +87,8 @@ describe('MetaTaskList', () => {
 
     let [results, errors] = await taskList.runTasks();
 
-    expect(results[0].toJson()).toMatchSnapshot();
-    expect(results[1].toJson()).toMatchSnapshot();
+    expect(results[0].appendCheckupProperties()).toMatchSnapshot();
+    expect(results[1].appendCheckupProperties()).toMatchSnapshot();
     expect(errors).toHaveLength(0);
   });
 });

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -15,7 +15,7 @@ class InsightsTaskHigh extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 
@@ -28,7 +28,7 @@ class InsightsTaskLow extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 
@@ -42,7 +42,7 @@ class RecommendationsTaskHigh extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 
@@ -56,7 +56,7 @@ class RecommendationsTaskLow extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 
@@ -70,7 +70,7 @@ class MigrationTaskHigh extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 
@@ -84,7 +84,7 @@ class MigrationTaskLow extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 
@@ -113,7 +113,7 @@ class TaskWithoutCategory extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    return [this.toJson({ message: { text: 'hi' } })];
+    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
   }
 }
 

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -51,7 +51,7 @@ describe('project-meta-task', () => {
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
 
-      expect(taskResult.toJson()).toMatchInlineSnapshot(`
+      expect(taskResult.appendCheckupProperties()).toMatchInlineSnapshot(`
         Object {
           "analyzedFiles": FilePathArray [
             ".git/HEAD",
@@ -144,7 +144,7 @@ describe('project-meta-task', () => {
         })
       ).run();
 
-      expect(result.toJson()).toMatchInlineSnapshot(`
+      expect(result.appendCheckupProperties()).toMatchInlineSnapshot(`
         Object {
           "analyzedFiles": FilePathArray [],
           "analyzedFilesCount": 0,

--- a/packages/cli/src/get-log.ts
+++ b/packages/cli/src/get-log.ts
@@ -10,7 +10,10 @@ export function getLog(
   invocation: Invocation,
   taskList: TaskList
 ): Log {
-  let _info = Object.assign({}, ...info.map((result) => result.toJson())) as CheckupMetadata;
+  let _info = Object.assign(
+    {},
+    ...info.map((result) => result.appendCheckupProperties())
+  ) as CheckupMetadata;
 
   return {
     version: '2.1.0',

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -7,7 +7,7 @@ import { JsonObject } from 'type-fest';
 export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
   data!: CheckupMetadata;
 
-  toJson() {
+  appendCheckupProperties() {
     return (this.data as unknown) as JsonObject;
   }
 }

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -10,5 +10,5 @@ export interface MetaTask {
 
 export interface MetaTaskResult {
   meta: TaskIdentifier;
-  toJson: () => JsonMetaTaskResult;
+  appendCheckupProperties: () => JsonMetaTaskResult;
 }

--- a/packages/cli/templates/src/task/src/tasks/task.js.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.js.ejs
@@ -10,6 +10,6 @@ export default class <%- taskClass %> extends BaseTask {
 
 
   async run() {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }

--- a/packages/cli/templates/src/task/src/tasks/task.ts.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.ts.ejs
@@ -10,6 +10,6 @@ export default class <%- taskClass %> extends BaseTask implements Task {
   <%_ } _%>
 
   async run(): Promise<Result[]> {
-    return this.toJson([]);
+    return this.appendCheckupProperties([]);
   }
 }

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -47,7 +47,7 @@ export default abstract class BaseTask {
     return `${this._pluginName}/${this.taskName}`;
   }
 
-  toJson(result: Result) {
+  appendCheckupProperties(result: Result) {
     result.properties = {
       ...result.properties,
       ...{

--- a/packages/core/src/data/formatters.ts
+++ b/packages/core/src/data/formatters.ts
@@ -1,3 +1,6 @@
+import { Result } from 'sarif';
+import { sumOccurrences } from '../utils/sarif-utils';
+
 export function toPercent(numeratorOrValue: number, denominator?: number): string {
   let value: number =
     typeof denominator === 'number' ? numeratorOrValue / denominator : numeratorOrValue;
@@ -11,6 +14,18 @@ export function groupDataByField<T>(results: T[], field: string): T[][] {
     map.get(getMultiLevelProp(result, field))?.push(result as never);
   });
   return [...map.values()];
+}
+
+/*
+ * This function takes in multiple Results with different locations but the same message,
+ * and return a single Result to be rendered in the console (with occurrenceCounts added together)
+ */
+export function combineResultsForRendering(groupedResults: Result[][]): Result[] {
+  return groupedResults.map((results) => {
+    const result = results[0];
+    result.occurrenceCount = sumOccurrences(results);
+    return result;
+  });
 }
 
 /*

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,11 +34,11 @@ export { FilePathArray } from './utils/file-path-array';
 export { sumOccurrences } from './utils/sarif-utils';
 
 export { byRuleId, byRuleIds, bySeverity } from './data/filters';
-export { toPercent, groupDataByField } from './data/formatters';
+export { toPercent, groupDataByField, combineResultsForRendering } from './data/formatters';
 export {
-  buildResultFromProperties,
-  buildResultFromLintResult,
-  buildResultFromPathArray,
+  buildResultsFromProperties,
+  buildResultsFromLintResult,
+  buildResultsFromPathArray,
   buildLintResultData,
   buildLintResultDataItem,
   buildLintResultsFromEslintOrTemplateLint,

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -39,7 +39,7 @@ export interface Task {
   readonly enabled: boolean;
 
   run: () => Promise<Result[]>;
-  toJson: (result: Result) => Result;
+  appendCheckupProperties: (result: Result) => Result;
 }
 
 export type ActionItem = string | string[] | { columns: string[]; rows: object[] };


### PR DESCRIPTION
Even though locations is technically a Location[], if you read the SARIF spec it says that The locations array SHALL NOT be used to specify distinct occurrences of the same result which can be corrected independently.

Modifying tasks to return one Result per location.

Also renamed `toJson` to `appendCheckupProperties` because the name `toJson` made no sense :) In the future, I would love if we could remove this extra call all together, but that may have to involve putting the builders in the base class (or passing in all 4 properties we need to all the builders) but wanted to do that as a follow up to simplify this 

https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127841