### PR TITLE
Fixes output to only include tasks that were executed.

### DIFF
--- a/checkup.code-workspace
+++ b/checkup.code-workspace
@@ -14,7 +14,8 @@
   "settings": {
     "files.exclude": {
       "**/node_modules/**": true
-    }
+    },
+    "typescript.tsdk": "node_modules/typescript/lib"
   },
   "files.associations": {}
 }

--- a/checkup.code-workspace
+++ b/checkup.code-workspace
@@ -15,7 +15,8 @@
     "files.exclude": {
       "**/node_modules/**": true
     },
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "editor.formatOnSave": true
   },
   "files.associations": {}
 }

--- a/packages/checkup-plugin-javascript/__tests__/__snapshots__/outdated-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-javascript/__tests__/__snapshots__/outdated-dependencies-task-test.ts.snap
@@ -36,7 +36,7 @@ Array [
         Object {
           "homepage": "https://ember-cli.com/",
           "installed": "3.20.0",
-          "latest": "3.22.0",
+          "latest": "3.23.0",
           "packageJsonVersion": "3.20.0",
           "packageName": "ember-cli",
           "semverBump": "minor",

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -111,6 +111,16 @@ config dd17cda1fc2eb2bc6bb5206b41fc1a84
 "
 `;
 
+exports[`@checkup/cli normal cli output should output list of available tasks 1`] = `
+"
+AVAILABLE TASKS
+
+  fake/file-count
+  fake/foo
+
+"
+`;
+
 exports[`@checkup/cli normal cli output should run a single task if the tasks option is specified with a single task 1`] = `
 "
 Checkup report generated for checkup-app v0.0.0 (6 files analyzed)

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -64,6 +64,7 @@ describe('@checkup/cli', () => {
     });
 
     afterEach(function () {
+      _resetTasksForTesting();
       project.dispose();
     });
 
@@ -80,7 +81,7 @@ describe('@checkup/cli', () => {
           '',
           'This project is 0 days old, with 0 days active days, 0 commits and 0 files.',
           '',
-          'Checkup ran the following tasks successfully:',
+          'Checkup ran the following task(s) successfully:',
           '',
           'Results have been saved to the following file:',
           '<outputPath>',
@@ -88,6 +89,19 @@ describe('@checkup/cli', () => {
           'checkup v0.0.0',
           'config dd17cda1fc2eb2bc6bb5206b41fc1a84',
         ]);
+      },
+      TEST_TIMEOUT
+    );
+
+    it(
+      'should output list of available tasks',
+      async () => {
+        _registerTaskForTesting(new FileCountTask(getTaskContext()));
+        _registerTaskForTesting(new FooTask(getTaskContext()));
+
+        await runCommand(['run', '--cwd', project.baseDir, '--listTasks']);
+
+        expect(stdout()).toMatchSnapshot();
       },
       TEST_TIMEOUT
     );
@@ -142,7 +156,6 @@ describe('@checkup/cli', () => {
       await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir, '--verbose']);
 
       expect(stdout()).toMatchSnapshot();
-      _resetTasksForTesting();
     });
 
     it('should run with timing if CHECKUP_TIMING=1', async () => {
@@ -153,7 +166,6 @@ describe('@checkup/cli', () => {
 
       expect(stdout()).toContain('Task Timings');
       process.env.CHECKUP_TIMING = undefined;
-      _resetTasksForTesting();
     });
 
     it('should run multiple tasks if the tasks option is specified with multiple tasks', async () => {
@@ -172,7 +184,6 @@ describe('@checkup/cli', () => {
       ]);
 
       expect(stdout()).toMatchSnapshot();
-      _resetTasksForTesting();
     });
 
     it('should run only one task if the category option is specified', async () => {
@@ -182,7 +193,6 @@ describe('@checkup/cli', () => {
       await runCommand(['run', '--category', 'fake1', '--cwd', project.baseDir, '--verbose']);
 
       expect(stdout()).toMatchSnapshot();
-      _resetTasksForTesting();
     });
 
     it('should run multiple tasks if the category option is specified with multiple categories', async () => {
@@ -201,7 +211,6 @@ describe('@checkup/cli', () => {
       ]);
 
       expect(stdout()).toMatchSnapshot();
-      _resetTasksForTesting();
     });
 
     it('should run only one task if the group option is specified', async () => {
@@ -211,7 +220,6 @@ describe('@checkup/cli', () => {
       await runCommand(['run', '--group', 'group1', '--cwd', project.baseDir, '--verbose']);
 
       expect(stdout()).toMatchSnapshot();
-      _resetTasksForTesting();
     });
 
     it('should run multiple tasks if the group option is specified with multiple groups', async () => {
@@ -230,7 +238,6 @@ describe('@checkup/cli', () => {
       ]);
 
       expect(stdout()).toMatchSnapshot();
-      _resetTasksForTesting();
     });
 
     it(
@@ -251,8 +258,6 @@ describe('@checkup/cli', () => {
         ]);
 
         expect(stdout()).toMatchSnapshot();
-        project.dispose();
-        _resetTasksForTesting();
       },
       TEST_TIMEOUT
     );
@@ -314,7 +319,6 @@ describe('@checkup/cli', () => {
         expect(unFilteredRun).toMatchSnapshot();
 
         expect(filteredRun).not.toStrictEqual(unFilteredRun);
-        _resetTasksForTesting();
       },
       TEST_TIMEOUT
     );

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -109,6 +109,7 @@ export default class RunCommand extends BaseCommand {
     }),
     listTasks: flags.boolean({
       char: 'l',
+
       description: 'List all available tasks to run.',
     }),
     verbose: flags.boolean({
@@ -127,6 +128,7 @@ export default class RunCommand extends BaseCommand {
   startTime: string = '';
   actions: Action[] = [];
   checkupConfig!: CheckupConfig;
+  executedTasks!: Task[];
   cliModeEnabled: boolean = true;
 
   get taskFilterType() {
@@ -179,7 +181,8 @@ export default class RunCommand extends BaseCommand {
         this.pluginTaskResults,
         this.actions,
         this.getInvocation(errors),
-        this.pluginTasks
+        this.pluginTasks,
+        this.executedTasks
       );
 
       if (this.cliModeEnabled) {
@@ -215,8 +218,11 @@ export default class RunCommand extends BaseCommand {
         this.extendedError(new CheckupError(error.message(tasksNotFound), error.callToAction));
         ui.action.stop();
       }
+
+      this.executedTasks = tasksFound;
     } else {
       [this.pluginTaskResults, this.pluginTaskErrors] = await this.pluginTasks.runTasks();
+      this.executedTasks = this.pluginTasks.getTasks();
     }
   }
 

--- a/packages/cli/src/get-log.ts
+++ b/packages/cli/src/get-log.ts
@@ -8,7 +8,8 @@ export function getLog(
   taskResults: Result[],
   actions: Action[],
   invocation: Invocation,
-  taskList: TaskList
+  taskList: TaskList,
+  executedTasks: Task[]
 ): Log {
   let _info = Object.assign(
     {},
@@ -26,7 +27,7 @@ export function getLog(
         tool: {
           driver: {
             name: 'Checkup',
-            rules: getReportingDescriptors(taskList),
+            rules: getReportingDescriptors(executedTasks),
             language: 'en-US',
             informationUri: 'https://github.com/checkupjs/checkup',
             version: _info.cli.version,
@@ -42,8 +43,7 @@ export function getLog(
  * @param taskNames
  * @returns {ReportingDescriptor[]} used to populate tool.driver.rules
  */
-function getReportingDescriptors(taskList: TaskList): ReportingDescriptor[] {
-  let tasks = taskList.getTasks();
+function getReportingDescriptors(tasks: Task[]): ReportingDescriptor[] {
   return tasks.map((task: Task) => {
     return {
       id: task.taskName,

--- a/packages/cli/src/reporters/console-reporter.ts
+++ b/packages/cli/src/reporters/console-reporter.ts
@@ -11,7 +11,7 @@ export function report(result: Log, flags?: RunFlags) {
 
   renderInfo(metaData);
 
-  ui.log('Checkup ran the following tasks successfully:');
+  ui.log('Checkup ran the following task(s) successfully:');
   rules!
     .map((rule) => rule.id)
     .sort()


### PR DESCRIPTION
The output should reflect only the tasks that were executed based on the passed flags.

Example: only executing the Octane migration task

```shell
❯ checkup --task=ember-octane/ember-octane-migration-status

Checkup report generated for travis v0.0.1 (1667 files analyzed)

This project is 9 years old, with 1446 active days, 5981 commits and 1661 files.

Checkup ran the following task(s) successfully:
✔ ember-octane-migration-status

Results have been saved to the following file:
/Users/scalvert/workspace/personal/travis-web/checkup-report-2020-12-14-13_55_57.sarif

checkup v0.12.0
config ba31c18af0bcc3546b98ae3e431b8a5f

Checking up on your project... done
```

Example: executing all configured tasks

```shell
❯ checkup

Checkup report generated for travis v0.0.1 (1668 files analyzed)

This project is 9 years old, with 1446 active days, 5981 commits and 1661 files.

Checkup ran the following task(s) successfully:
✔ ember-octane-migration-status
✔ eslint-disables
✔ eslint-summary
✔ outdated-dependencies

Results have been saved to the following file:
/Users/scalvert/workspace/personal/travis-web/checkup-report-2020-12-14-13_56_25.sarif

checkup v0.12.0
config ba31c18af0bcc3546b98ae3e431b8a5f

Checking up on your project... done
```