### PR TITLE
Adding task to run ember-template-lint

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-template-lint-summary-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-template-lint-summary-task-test.ts.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ember-emplate-lint-summary-task summarizes eslint and outputs to JSON 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "uri": "included-path.hbs",
+          },
+          "region": Object {
+            "startColumn": 10,
+            "startLine": 3,
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "text": "Non-translated string used",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "linting",
+      "group": "ember",
+      "lintRuleId": "no-bare-strings",
+      "taskDisplayName": "Template Lint Summary",
+      "type": "error",
+    },
+    "ruleId": "ember-template-lint-summary",
+  },
+  Object {
+    "locations": Array [
+      Object {
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "uri": "included-path.hbs",
+          },
+          "region": Object {
+            "startColumn": 10,
+            "startLine": 5,
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "text": "Non-translated string used",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "linting",
+      "group": "ember",
+      "lintRuleId": "no-bare-strings",
+      "taskDisplayName": "Template Lint Summary",
+      "type": "error",
+    },
+    "ruleId": "ember-template-lint-summary",
+  },
+  Object {
+    "locations": Array [
+      Object {
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "uri": "included-path.hbs",
+          },
+          "region": Object {
+            "startColumn": 9,
+            "startLine": 2,
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "text": "elements cannot have inline styles",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "linting",
+      "group": "ember",
+      "lintRuleId": "no-inline-styles",
+      "taskDisplayName": "Template Lint Summary",
+      "type": "error",
+    },
+    "ruleId": "ember-template-lint-summary",
+  },
+  Object {
+    "locations": Array [
+      Object {
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "uri": "included-path.hbs",
+          },
+          "region": Object {
+            "startColumn": 6,
+            "startLine": 4,
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "text": "All \`<img>\` tags must have an alt attribute",
+    },
+    "occurrenceCount": 1,
+    "properties": Object {
+      "category": "linting",
+      "group": "ember",
+      "lintRuleId": "require-valid-alt-text",
+      "taskDisplayName": "Template Lint Summary",
+      "type": "warning",
+    },
+    "ruleId": "ember-template-lint-summary",
+  },
+]
+`;

--- a/packages/checkup-plugin-ember/__tests__/ember-template-lint-summary-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-template-lint-summary-task-test.ts
@@ -1,0 +1,121 @@
+import { CheckupProject, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName, FilePathArray, Task } from '@checkup/core';
+import TemplateLintSummaryTask from '../src/tasks/ember-template-lint-summary-task';
+import { evaluateActions } from '../src/actions/ember-template-lint-summary-actions';
+import { Result, Location } from 'sarif';
+
+describe('ember-emplate-lint-summary-task', () => {
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
+  let task: Task;
+  let result: Result[];
+
+  beforeAll(async () => {
+    project = new CheckupProject('checkup-app', '0.0.0');
+    project.files['included-path.hbs'] = `
+    <div style="color:blue">
+      <h1>Checkup</h1>
+      <img src="foo"/>
+    </div>
+    WHATEVER MAN
+    `;
+    project.files['excluded-path.hbs'] = `
+    LALALALALALALA
+    `;
+    project.files['.template-lintrc.js'] = `module.exports = {
+        rules: {
+            'no-bare-strings': 'error',
+            'require-valid-alt-text': 'warn',
+            'no-inline-styles': 'error'
+        }
+      };`;
+
+    project.writeSync();
+    project.gitInit();
+    project.install();
+
+    task = new TemplateLintSummaryTask(
+      pluginName,
+      getTaskContext({
+        cliFlags: { cwd: project.baseDir },
+        pkg: project.pkg,
+        paths: project.filePaths.filter((path) => path.includes('included-path')) as FilePathArray,
+        config: {
+          tasks: {
+            'ember/ember-template-lint-summary': [
+              'on',
+              {
+                actions: {
+                  'reduce-template-lint-errors': ['on', { threshold: 0 }],
+                  'reduce-template-lint-warnings': ['on', { threshold: 0 }],
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+    result = await task.run();
+  });
+
+  afterAll(() => {
+    project.dispose();
+  });
+
+  it('summarizes eslint and outputs to JSON', async () => {
+    expect(result).toMatchSnapshot();
+  });
+
+  it('only lints the files passed in via paths array', async () => {
+    let excludedPathsResults = result.filter(
+      (resultData: Result) =>
+        (
+          resultData.locations?.filter((fileLocation: Location) => {
+            return fileLocation?.physicalLocation?.artifactLocation?.uri?.includes('excluded-path');
+          }) || []
+        ).length > 0
+    );
+
+    let includedPathsResults = result.filter(
+      (resultData: Result) =>
+        (
+          resultData.locations?.filter((fileLocation: Location) => {
+            return fileLocation?.physicalLocation?.artifactLocation?.uri?.includes('included-path');
+          }) || []
+        ).length > 0
+    );
+
+    expect(excludedPathsResults).toHaveLength(0);
+    expect(includedPathsResults).toHaveLength(4);
+  });
+
+  it('returns correct action items if there are too many warnings or errors', async () => {
+    let actions = evaluateActions(result, task.config);
+
+    expect(actions).toHaveLength(2);
+    expect(actions).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "defaultThreshold": 20,
+          "details": "3 total errors",
+          "input": 3,
+          "items": Array [
+            "Total template-lint errors: 3",
+          ],
+          "name": "reduce-template-lint-errors",
+          "summary": "Reduce number of template-lint errors",
+        },
+        Object {
+          "defaultThreshold": 20,
+          "details": "1 total warnings",
+          "input": 1,
+          "items": Array [
+            "Total template-lint warnings: 1",
+          ],
+          "name": "reduce-template-lint-warnings",
+          "summary": "Reduce number of template-lin warnings",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/checkup-plugin-ember/src/actions/ember-template-lint-summary-actions.ts
+++ b/packages/checkup-plugin-ember/src/actions/ember-template-lint-summary-actions.ts
@@ -1,0 +1,32 @@
+import { ActionsEvaluator, TaskConfig, sumOccurrences } from '@checkup/core';
+import { Result } from 'sarif';
+
+export function evaluateActions(taskResults: Result[], taskConfig: TaskConfig) {
+  let actionsEvaluator = new ActionsEvaluator();
+
+  let errors = taskResults.filter((result: Result) => result.properties?.type === 'error')!;
+  let warnings = taskResults.filter((result: Result) => result.properties?.type === 'warning')!;
+
+  let errorCount = sumOccurrences(errors);
+  let warningCount = sumOccurrences(warnings);
+
+  actionsEvaluator.add({
+    name: 'reduce-template-lint-errors',
+    summary: 'Reduce number of template-lint errors',
+    details: `${errorCount} total errors`,
+    defaultThreshold: 20,
+    items: [`Total template-lint errors: ${errorCount}`],
+    input: errorCount,
+  });
+
+  actionsEvaluator.add({
+    name: 'reduce-template-lint-warnings',
+    summary: 'Reduce number of template-lin warnings',
+    details: `${warningCount} total warnings`,
+    defaultThreshold: 20,
+    items: [`Total template-lint warnings: ${warningCount}`],
+    input: warningCount,
+  });
+
+  return actionsEvaluator.evaluate(taskConfig);
+}

--- a/packages/checkup-plugin-ember/src/hooks/register-actions.ts
+++ b/packages/checkup-plugin-ember/src/hooks/register-actions.ts
@@ -1,10 +1,12 @@
 import { Hook } from '@oclif/config';
 import { RegisterActionsArgs } from '@checkup/core';
-import { evaluateActions as evaluateTemplateLint } from '../actions/ember-template-lint-disable-actions';
+import { evaluateActions as evaluateTemplateLintDisables } from '../actions/ember-template-lint-disable-actions';
+import { evaluateActions as evaluateTemplateLintSummary } from '../actions/ember-template-lint-summary-actions';
 import { evaluateActions as evaluateTestTypes } from '../actions/ember-test-types-actions';
 
 const hook: Hook<RegisterActionsArgs> = async function ({ registerActions }: RegisterActionsArgs) {
-  registerActions('ember-template-lint-disables', evaluateTemplateLint);
+  registerActions('ember-template-lint-disables', evaluateTemplateLintDisables);
+  registerActions('ember-template-lint-summary', evaluateTemplateLintSummary);
   registerActions('ember-test-types', evaluateTestTypes);
 };
 

--- a/packages/checkup-plugin-ember/src/hooks/register-tasks.ts
+++ b/packages/checkup-plugin-ember/src/hooks/register-tasks.ts
@@ -6,6 +6,7 @@ import EmberInRepoAddonsEnginesTask from '../tasks/ember-in-repo-addons-engines-
 import EmberTestTypesTaskTask from '../tasks/ember-test-types-task';
 import EmberTypesTask from '../tasks/ember-types-task';
 import EmberTemplateLintDisableTask from '../tasks/ember-template-lint-disable-task';
+import EmberTemplateLintSummaryTask from '../tasks/ember-template-lint-summary-task';
 
 const hook: Hook<RegisterTaskArgs> = async function ({ context, tasks }: RegisterTaskArgs) {
   let pluginName = getPluginName(__dirname);
@@ -15,6 +16,7 @@ const hook: Hook<RegisterTaskArgs> = async function ({ context, tasks }: Registe
   tasks.registerTask(new EmberInRepoAddonsEnginesTask(pluginName, context));
   tasks.registerTask(new EmberTestTypesTaskTask(pluginName, context));
   tasks.registerTask(new EmberTemplateLintDisableTask(pluginName, context));
+  tasks.registerTask(new EmberTemplateLintSummaryTask(pluginName, context));
 };
 
 export default hook;

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
@@ -1,0 +1,76 @@
+import {
+  BaseTask,
+  buildLintResultDataItem,
+  buildResultsFromLintResult,
+  LintResult,
+  Task,
+  TaskContext,
+  TemplateLinter,
+  TemplateLintMessage,
+  TemplateLintReport,
+  groupDataByField,
+  bySeverity,
+} from '@checkup/core';
+import { join, resolve } from 'path';
+import { Result } from 'sarif';
+
+export default class TemplateLintSummaryTask extends BaseTask implements Task {
+  taskName = 'ember-template-lint-summary';
+  taskDisplayName = 'Template Lint Summary';
+  category = 'linting';
+  group = 'ember';
+
+  private templateLinter: TemplateLinter;
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    let createEmberTemplateLintParser = this.context.parsers.get('ember-template-lint')!;
+
+    let resolvedTemplateLintConfigFile = join(
+      resolve(this.context.cliFlags.cwd),
+      '.template-lintrc.js'
+    );
+
+    this.templateLinter = createEmberTemplateLintParser(require(resolvedTemplateLintConfigFile));
+  }
+
+  private async runTemplateLint(): Promise<TemplateLintReport> {
+    let hbsPaths = this.context.paths.filterByGlob('**/*.hbs');
+
+    return this.templateLinter.execute(hbsPaths);
+  }
+
+  async run(): Promise<Result[]> {
+    let templateLintReport = await this.runTemplateLint();
+    let lintResults = templateLintReport.results.reduce((resultDataItems, lintingResults) => {
+      let messages = (<any>lintingResults.messages).map((lintMessage: TemplateLintMessage) => {
+        return buildLintResultDataItem(
+          lintMessage,
+          this.context.cliFlags.cwd,
+          lintingResults.filePath
+        );
+      });
+      resultDataItems.push(...messages);
+
+      return resultDataItems;
+    }, [] as LintResult[]);
+
+    let lintingErrors = groupDataByField(bySeverity(lintResults, 2), 'lintRuleId');
+    let lintingWarnings = groupDataByField(bySeverity(lintResults, 1), 'lintRuleId');
+
+    let errorsResult = lintingErrors.flatMap((lintingError) => {
+      return buildResultsFromLintResult(lintingError, {
+        type: 'error',
+      }).map((result) => this.appendCheckupProperties(result));
+    });
+
+    let warningsResult = lintingWarnings.flatMap((lintingWarning) => {
+      return buildResultsFromLintResult(lintingWarning, {
+        type: 'warning',
+      }).map((result) => this.appendCheckupProperties(result));
+    });
+
+    return [...errorsResult, ...warningsResult];
+  }
+}

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -92,31 +92,8 @@ let outputMap: { [taskName: string]: (taskResults: Result[]) => void } = {
       });
     });
   },
-  'eslint-summary': function (taskResults: Result[]) {
-    let groupedTaskResultsByType = groupDataByField(taskResults, 'properties.type');
-
-    ui.section(taskResults[0].properties?.taskDisplayName, () => {
-      groupedTaskResultsByType.forEach((resultGroup: Result[]) => {
-        let groupedTaskResultsByLintRule = combineResultsForRendering(
-          groupDataByField(resultGroup, 'properties.lintRuleId')
-        );
-        let totalCount = sumOccurrences(groupedTaskResultsByLintRule);
-        if (totalCount) {
-          ui.subHeader(`${groupedTaskResultsByLintRule[0].properties?.type}s: (${totalCount})`);
-          ui.valuesList(
-            groupedTaskResultsByLintRule.map((result) => {
-              if (result.message.text === NO_RESULTS_FOUND) {
-                renderEmptyResult(result);
-              } else {
-                return { title: result.properties?.lintRuleId, count: result?.occurrenceCount };
-              }
-            })
-          );
-          ui.blankLine();
-        }
-      });
-    });
-  },
+  'ember-template-lint-summary': renderLintingSummaryResult,
+  'eslint-summary': renderLintingSummaryResult,
   'outdated-dependencies': function (taskResults: Result[]) {
     ui.section(taskResults[0].properties?.taskDisplayName, () => {
       ui.sectionedBar(
@@ -308,4 +285,30 @@ function renderTimings(timings: Record<string, number>) {
     }
   );
   ui.blankLine();
+}
+
+function renderLintingSummaryResult(taskResults: Result[]) {
+  let groupedTaskResultsByType = groupDataByField(taskResults, 'properties.type');
+
+  ui.section(taskResults[0].properties?.taskDisplayName, () => {
+    groupedTaskResultsByType.forEach((resultGroup: Result[]) => {
+      let groupedTaskResultsByLintRule = combineResultsForRendering(
+        groupDataByField(resultGroup, 'properties.lintRuleId')
+      ).sort((a, b) => (b.occurrenceCount || 0) - (a.occurrenceCount || 0));
+      let totalCount = sumOccurrences(groupedTaskResultsByLintRule);
+      if (totalCount) {
+        ui.subHeader(`${groupedTaskResultsByLintRule[0].properties?.type}s: (${totalCount})`);
+        ui.valuesList(
+          groupedTaskResultsByLintRule.map((result) => {
+            if (result.message.text === NO_RESULTS_FOUND) {
+              renderEmptyResult(result);
+            } else {
+              return { title: result.properties?.lintRuleId, count: result?.occurrenceCount };
+            }
+          })
+        );
+        ui.blankLine();
+      }
+    });
+  });
 }


### PR DESCRIPTION
This task is very similar to eslint-summary, but runs ember-template-lint instead of eslint. 

Sample output (running on travis-web) 
```
Template Lint Summary

Errors 252

■ require-button-type (70)
■ link-href-attributes (24)
■ no-invalid-interactive (33)
■ no-negated-condition (1)
■ no-triple-curlies (4)
■ no-quoteless-attributes (16)
■ simple-unless (5)
■ no-inline-styles (5)
■ require-valid-alt-text (57)
■ link-rel-noopener (35)
■ table-groups (1)
■ no-extra-mut-helper-argument (1)
```