### PR TITLE
Add ability to run tasks by category/group

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,7 @@
     "unicorn/no-reduce": "off",
     "unicorn/prevent-abbreviations": "off",
     "unicorn/import-style": "off",
+    "unicorn/no-fn-reference-in-iterator": "off",
     "unicorn/no-process-exit": "off",
     "node/no-unsupported-features/es-syntax": ["error", { "ignores": ["modules"] }],
     "node/no-extraneous-import": ["error"],

--- a/package.json
+++ b/package.json
@@ -94,9 +94,6 @@
       "generators": ":recycle: Generators"
     }
   },
-  "resolutions": {
-    "type-fest": "^0.13.1"
-  },
   "volta": {
     "node": "12.16.2",
     "yarn": "1.22.4"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
       "generators": ":recycle: Generators"
     }
   },
+  "resolutions": {
+    "type-fest": "^0.20.2"
+  },
   "volta": {
     "node": "12.16.2",
     "yarn": "1.22.4"

--- a/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
@@ -128,7 +128,7 @@ describe('eslint-summary-task', () => {
 
 describe('readEslintConfig', () => {
   const eslintConfigJson = 'airbnb';
-  const pkg: PackageJson = {
+  const pkg: PackageJson & { eslintConfig: string } = {
     name: 'foo-project',
     version: '0.0.0',
     keywords: [],

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -16,6 +16,8 @@ import { PackageJson } from 'type-fest';
 import { readFileSync } from 'fs';
 import { Result } from 'sarif';
 
+export type PackageJsonWithEslint = PackageJson & { eslintConfig: string };
+
 /**
  * @export
  * @description In prioritized order as specified by https://eslint.org/docs/user-guide/configuring
@@ -44,7 +46,7 @@ export class EslintSummaryTask extends BaseTask implements Task {
     let eslintConfig: ESLintOptions = readEslintConfig(
       this.context.paths,
       this.context.cliFlags.cwd,
-      this.context.pkg
+      this.context.pkg as PackageJsonWithEslint
     );
     this._eslintParser = createEslintParser(eslintConfig);
   }
@@ -74,7 +76,7 @@ export class EslintSummaryTask extends BaseTask implements Task {
 export function readEslintConfig(
   paths: string[],
   basePath: string,
-  pkg: PackageJson
+  pkg: PackageJsonWithEslint
 ): ESLintOptions {
   let eslintConfigFile: string = '';
 

--- a/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/task-list-test.ts.snap
@@ -8,7 +8,7 @@ Array [
     },
     "properties": Object {
       "category": "bar",
-      "group": undefined,
+      "group": "group1",
       "taskDisplayName": "Insights Task High",
     },
     "ruleId": "insights-task-high",
@@ -22,11 +22,11 @@ Object {
     "text": "hi",
   },
   "properties": Object {
-    "category": "bar",
-    "group": undefined,
-    "taskDisplayName": "Insights Task High",
+    "category": "foo",
+    "group": "group2",
+    "taskDisplayName": "Insights Task Low",
   },
-  "ruleId": "insights-task-high",
+  "ruleId": "insights-task-low",
 }
 `;
 
@@ -36,10 +36,10 @@ Object {
     "text": "hi",
   },
   "properties": Object {
-    "category": "foo",
-    "group": undefined,
-    "taskDisplayName": "Insights Task Low",
+    "category": "bar",
+    "group": "group1",
+    "taskDisplayName": "Insights Task High",
   },
-  "ruleId": "insights-task-low",
+  "ruleId": "insights-task-high",
 }
 `;

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -124,7 +124,7 @@ config dd17cda1fc2eb2bc6bb5206b41fc1a84
 ■ js (2)
 ■ hbs (1)
 
-=== Fake
+=== Fake 2
 
 File Count Task
 
@@ -147,9 +147,67 @@ config 2910e38984c8092494a42c88b642b9de
 ■ js (2)
 ■ hbs (1)
 
-=== Fake
+=== Fake 2
 
 File Count Task
+
+■ hi (NaN)
+
+
+"
+`;
+
+exports[`@checkup/cli normal cli output should run multiple tasks if the category option is specified with multiple categories 1`] = `
+"
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
+
+This project is 0 days old, with 0 days active days, 0 commits and 0 files.
+
+checkup v0.0.0
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
+
+■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
+■ js (2)
+■ hbs (1)
+
+=== Fake 2
+
+File Count Task
+
+■ hi (-NaN)
+
+=== Fake 1
+
+Foo Task
+
+■ hi (-NaN)
+
+
+"
+`;
+
+exports[`@checkup/cli normal cli output should run multiple tasks if the group option is specified with multiple groups 1`] = `
+"
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
+
+This project is 0 days old, with 0 days active days, 0 commits and 0 files.
+
+checkup v0.0.0
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
+
+■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
+■ js (2)
+■ hbs (1)
+
+=== Fake 2
+
+File Count Task
+
+■ hi (-NaN)
+
+=== Fake 1
+
+Foo Task
 
 ■ hi (-NaN)
 
@@ -170,11 +228,59 @@ config dd17cda1fc2eb2bc6bb5206b41fc1a84
 ■ js (2)
 ■ hbs (1)
 
-=== Fake
+=== Fake 2
 
 File Count Task
 
 ■ hi (-NaN)
+
+=== Fake 1
+
+Foo Task
+
+■ hi (-NaN)
+
+
+"
+`;
+
+exports[`@checkup/cli normal cli output should run only one task if the category option is specified 1`] = `
+"
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
+
+This project is 0 days old, with 0 days active days, 0 commits and 0 files.
+
+checkup v0.0.0
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
+
+■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
+■ js (2)
+■ hbs (1)
+
+=== Fake 1
+
+Foo Task
+
+■ hi (-NaN)
+
+
+"
+`;
+
+exports[`@checkup/cli normal cli output should run only one task if the group option is specified 1`] = `
+"
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
+
+This project is 0 days old, with 0 days active days, 0 commits and 0 files.
+
+checkup v0.0.0
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
+
+■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
+■ js (2)
+■ hbs (1)
+
+=== Fake 1
 
 Foo Task
 
@@ -197,11 +303,11 @@ config dd17cda1fc2eb2bc6bb5206b41fc1a84
 ■ hbs (2)
 ■ js (1)
 
-=== Fake
+=== Fake 2
 
 File Count Task
 
-■ hi (-NaN)
+■ hi (NaN)
 
 
 "
@@ -220,11 +326,11 @@ config dd17cda1fc2eb2bc6bb5206b41fc1a84
 ■ js (4)
 ■ hbs (2)
 
-=== Fake
+=== Fake 2
 
 File Count Task
 
-■ hi (-NaN)
+■ hi (NaN)
 
 
 "

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -9,6 +9,7 @@ class InsightsTaskHigh extends BaseTask implements Task {
   taskName = 'insights-task-high';
   taskDisplayName = 'Insights Task High';
   category = 'bar';
+  group = 'group1';
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -23,6 +24,7 @@ class InsightsTaskLow extends BaseTask implements Task {
   taskName = 'insights-task-low';
   taskDisplayName = 'Insights Task Low';
   category = 'foo';
+  group = 'group2';
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -133,7 +135,7 @@ describe('TaskList', () => {
     expect(taskList.categories.get('bar')!.size).toEqual(1);
   });
 
-  it('registerTask fails if a task doesnt have a category set', () => {
+  it("registerTask fails if a task doesn't have a category set", () => {
     let taskList = new TaskList();
     let taskWithoutCategory = new TaskWithoutCategory(getTaskContext());
 
@@ -165,7 +167,7 @@ describe('TaskList', () => {
 
     taskList.registerTask(new InsightsTaskHigh(getTaskContext()));
 
-    expect(taskList.findTask('foo')).toBeUndefined();
+    expect(taskList.find('foo')).toBeUndefined();
   });
 
   it('findTask returns task instance if task exists with that name', () => {
@@ -173,25 +175,25 @@ describe('TaskList', () => {
 
     taskList.registerTask(new InsightsTaskHigh(getTaskContext()));
 
-    expect(taskList.findTask('insights-task-high')).toBeDefined();
+    expect(taskList.find('insights-task-high')).toBeDefined();
   });
 
-  it('findTasks returns task instances if tasks exists with that name', () => {
+  it('findAllByTaskName returns task instances if tasks exists with that name', () => {
     let taskList = new TaskList();
 
     taskList.registerTask(new InsightsTaskHigh(getTaskContext()));
     taskList.registerTask(new InsightsTaskLow(getTaskContext()));
 
     expect(
-      taskList.findTasks('fake/insights-task-high', 'fake/insights-task-low').tasksFound
+      taskList.findAllByTaskName('fake/insights-task-high', 'fake/insights-task-low').tasksFound
     ).toHaveLength(2);
   });
 
-  it('findTasks returns task instances that exist, as well as names of tasks not found', () => {
+  it('findAllByTaskName returns task instances that exist, as well as names of tasks not found', () => {
     let taskList = new TaskList();
 
     taskList.registerTask(new InsightsTaskHigh(getTaskContext()));
-    let tasks = taskList.findTasks('fake/insights-task-high', 'fake/random');
+    let tasks = taskList.findAllByTaskName('fake/insights-task-high', 'fake/random');
     expect(tasks.tasksFound).toHaveLength(1);
     expect(tasks.tasksNotFound).toContain('fake/random');
   });
@@ -205,6 +207,42 @@ describe('TaskList', () => {
 
     expect(result).toMatchSnapshot();
     expect(errors).toHaveLength(0);
+  });
+
+  it('findAllByCategory returns task instances if tasks exists by category', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new InsightsTaskHigh(getTaskContext()));
+    taskList.registerTask(new InsightsTaskLow(getTaskContext()));
+
+    expect(taskList.findAllByCategory('foo', 'bar').tasksFound).toHaveLength(2);
+  });
+
+  it('findAllByCategory returns task instances that exist, as well as names of tasks not found', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new InsightsTaskLow(getTaskContext()));
+    let tasks = taskList.findAllByCategory('foo', 'bar');
+    expect(tasks.tasksFound).toHaveLength(1);
+    expect(tasks.tasksNotFound).toContain('bar');
+  });
+
+  it('findAllByGroup returns task instances if tasks exists by group', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new InsightsTaskHigh(getTaskContext()));
+    taskList.registerTask(new InsightsTaskLow(getTaskContext()));
+
+    expect(taskList.findAllByGroup('group1', 'group2').tasksFound).toHaveLength(2);
+  });
+
+  it('findAllByGroup returns task instances that exist, as well as names of tasks not found', () => {
+    let taskList = new TaskList();
+
+    taskList.registerTask(new InsightsTaskLow(getTaskContext()));
+    let tasks = taskList.findAllByGroup('group1', 'group2');
+    expect(tasks.tasksFound).toHaveLength(1);
+    expect(tasks.tasksNotFound).toContain('group1');
   });
 
   it('runTasks will run all registered tasks', async () => {
@@ -240,10 +278,21 @@ describe('TaskList', () => {
           },
           "properties": Object {
             "category": "foo",
-            "group": undefined,
+            "group": "group2",
             "taskDisplayName": "Insights Task Low",
           },
           "ruleId": "insights-task-low",
+        },
+        Object {
+          "message": Object {
+            "text": "hi",
+          },
+          "properties": Object {
+            "category": "bar",
+            "group": "group1",
+            "taskDisplayName": "Insights Task High",
+          },
+          "ruleId": "insights-task-high",
         },
         Object {
           "message": Object {
@@ -288,17 +337,6 @@ describe('TaskList', () => {
             "taskDisplayName": "Recommendations Task Low",
           },
           "ruleId": "recommendations-task-low",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "bar",
-            "group": undefined,
-            "taskDisplayName": "Insights Task High",
-          },
-          "ruleId": "insights-task-high",
         },
       ]
     `);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -79,17 +79,17 @@ export default class RunCommand extends BaseCommand {
       description: 'The path referring to the root directory that Checkup will run in',
     }),
     category: flags.string({
-      description: 'Runs specific task specified by category. Can be used multiple times.',
+      description: 'Runs specific tasks specified by category. Can be used multiple times.',
       multiple: true,
     }),
     group: flags.string({
-      description: 'Runs specific task specified by group. Can be used multiple times.',
+      description: 'Runs specific tasks specified by group. Can be used multiple times.',
       multiple: true,
     }),
     task: flags.string({
       char: 't',
       description:
-        'Runs specific task specified by the fully qualified task name in the format pluginName/taskName. Can be used multiple times.',
+        'Runs specific tasks specified by the fully qualified task name in the format pluginName/taskName. Can be used multiple times.',
       multiple: true,
     }),
     format: flags.string({

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -33,6 +33,7 @@ import ProjectMetaTask from '../tasks/project-meta-task';
 import { getLog } from '../get-log';
 import { reportAvailableTasks } from '../reporters/console-reporter';
 import { Invocation, Log, Result } from 'sarif';
+import { TASK_ERRORS } from '../task-errors';
 
 let __tasksForTesting: Set<Task> = new Set<Task>();
 
@@ -77,6 +78,14 @@ export default class RunCommand extends BaseCommand {
       char: 'd',
       description: 'The path referring to the root directory that Checkup will run in',
     }),
+    category: flags.string({
+      description: 'Runs specific task specified by category. Can be used multiple times.',
+      multiple: true,
+    }),
+    group: flags.string({
+      description: 'Runs specific task specified by group. Can be used multiple times.',
+      multiple: true,
+    }),
     task: flags.string({
       char: 't',
       description:
@@ -113,6 +122,18 @@ export default class RunCommand extends BaseCommand {
   actions: Action[] = [];
   checkupConfig!: CheckupConfig;
   cliModeEnabled: boolean = true;
+
+  get taskFilterType() {
+    if (this.runFlags.task !== undefined) {
+      return 'task';
+    } else if (this.runFlags.category !== undefined) {
+      return 'category';
+    } else if (this.runFlags.group !== undefined) {
+      return 'group';
+    }
+
+    return '';
+  }
 
   public async init() {
     let { argv, flags } = this.parse(RunCommand);
@@ -173,8 +194,8 @@ export default class RunCommand extends BaseCommand {
   private async runTasks() {
     [this.metaTaskResults, this.metaTaskErrors] = await this.defaultTasks.runTasks();
 
-    if (this.runFlags.task !== undefined) {
-      let { tasksFound, tasksNotFound } = this.pluginTasks.findTasks(...this.runFlags.task);
+    if (this.taskFilterType) {
+      let { tasksFound, tasksNotFound } = this.findTasks();
 
       if (tasksFound.length > 0) {
         [this.pluginTaskResults, this.pluginTaskErrors] = await this.pluginTasks.runTasks(
@@ -183,14 +204,9 @@ export default class RunCommand extends BaseCommand {
       }
 
       if (tasksNotFound.length > 0) {
-        this.extendedError(
-          new CheckupError(
-            `Cannot find the ${tasksNotFound.join(',')} task${
-              tasksNotFound.length > 1 ? 's' : '' // pluralize task if more than one task is not found
-            }.`,
-            'Run `checkup --listTasks` to see available tasks'
-          )
-        );
+        let error = TASK_ERRORS.get(this.taskFilterType)!;
+
+        this.extendedError(new CheckupError(error.message(tasksNotFound), error.callToAction));
         ui.action.stop();
       }
     } else {
@@ -198,12 +214,24 @@ export default class RunCommand extends BaseCommand {
     }
   }
 
+  private findTasks() {
+    if (this.runFlags.task !== undefined) {
+      return this.pluginTasks.findAllByTaskName(...this.runFlags.task);
+    } else if (this.runFlags.category !== undefined) {
+      return this.pluginTasks.findAllByCategory(...this.runFlags.category);
+    } else if (this.runFlags.group !== undefined) {
+      return this.pluginTasks.findAllByGroup(...this.runFlags.group);
+    }
+
+    return { tasksFound: [], tasksNotFound: [] };
+  }
+
   private runActions() {
     new Promise((resolve, reject) => {
       let evaluators = getRegisteredActions();
 
       for (let [taskName, evaluator] of evaluators) {
-        let task = this.pluginTasks.findTask(taskName);
+        let task = this.pluginTasks.find(taskName);
 
         let taskResult = this.pluginTaskResults.filter((result: Result) => {
           return result.properties?.taskName === taskName;

--- a/packages/cli/src/task-errors.ts
+++ b/packages/cli/src/task-errors.ts
@@ -1,0 +1,33 @@
+export const TASK_ERRORS = new Map<
+  string,
+  { message: (notFound: string[]) => string; callToAction: string }
+>([
+  [
+    'task',
+    {
+      message: (notFound: string[]) =>
+        `Cannot find the ${notFound.join(',')} task${notFound.length > 1 ? 's' : ''}.`,
+      callToAction: 'Run `checkup --listTasks` to see available tasks',
+    },
+  ],
+  [
+    'category',
+    {
+      message: (notFound: string[]) =>
+        `Cannot find any tasks with the following ${
+          notFound.length > 1 ? 'category' : 'categories'
+        } ${notFound.join(',')}.`,
+      callToAction: '',
+    },
+  ],
+  [
+    'group',
+    {
+      message: (notFound: string[]) =>
+        `Cannot find any tasks with the following ${
+          notFound.length > 1 ? 'group' : 'groups'
+        } ${notFound.join(',')}.`,
+      callToAction: '',
+    },
+  ],
+]);

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -3,6 +3,8 @@ export type RunFlags = {
   help: void;
   config: string | undefined;
   cwd: string;
+  category: string[] | undefined;
+  group: string[] | undefined;
   task: string[] | undefined;
   listTasks: boolean;
   format: string;

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -23,6 +23,8 @@ const DEFAULT_FLAGS: RunFlags = {
   config: undefined,
   excludePaths: undefined,
   cwd: process.cwd(),
+  category: undefined,
+  group: undefined,
   task: undefined,
   listTasks: false,
   format: 'stdout',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9094,25 +9094,10 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
-  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
-
-type-fest@^0.20.2:
+type-fest@^0.11.0, type-fest@^0.20.2, type-fest@^0.6.0, type-fest@^0.8.1:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,7 +143,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.7", "@babel/parser@^7.3.1", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.7", "@babel/parser@^7.3.1", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5", "@babel/parser@^7.9.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
   integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
@@ -218,7 +218,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/template@^7.10.4":
+"@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
   integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
@@ -226,15 +226,6 @@
     "@babel/code-frame" "^7.10.4"
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
-
-"@babel/template@^7.3.3", "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
-  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
-  dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/parser" "^7.8.6"
-    "@babel/types" "^7.8.6"
 
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.11.5", "@babel/traverse@^7.2.3", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.11.5"
@@ -804,28 +795,14 @@
     "@octokit/plugin-request-log" "^1.0.0"
     "@octokit/plugin-rest-endpoint-methods" "4.2.1"
 
-"@octokit/types@^2.0.0", "@octokit/types@^2.11.1":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.12.1.tgz#4a26b4a85ec121043d3b0745b5798f9d8fd968ca"
-  integrity sha512-LRLR1tjbcCfAmUElvTmMvLEzstpx6Xt/aQVTg2xvd+kHA2Ekp1eWl5t+gU7bcwjXHYEAzh4hH4WH+kS3vh+wRw==
-  dependencies:
-    "@types/node" ">= 8"
-
-"@octokit/types@^2.12.1":
+"@octokit/types@^2.0.0", "@octokit/types@^2.11.1", "@octokit/types@^2.12.1":
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.12.2.tgz#e9fbffa294adb54140946d436da9f73bc94b169c"
   integrity sha512-1GHLI/Jll3j6F0GbYyZPFTcHZMGjAiRfkTEoRUyaVVk2IWbDdwEiClAJvXzfXCDayuGSNCqAUH8lpjZtqW9GDw==
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/types@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.0.1.tgz#5459e9a5e9df8565dcc62c17a34491904d71971e"
-  integrity sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==
-  dependencies:
-    "@types/node" ">= 8"
-
-"@octokit/types@^5.5.0":
+"@octokit/types@^5.0.0", "@octokit/types@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.5.0.tgz#e5f06e8db21246ca102aa28444cdb13ae17a139b"
   integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
@@ -1365,12 +1342,7 @@ acorn@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
-  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
-
-acorn@^7.4.0:
+acorn@^7.1.0, acorn@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
@@ -3617,12 +3589,7 @@ estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -6673,15 +6640,10 @@ mkdirp@^1.0.0, mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.15.1, moment@^2.24.0:
+moment@^2.15.1, moment@^2.18.1, moment@^2.24.0:
   version "2.25.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.1.tgz#1cb546dca1eccdd607c9324747842200b683465d"
   integrity sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w==
-
-moment@^2.18.1:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -8157,41 +8119,22 @@ rx-lite@^3.1.2:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
   integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
 
-rxjs@>=6.4.0, rxjs@^6.4.0:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
-  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.6.3:
+rxjs@>=6.4.0, rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -9151,10 +9094,25 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.11.0, type-fest@^0.13.1, type-fest@^0.20.2, type-fest@^0.6.0, type-fest@^0.8.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
-  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
This change expands the existing functionality of the command line options to include the ability to run tasks by either category or group.

Similar to the `task` option, you can now pass a `category` option (multiple times):

```shell
checkup --category 'best practices'
```

or a `group` option (multiple times)

```shell
checkup --group 'ember'
```