### PR TITLE
Fixes warnings, lint issues, and adds a test to ensure config schema is reachable

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/yeoman-assert": "^3.1.1",
     "@types/yeoman-test": "^2.0.5",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
-    "@typescript-eslint/parser": "^3.10.1",
+    "@typescript-eslint/parser": "^4.0.0",
     "chai": "^4.2.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
@@ -37,26 +37,28 @@ async function getTemplateLintDisables(filePaths: string[], cwd: string) {
 
     constructor(private filePath: string) {}
 
+    add(node: any) {
+      this.data.push({
+        filePath: normalizePath(this.filePath, cwd),
+        lintRuleId: 'no-ember-template-lint-disable',
+        message: 'ember-template-lint-disable usages',
+        line: node.loc.start.line,
+        column: node.loc.start.column,
+      });
+    }
+
     get visitors() {
-      let add = (node: any) => {
-        this.data.push({
-          filePath: normalizePath(this.filePath, cwd),
-          lintRuleId: 'no-ember-template-lint-disable',
-          message: 'ember-template-lint-disable usages',
-          line: node.loc.start.line,
-          column: node.loc.start.column,
-        });
-      };
+      let self = this;
 
       return {
         MustacheCommentStatement(node: any) {
           if (node.value.toLowerCase().includes(TEMPLATE_LINT_DISABLE)) {
-            add(node);
+            self.add(node);
           }
         },
         CommentStatement(node: any) {
           if (node.value.toLowerCase().includes(TEMPLATE_LINT_DISABLE)) {
-            add(node);
+            self.add(node);
           }
         },
       };

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -40,21 +40,23 @@ async function getEslintDisables(filePaths: string[], cwd: string) {
 
     constructor(private filePath: string) {}
 
+    add(node: any) {
+      this.data.push({
+        filePath: normalizePath(this.filePath, cwd),
+        lintRuleId: 'no-eslint-disable',
+        message: 'eslint-disable usages',
+        line: node.loc.start.line,
+        column: node.loc.start.column,
+      });
+    }
+
     get visitors(): Visitor<any> {
-      let add = (node: any) => {
-        this.data.push({
-          filePath: normalizePath(this.filePath, cwd),
-          lintRuleId: 'no-eslint-disable',
-          message: 'eslint-disable usages',
-          line: node.loc.start.line,
-          column: node.loc.start.column,
-        });
-      };
+      let self = this;
 
       return {
         visitComment: function (path: any) {
           if (path.value.value.trim().match(ESLINT_DISABLE_REGEX)) {
-            add(path.value);
+            self.add(path.value);
           }
 
           this.traverse(path);

--- a/packages/cli/__tests__/__snapshots__/checkup-node-api-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/checkup-node-api-test.ts.snap
@@ -19,12 +19,12 @@ Object {
         "paths": Array [],
       },
       "config": Object {
-        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
         "excludePaths": Array [],
         "plugins": Array [],
         "tasks": Object {},
       },
-      "configHash": "395b15f7dea0dee193db593e1c6cfb5b",
+      "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
       "flags": Object {
         "config": undefined,
         "excludePaths": undefined,

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -7,7 +7,7 @@ Checkup report generated for checkup-app v0.0.0 (4 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 988dab0635e80290c915a8729decff96
+config 0e3da47ee1e0a5e663465af5cc66cf37
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 1 lines of code
 ■ hbs (1)
@@ -23,7 +23,7 @@ Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 988dab0635e80290c915a8729decff96
+config 0e3da47ee1e0a5e663465af5cc66cf37
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2 lines of code
 ■ js (2)
@@ -39,7 +39,7 @@ Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ js (2)
@@ -68,12 +68,12 @@ Object {
         "paths": Array [],
       },
       "config": Object {
-        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
         "excludePaths": Array [],
         "plugins": Array [],
         "tasks": Object {},
       },
-      "configHash": "395b15f7dea0dee193db593e1c6cfb5b",
+      "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
       "flags": Object {
         "format": "json",
         "outputFile": "",
@@ -118,7 +118,7 @@ Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ js (2)
@@ -141,7 +141,7 @@ Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config c88c290095f76e0b55cc190c876eaa8f
+config 2910e38984c8092494a42c88b642b9de
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ js (2)
@@ -164,7 +164,7 @@ Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ js (2)
@@ -191,7 +191,7 @@ Checkup report generated for checkup-app v0.0.0 (3 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ hbs (2)
@@ -214,7 +214,7 @@ Checkup report generated for checkup-app v0.0.0 (9 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 6 lines of code
 ■ js (4)
@@ -237,7 +237,7 @@ Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ js (2)
@@ -254,7 +254,7 @@ Checkup report generated for checkup-app v0.0.0 (3 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
  0 lines of code
 
@@ -269,7 +269,7 @@ Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2 lines of code
 ■ js (2)
@@ -285,7 +285,7 @@ Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 988dab0635e80290c915a8729decff96
+config 0e3da47ee1e0a5e663465af5cc66cf37
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 2 lines of code
 ■ js (2)
@@ -301,7 +301,7 @@ Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
 This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 checkup v0.0.0
-config 395b15f7dea0dee193db593e1c6cfb5b
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
 
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
 ■ js (2)

--- a/packages/cli/__tests__/generators/__snapshots__/generate-config-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-config-test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`config-init-generator should write a config 1`] = `
 "{
-  \\"$schema\\": \\"https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json\\",
+  \\"$schema\\": \\"https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json\\",
   \\"excludePaths\\": [],
   \\"plugins\\": [],
   \\"tasks\\": {}
@@ -12,7 +12,7 @@ exports[`config-init-generator should write a config 1`] = `
 
 exports[`config-init-generator should write a config in custom path 1`] = `
 "{
-  \\"$schema\\": \\"https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json\\",
+  \\"$schema\\": \\"https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json\\",
   \\"excludePaths\\": [],
   \\"plugins\\": [],
   \\"tasks\\": {}

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -82,12 +82,12 @@ describe('project-meta-task', () => {
               "paths": Array [],
             },
             "config": Object {
-              "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+              "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
               "excludePaths": Array [],
               "plugins": Array [],
               "tasks": Object {},
             },
-            "configHash": "395b15f7dea0dee193db593e1c6cfb5b",
+            "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
             "flags": Object {
               "config": undefined,
               "excludePaths": undefined,
@@ -153,14 +153,14 @@ describe('project-meta-task', () => {
               "paths": Array [],
             },
             "config": Object {
-              "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+              "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
               "excludePaths": Array [],
               "plugins": Array [
                 "checkup-plugin-ember",
               ],
               "tasks": Object {},
             },
-            "configHash": "1ba2bd62ba89147967dc57decae6b129",
+            "configHash": "2f97c4acdec7c73cce0b6c3e3e0cedc2",
             "flags": Object {
               "config": undefined,
               "excludePaths": undefined,

--- a/packages/core/__tests__/__fixtures__/.checkuprc.json
+++ b/packages/core/__tests__/__fixtures__/.checkuprc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
   "excludePaths": ["**/foo"],
   "plugins": ["@foo/checkup-plugin-bar"],
   "tasks": {}

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -1,3 +1,7 @@
+import fetch from 'node-fetch';
+import { readJsonSync, writeJsonSync, writeFileSync } from 'fs-extra';
+import { createTmpDir } from '@checkup/test-helpers';
+import { DEFAULT_CONFIG } from '../src';
 import {
   getConfigPath,
   readConfig,
@@ -6,10 +10,6 @@ import {
   getConfigPathFromOptions,
   CONFIG_SCHEMA_URL,
 } from '../src/config';
-import { readJsonSync, writeJsonSync, writeFileSync } from 'fs-extra';
-
-import { DEFAULT_CONFIG } from '../src';
-import { createTmpDir } from '@checkup/test-helpers';
 
 const REMOTE_CONFIG = {
   $schema: CONFIG_SCHEMA_URL,
@@ -104,6 +104,12 @@ describe('config', () => {
       }).toThrow(`Config in ${configPath} is invalid.`);
     });
 
+    it('references schema from a valid HTTP endpoint', async () => {
+      let response = await fetch(CONFIG_SCHEMA_URL);
+
+      expect(response.ok).toEqual(true);
+    });
+
     it('can read a valid config with valid task config string value set to "on"', () => {
       let configPath = writeConfig(tmp, {
         plugins: ['ember'],
@@ -116,7 +122,7 @@ describe('config', () => {
 
       expect(config).toMatchInlineSnapshot(`
         Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
           "excludePaths": Array [],
           "plugins": Array [
             "checkup-plugin-ember",
@@ -140,7 +146,7 @@ describe('config', () => {
 
       expect(config).toMatchInlineSnapshot(`
         Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
           "excludePaths": Array [],
           "plugins": Array [
             "checkup-plugin-ember",
@@ -164,7 +170,7 @@ describe('config', () => {
 
       expect(config).toMatchInlineSnapshot(`
         Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
           "excludePaths": Array [],
           "plugins": Array [
             "checkup-plugin-ember",
@@ -198,7 +204,7 @@ describe('config', () => {
 
       expect(readJsonSync(path)).toMatchInlineSnapshot(`
         Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
           "excludePaths": Array [],
           "plugins": Array [],
           "tasks": Object {},
@@ -216,7 +222,7 @@ describe('config', () => {
 
       expect(readJsonSync(path)).toMatchInlineSnapshot(`
         Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
           "excludePaths": Array [],
           "plugins": Array [
             "ember",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,7 +16,7 @@ export const CONFIG_DOCS_URL =
   'https://docs.checkupjs.com/quickstart/usage#1-generate-a-configuration-file';
 
 export const CONFIG_SCHEMA_URL =
-  'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json';
+  'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json';
 
 export const DEFAULT_CONFIG: CheckupConfig = {
   $schema: CONFIG_SCHEMA_URL,

--- a/packages/core/src/types/ember-template-lint.ts
+++ b/packages/core/src/types/ember-template-lint.ts
@@ -1,3 +1,5 @@
+import type Prepend from 'eslint';
+
 type Severity = 0 | 1 | 2;
 type RuleLevel = Severity | 'off' | 'warn' | 'error';
 type RuleLevelAndOptions<Options extends any[] = any[]> = Prepend<Partial<Options>, RuleLevel>;

--- a/packages/core/src/types/parsers.ts
+++ b/packages/core/src/types/parsers.ts
@@ -1,6 +1,6 @@
 import { CLIEngine, Linter } from 'eslint';
 
-const TemplateLinter = require('ember-template-lint');
+const EmberTemplateLinter = require('ember-template-lint').TemplateLinter;
 
 export type ParserName = string;
 export type ParserOptions = Record<string, any>;
@@ -13,7 +13,7 @@ export interface CreateParser<ParserOptions, TParser = Parser<ParserReport>> {
   (config: ParserOptions): TParser;
 }
 
-export type TemplateLinter = typeof TemplateLinter;
+export type TemplateLinter = typeof EmberTemplateLinter;
 
 export type ESLintOptions = CLIEngine.Options;
 export type ESLintReport = CLIEngine.LintReport;

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,11 +946,6 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
 "@types/eslint@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.2.tgz#c88426b896efeb0b2732a92431ce8aa7ec0dee61"
@@ -1251,17 +1246,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
-  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@4.9.0", "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.0.tgz#23a296b85d243afba24e75a43fd55aceda5141f0"
@@ -1274,16 +1258,15 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.10.1.tgz#1883858e83e8b442627e1ac6f408925211155467"
-  integrity sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==
+"@typescript-eslint/parser@^4.0.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.9.0.tgz#bb65f1214b5e221604996db53ef77c9d62b09249"
+  integrity sha512-QRSDAV8tGZoQye/ogp28ypb8qpsZPV6FOLD+tbN4ohKUWHD2n/u0Q2tIBnCsGwQCiD94RdtLkcqpdK4vKcLCCw==
   dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.10.1"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
-    eslint-visitor-keys "^1.1.0"
+    "@typescript-eslint/scope-manager" "4.9.0"
+    "@typescript-eslint/types" "4.9.0"
+    "@typescript-eslint/typescript-estree" "4.9.0"
+    debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.9.0":
   version "4.9.0"
@@ -1293,29 +1276,10 @@
     "@typescript-eslint/types" "4.9.0"
     "@typescript-eslint/visitor-keys" "4.9.0"
 
-"@typescript-eslint/types@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
-  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
-
 "@typescript-eslint/types@4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.9.0.tgz#3fe8c3632abd07095c7458f7451bd14c85d0033c"
   integrity sha512-luzLKmowfiM/IoJL/rus1K9iZpSJK6GlOS/1ezKplb7MkORt2dDcfi8g9B0bsF6JoRGhqn0D3Va55b+vredFHA==
-
-"@typescript-eslint/typescript-estree@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
-  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
-  dependencies:
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/visitor-keys" "3.10.1"
-    debug "^4.1.1"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.9.0":
   version "4.9.0"
@@ -1330,13 +1294,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
-  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/visitor-keys@4.9.0":
   version "4.9.0"
@@ -4321,7 +4278,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
This PR is just a few cleanup tasks.

- upgrades dependencies to remove yarn warnings on install
- fixes lint issues related to the upgrades
- adds a test to ensure we can reach the config schema, and will error if that schema is moved or renamed (this happened, which is why I added this test)