### PR TITLE
Creating interface "TaskMetadata" and bucketing info about each task under it

### DIFF
--- a/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
@@ -79,10 +79,12 @@ const OWN_PROPERTIES_RULES = ['no-implicit-this'];
 const USE_MODIFIERS_RULES = ['no-action'];
 
 export default class EmberOctaneMigrationStatusTask extends BaseTask implements Task {
-  taskName = 'ember-octane-migration-status';
-  taskDisplayName = 'Ember Octane Migration Status';
-  category = 'migrations';
-  group = 'ember';
+  taskMetadata = {
+    taskName: 'ember-octane-migration-status',
+    taskDisplayName: 'Ember Octane Migration Status',
+    category: 'migrations',
+    group: 'ember',
+  };
 
   private eslintParser: Parser<ESLintReport>;
   private templateLinter: TemplateLinter;

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-template-lint-summary-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-template-lint-summary-task-test.ts.snap
@@ -22,7 +22,7 @@ Array [
     "occurrenceCount": 1,
     "properties": Object {
       "category": "linting",
-      "group": "ember",
+      "group": "linting-summary",
       "lintRuleId": "no-bare-strings",
       "taskDisplayName": "Template Lint Summary",
       "type": "error",
@@ -49,7 +49,7 @@ Array [
     "occurrenceCount": 1,
     "properties": Object {
       "category": "linting",
-      "group": "ember",
+      "group": "linting-summary",
       "lintRuleId": "no-bare-strings",
       "taskDisplayName": "Template Lint Summary",
       "type": "error",
@@ -76,7 +76,7 @@ Array [
     "occurrenceCount": 1,
     "properties": Object {
       "category": "linting",
-      "group": "ember",
+      "group": "linting-summary",
       "lintRuleId": "no-inline-styles",
       "taskDisplayName": "Template Lint Summary",
       "type": "error",
@@ -103,7 +103,7 @@ Array [
     "occurrenceCount": 1,
     "properties": Object {
       "category": "linting",
-      "group": "ember",
+      "group": "linting-summary",
       "lintRuleId": "require-valid-alt-text",
       "taskDisplayName": "Template Lint Summary",
       "type": "warning",

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -10,10 +10,12 @@ type Dependency = {
 };
 
 export default class EmberDependenciesTask extends BaseTask implements Task {
-  taskName = 'ember-dependencies';
-  taskDisplayName = 'Ember Dependencies';
-  category = 'dependencies';
-  group = 'ember';
+  taskMetadata = {
+    taskName: 'ember-dependencies',
+    taskDisplayName: 'Ember Dependencies',
+    category: 'dependencies',
+    group: 'ember',
+  };
 
   async run(): Promise<Result[]> {
     let packageJson = this.context.pkg;

--- a/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
@@ -7,10 +7,12 @@ import { readJsonSync } from 'fs-extra';
 import { Result } from 'sarif';
 
 export default class EmberInRepoAddonsEnginesTask extends BaseTask implements Task {
-  taskName = 'ember-in-repo-addons-engines';
-  taskDisplayName = 'Ember In-Repo Addons / Engines';
-  category = 'metrics';
-  group = 'ember';
+  taskMetadata = {
+    taskName: 'ember-in-repo-addons-engines',
+    taskDisplayName: 'Ember In-Repo Addons / Engines',
+    category: 'metrics',
+    group: 'ember',
+  };
 
   async run(): Promise<Result[]> {
     let inRepoAddons: string[] = [];

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
@@ -14,10 +14,12 @@ const { parse, traverse } = require('ember-template-recast');
 const TEMPLATE_LINT_DISABLE = 'template-lint-disable';
 
 export default class EmberTemplateLintDisableTask extends BaseTask implements Task {
-  taskName = 'ember-template-lint-disables';
-  taskDisplayName = 'Number of template-lint-disable Usages';
-  category = 'linting';
-  group = 'disabled-lint-rules';
+  taskMetadata = {
+    taskName: 'ember-template-lint-disables',
+    taskDisplayName: 'Number of template-lint-disable Usages',
+    category: 'linting',
+    group: 'disabled-lint-rules',
+  };
 
   async run(): Promise<Result[]> {
     let hbsPaths = this.context.paths.filterByGlob('**/*.hbs');

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
@@ -15,10 +15,12 @@ import { join, resolve } from 'path';
 import { Result } from 'sarif';
 
 export default class TemplateLintSummaryTask extends BaseTask implements Task {
-  taskName = 'ember-template-lint-summary';
-  taskDisplayName = 'Template Lint Summary';
-  category = 'linting';
-  group = 'ember';
+  taskMetadata = {
+    taskName: 'ember-template-lint-summary',
+    taskDisplayName: 'Template Lint Summary',
+    category: 'linting',
+    group: 'linting-summary',
+  };
 
   private templateLinter: TemplateLinter;
 

--- a/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
@@ -12,10 +12,12 @@ import { EMBER_TEST_TYPES } from '../utils/lint-configs';
 import { Result } from 'sarif';
 
 export default class EmberTestTypesTask extends BaseTask implements Task {
-  taskName = 'ember-test-types';
-  taskDisplayName = 'Test Types';
-  category = 'testing';
-  group = 'ember';
+  taskMetadata = {
+    taskName: 'ember-test-types',
+    taskDisplayName: 'Test Types',
+    category: 'testing',
+    group: 'ember',
+  };
 
   private eslintParser: Parser<ESLintReport>;
   private testFiles: string[];

--- a/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
@@ -15,10 +15,12 @@ const SEARCH_PATTERNS = [
 ];
 
 export default class EmberTypesTask extends BaseTask implements Task {
-  taskName = 'ember-types';
-  taskDisplayName = 'Ember Types';
-  category = 'metrics';
-  group = 'ember';
+  taskMetadata = {
+    taskName: 'ember-types',
+    taskDisplayName: 'Ember Types',
+    category: 'metrics',
+    group: 'ember',
+  };
 
   async run(): Promise<Result[]> {
     let types = SEARCH_PATTERNS.flatMap((pattern) => {

--- a/packages/checkup-plugin-javascript/__tests__/__snapshots__/eslint-summary-task-test.ts.snap
+++ b/packages/checkup-plugin-javascript/__tests__/__snapshots__/eslint-summary-task-test.ts.snap
@@ -22,7 +22,7 @@ Array [
     "occurrenceCount": 1,
     "properties": Object {
       "category": "linting",
-      "group": undefined,
+      "group": "linting-summary",
       "lintRuleId": "semi",
       "taskDisplayName": "Eslint Summary",
       "type": "error",
@@ -49,7 +49,7 @@ Array [
     "occurrenceCount": 1,
     "properties": Object {
       "category": "linting",
-      "group": undefined,
+      "group": "linting-summary",
       "lintRuleId": "no-var",
       "taskDisplayName": "Eslint Summary",
       "type": "warning",

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -17,10 +17,12 @@ const fs = require('fs');
 const ESLINT_DISABLE_REGEX = /^eslint-disable(?:-next-line|-line)*/gi;
 
 export default class EslintDisableTask extends BaseTask implements Task {
-  taskName = 'eslint-disables';
-  taskDisplayName = 'Number of eslint-disable Usages';
-  category = 'linting';
-  group = 'disabled-lint-rules';
+  taskMetadata = {
+    taskName: 'eslint-disables',
+    taskDisplayName: 'Number of eslint-disable Usages',
+    category: 'linting',
+    group: 'disabled-lint-rules',
+  };
 
   async run(): Promise<Result[]> {
     let jsPaths = this.context.paths.filterByGlob('**/*.js');

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -32,9 +32,12 @@ export const ACCEPTED_ESLINT_CONFIG_FILES = [
 ];
 
 export class EslintSummaryTask extends BaseTask implements Task {
-  taskName = 'eslint-summary';
-  taskDisplayName = 'Eslint Summary';
-  category = 'linting';
+  taskMetadata = {
+    taskName: 'eslint-summary',
+    taskDisplayName: 'Eslint Summary',
+    category: 'linting',
+    group: 'linting-summary',
+  };
 
   private _eslintParser: Parser<ESLintReport>;
 

--- a/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
@@ -59,9 +59,11 @@ async function getDependencies(path: string): Promise<OutdatedDependency[]> {
 }
 
 export default class OutdatedDependenciesTask extends BaseTask implements Task {
-  taskName = 'outdated-dependencies';
-  taskDisplayName = 'Outdated Dependencies';
-  category = 'dependencies';
+  taskMetadata = {
+    taskName: 'outdated-dependencies',
+    taskDisplayName: 'Outdated Dependencies',
+    category: 'dependencies',
+  };
 
   async run(): Promise<Result[]> {
     let outdatedDependencies = await getDependencies(this.context.cliFlags.cwd);

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -15,10 +15,12 @@ import { runCommand } from '../../src/run-command';
 const TEST_TIMEOUT = 100000;
 
 class FooTask extends BaseTask implements Task {
-  taskName = 'foo';
-  taskDisplayName = 'Foo Task';
-  category = 'fake1';
-  group = 'group1';
+  taskMetadata = {
+    taskName: 'foo',
+    taskDisplayName: 'Foo Task',
+    category: 'fake1',
+    group: 'group1',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -29,10 +31,12 @@ class FooTask extends BaseTask implements Task {
 }
 
 class FileCountTask extends BaseTask implements Task {
-  taskName = 'file-count';
-  taskDisplayName = 'File Count Task';
-  category = 'fake2';
-  group = 'group2';
+  taskMetadata = {
+    taskName: 'file-count',
+    taskDisplayName: 'File Count Task',
+    category: 'fake2',
+    group: 'group2',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -6,10 +6,12 @@ import { Result } from 'sarif';
 const STABLE_ERROR = new Error('Something went wrong in this task');
 
 class InsightsTaskHigh extends BaseTask implements Task {
-  taskName = 'insights-task-high';
-  taskDisplayName = 'Insights Task High';
-  category = 'bar';
-  group = 'group1';
+  taskMetadata = {
+    taskName: 'insights-task-high',
+    taskDisplayName: 'Insights Task High',
+    category: 'bar',
+    group: 'group1',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -21,10 +23,12 @@ class InsightsTaskHigh extends BaseTask implements Task {
 }
 
 class InsightsTaskLow extends BaseTask implements Task {
-  taskName = 'insights-task-low';
-  taskDisplayName = 'Insights Task Low';
-  category = 'foo';
-  group = 'group2';
+  taskMetadata = {
+    taskName: 'insights-task-low',
+    taskDisplayName: 'Insights Task Low',
+    category: 'foo',
+    group: 'group2',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -35,10 +39,11 @@ class InsightsTaskLow extends BaseTask implements Task {
 }
 
 class RecommendationsTaskHigh extends BaseTask implements Task {
-  taskName = 'recommendations-task-high';
-  taskDisplayName = 'Recommendations Task High';
-
-  category = 'baz';
+  taskMetadata = {
+    taskName: 'recommendations-task-high',
+    taskDisplayName: 'Recommendations Task High',
+    category: 'baz',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -49,10 +54,11 @@ class RecommendationsTaskHigh extends BaseTask implements Task {
 }
 
 class RecommendationsTaskLow extends BaseTask implements Task {
-  taskName = 'recommendations-task-low';
-  taskDisplayName = 'Recommendations Task Low';
-
-  category = 'bar';
+  taskMetadata = {
+    taskName: 'recommendations-task-low',
+    taskDisplayName: 'Recommendations Task Low',
+    category: 'bar',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -63,10 +69,11 @@ class RecommendationsTaskLow extends BaseTask implements Task {
 }
 
 class MigrationTaskHigh extends BaseTask implements Task {
-  taskName = 'migration-task-high';
-  taskDisplayName = 'Migration Task High';
-
-  category = 'foo';
+  taskMetadata = {
+    taskName: 'migration-task-high',
+    taskDisplayName: 'Migration Task High',
+    category: 'foo',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -77,10 +84,11 @@ class MigrationTaskHigh extends BaseTask implements Task {
 }
 
 class MigrationTaskLow extends BaseTask implements Task {
-  taskName = 'migration-task-low';
-  taskDisplayName = 'Migration Task Low';
-
-  category = 'baz';
+  taskMetadata = {
+    taskName: 'migration-task-low',
+    taskDisplayName: 'Migration Task Low',
+    category: 'baz',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -91,10 +99,11 @@ class MigrationTaskLow extends BaseTask implements Task {
 }
 
 class ErrorTask extends BaseTask implements Task {
-  taskName = 'error-task';
-  taskDisplayName = 'Error Task';
-
-  category = 'bar';
+  taskMetadata = {
+    taskName: 'error-task',
+    taskDisplayName: 'Error Task',
+    category: 'bar',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);
@@ -105,10 +114,11 @@ class ErrorTask extends BaseTask implements Task {
 }
 
 class TaskWithoutCategory extends BaseTask implements Task {
-  taskName = 'task-without-category';
-  taskDisplayName = 'Task Without Category';
-
-  category = '';
+  taskMetadata = {
+    taskName: 'task-without-category',
+    taskDisplayName: 'Task Without Category',
+    category: '',
+  };
 
   constructor(context: TaskContext) {
     super('fake', context);

--- a/packages/cli/src/get-log.ts
+++ b/packages/cli/src/get-log.ts
@@ -46,9 +46,13 @@ function getReportingDescriptors(taskList: TaskList): ReportingDescriptor[] {
   let tasks = taskList.getTasks();
   return tasks.map((task: Task) => {
     return {
-      id: task.taskName,
-      shortDescription: { text: task.taskDisplayName },
-      properties: { enabled: task.enabled, group: task.group, category: task.category },
+      id: task.taskMetadata.taskName,
+      shortDescription: { text: task.taskMetadata.taskDisplayName },
+      properties: {
+        enabled: task.enabled,
+        group: task.taskMetadata.group,
+        category: task.taskMetadata.category,
+      },
     };
   });
 }

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -52,13 +52,13 @@ export default class TaskList {
    * @param taskClassification
    */
   registerTask(task: Task) {
-    if (task.category === '') {
+    if (task.taskMetadata.category === '') {
       throw new Error(
         `Task category can not be empty. Please add a category to ${task.fullyQualifiedTaskName}-task.`
       );
     }
-    let categoryMap = this.getByCategory(task.category);
-    categoryMap!.set(task.taskName, task);
+    let categoryMap = this.getByCategory(task.taskMetadata.category);
+    categoryMap!.set(task.taskMetadata.taskName, task);
   }
 
   /**
@@ -79,7 +79,7 @@ export default class TaskList {
    */
   find(
     taskName: TaskName,
-    predicate: (task: Task) => boolean = (task) => task.taskName === taskName
+    predicate: (task: Task) => boolean = (task) => task.taskMetadata.taskName === taskName
   ): Task | undefined {
     return this.getTasks().find(predicate);
   }
@@ -140,7 +140,7 @@ export default class TaskList {
       let taskFound = false;
 
       for (let availableTask of availableTasks) {
-        if (availableTask.group === group) {
+        if (availableTask.taskMetadata.group === group) {
           taskFound = true;
           tasksFound.push(availableTask);
         }

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -4,9 +4,11 @@ import { getTaskContext } from '@checkup/test-helpers';
 import BaseTask from '../src/base-task';
 
 class FakeTask extends BaseTask {
-  taskName = 'my-fake';
-  taskDisplayName = 'Fake';
-  category = 'foo';
+  taskMetadata = {
+    taskName: 'my-fake',
+    taskDisplayName: 'Fake',
+    category: 'foo',
+  };
 }
 
 describe('BaseTask', () => {

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -1,6 +1,6 @@
 import * as debug from 'debug';
 
-import { TaskContext, TaskName } from './types/tasks';
+import { TaskContext, TaskMetadata } from './types/tasks';
 
 import { TaskConfig, ConfigValue } from './types/config';
 import { getShorthandName } from './utils/plugin-name';
@@ -9,10 +9,7 @@ import { parseConfigTuple } from './config';
 import { Result } from 'sarif';
 
 export default abstract class BaseTask {
-  abstract taskName: TaskName;
-  abstract taskDisplayName: string;
-  abstract category: string;
-  group?: string;
+  abstract taskMetadata: TaskMetadata;
   context: TaskContext;
   debug: debug.Debugger;
 
@@ -44,19 +41,19 @@ export default abstract class BaseTask {
   }
 
   get fullyQualifiedTaskName() {
-    return `${this._pluginName}/${this.taskName}`;
+    return `${this._pluginName}/${this.taskMetadata.taskName}`;
   }
 
   appendCheckupProperties(result: Result) {
     result.properties = {
       ...result.properties,
       ...{
-        taskDisplayName: this.taskDisplayName,
-        category: this.category,
-        group: this.group,
+        taskDisplayName: this.taskMetadata.taskDisplayName,
+        category: this.taskMetadata.category,
+        group: this.taskMetadata.group,
       },
     };
-    result.ruleId = this.taskName;
+    result.ruleId = this.taskMetadata.taskName;
     return result;
   }
 

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -29,17 +29,21 @@ export type TaskName = string;
 export type TaskIdentifier = { taskName: string; taskDisplayName: string };
 
 export interface Task {
-  taskName: TaskName;
-  taskDisplayName: TaskName;
+  taskMetadata: TaskMetadata;
   config: TaskConfig;
-  category: string;
-  group?: string;
 
   readonly fullyQualifiedTaskName: string;
   readonly enabled: boolean;
 
   run: () => Promise<Result[]>;
   appendCheckupProperties: (result: Result) => Result;
+}
+
+export interface TaskMetadata {
+  taskName: TaskName;
+  taskDisplayName: TaskName;
+  category: string;
+  group?: string;
 }
 
 export type ActionItem = string | string[] | { columns: string[]; rows: object[] };


### PR DESCRIPTION
This is PR 1 of 2 to remove the need for the `appendCheckupProperties` function pattern. After bucketing `taskName`, `taskDisplayName`, `category`, and `group` under `taskMetadata` I will put up another PR where I pass that data into the builders directly, and remove the need for the `appendCheckupProperties` on each Result