### PR TITLE
Convert all flags to dasherized

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,35 +57,36 @@ USAGE
   $ checkup [run] PATHS
 
 ARGUMENTS
-  PATHS  The paths that checkup will operate on. If no paths are provided, checkup
-         will run on the entire directory beginning at --cwd.
+  PATHS  The paths that checkup will operate on. If no paths are provided, checkup will run on the entire directory beginning
+         at --cwd.
 
 OPTIONS
-  -c, --config=config              Use this configuration, overriding .checkuprc.*
-                                   if present.
+  -c, --config=config                Use this configuration, overriding .checkuprc.* if present.
 
-  -d, --cwd=cwd                    [default: /Users/scalvert/Workspace/travis-web]
-                                   The path referring to the root directory that
-                                   Checkup will run in
+  -d, --cwd=cwd                      [default: '.'] The path referring to the root
+                                     directory that Checkup will run in
 
-  -e, --exclude-paths=excludePaths  Paths to exclude from checkup. If paths are
-                                   provided via command line and via checkup
-                                   config, command line paths will be used.
+  -e, --exclude-paths=exclude-paths  Paths to exclude from checkup. If paths are provided via command line and via checkup
+                                     config, command line paths will be used.
 
-  -f, --format=stdout|json         [default: stdout] The output format, one of
-                                   stdout, json
+  -f, --format=stdout|json           [default: stdout] The output format, one of stdout, json
 
-  -h, --help                       show CLI help
+  -h, --help                         show CLI help
 
-  -l, --list-tasks                  List all available tasks to run.
+  -l, --list-tasks                   List all available tasks to run.
 
-  -o, --output-file=outputFile      Specify file to write report to.
+  -o, --output-file=output-file      Specify file to write JSON output to. Requires the `--format` flag to be set to `json`
 
-  -t, --task=task                  Runs specific task specified by the fully
-                                   qualified task name in the format
-                                   pluginName/taskName. Can be used multiple times.
+  -t, --task=task                    Runs specific tasks specified by the fully qualified task name in the format
+                                     pluginName/taskName. Can be used multiple times.
 
-  -v, --version                    show CLI version
+  -v, --version                      show CLI version
+
+  --category=category                Runs specific tasks specified by category. Can be used multiple times.
+
+  --group=group                      Runs specific tasks specified by group. Can be used multiple times.
+
+  --verbose
 ```
 
 _See code: [src/commands/run.ts](https://github.com/checkupjs/checkup/blob/v0.0.0/src/commands/run.ts)_

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,7 +68,7 @@ OPTIONS
                                    The path referring to the root directory that
                                    Checkup will run in
 
-  -e, --excludePaths=excludePaths  Paths to exclude from checkup. If paths are
+  -e, --exclude-paths=excludePaths  Paths to exclude from checkup. If paths are
                                    provided via command line and via checkup
                                    config, command line paths will be used.
 
@@ -77,9 +77,9 @@ OPTIONS
 
   -h, --help                       show CLI help
 
-  -l, --listTasks                  List all available tasks to run.
+  -l, --list-tasks                  List all available tasks to run.
 
-  -o, --outputFile=outputFile      Specify file to write report to.
+  -o, --output-file=outputFile      Specify file to write report to.
 
   -t, --task=task                  Runs specific task specified by the fully
                                    qualified task name in the format

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -99,7 +99,7 @@ describe('@checkup/cli', () => {
         _registerTaskForTesting(new FileCountTask(getTaskContext()));
         _registerTaskForTesting(new FooTask(getTaskContext()));
 
-        await runCommand(['run', '--cwd', project.baseDir, '--listTasks']);
+        await runCommand(['run', '--cwd', project.baseDir, '--list-tasks']);
 
         expect(stdout()).toMatchSnapshot();
       },
@@ -126,7 +126,7 @@ describe('@checkup/cli', () => {
     });
 
     it(
-      'should output a json file in a custom directory if the json format and outputFile options are provided',
+      'should output a json file in a custom directory if the json format and output-file options are provided',
       async () => {
         let tmp = createTmpDir();
 
@@ -134,7 +134,7 @@ describe('@checkup/cli', () => {
           'run',
           '--format',
           'json',
-          `--outputFile`,
+          `--output-file`,
           join(tmp, 'my-checkup-file.json'),
           '--cwd',
           project.baseDir,
@@ -356,7 +356,7 @@ describe('@checkup/cli', () => {
           'run',
           '--cwd',
           project.baseDir,
-          '--excludePaths',
+          '--exclude-paths',
           '**/*.hbs',
           '**/*.js',
           '--verbose',
@@ -372,7 +372,7 @@ describe('@checkup/cli', () => {
           'run',
           '--cwd',
           project.baseDir,
-          '--excludePaths',
+          '--exclude-paths',
           '**/*.hbs',
           '--verbose',
         ]);
@@ -395,7 +395,7 @@ describe('@checkup/cli', () => {
           'run',
           '--cwd',
           project.baseDir,
-          '--excludePaths',
+          '--exclude-paths',
           '**/*.js',
           '--verbose',
         ]);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -63,7 +63,7 @@ export default class RunCommand extends BaseCommand {
   static flags = {
     version: flags.version({ char: 'v' }),
     help: flags.help({ char: 'h' }),
-    excludePaths: flags.string({
+    'exclude-paths': flags.string({
       description:
         'Paths to exclude from checkup. If paths are provided via command line and via checkup config, command line paths will be used.',
       char: 'e',
@@ -101,13 +101,13 @@ export default class RunCommand extends BaseCommand {
       default: 'stdout',
       description: `The output format, one of ${[...Object.values(OutputFormat)].join(', ')}`,
     }),
-    outputFile: flags.string({
+    'output-file': flags.string({
       char: 'o',
       default: '',
       description:
         'Specify file to write JSON output to. Requires the `--format` flag to be set to `json`',
     }),
-    listTasks: flags.boolean({
+    'list-tasks': flags.boolean({
       char: 'l',
 
       description: 'List all available tasks to run.',
@@ -146,10 +146,10 @@ export default class RunCommand extends BaseCommand {
   public async init() {
     let { argv, flags } = this.parse(RunCommand);
 
-    if (flags.outputFile && flags.format !== OutputFormat.json) {
+    if (flags['output-file'] && flags.format !== OutputFormat.json) {
       this.error(
         new Error(
-          'Missing --format flag. --format=json must also be provided when using --outputFile'
+          'Missing --format flag. --format=json must also be provided when using --output-file'
         )
       );
     }
@@ -164,7 +164,7 @@ export default class RunCommand extends BaseCommand {
 
     await this.register();
 
-    if (this.runFlags.listTasks) {
+    if (this.runFlags['list-tasks']) {
       this.printAvailableTasks();
     } else {
       if (this.cliModeEnabled) {
@@ -294,7 +294,7 @@ export default class RunCommand extends BaseCommand {
     });
 
     // if excludePaths are provided both via the command line and config, the command line is prioritized
-    let excludePaths = this.runFlags.excludePaths || this.checkupConfig.excludePaths;
+    let excludePaths = this.runFlags['exclude-paths'] || this.checkupConfig.excludePaths;
 
     taskContext = Object.freeze({
       cliArguments: this.runArgs,
@@ -336,7 +336,7 @@ export default class RunCommand extends BaseCommand {
       endTimeUtc: new Date().toJSON(),
       environmentVariables: {
         cwd: this.runFlags.cwd,
-        outputFile: this.runFlags.outputFile,
+        outputFile: this.runFlags['output-file'],
         format: this.runFlags.format,
       },
       toolExecutionNotifications: buildNotificationsFromTaskErrors(errors),

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -113,7 +113,7 @@ export default class RunCommand extends BaseCommand {
       description: 'List all available tasks to run.',
     }),
     verbose: flags.boolean({
-      exclusive: ['format'],
+      exclusive: ['format', 'output-file'],
     }),
   };
 

--- a/packages/cli/src/reporters/json-reporter.ts
+++ b/packages/cli/src/reporters/json-reporter.ts
@@ -3,10 +3,8 @@ import { ui, RunFlags } from '@checkup/core';
 import { writeOutputFile } from './sarif-file-writer';
 
 export function report(result: Log, flags?: RunFlags) {
-  let { outputFile, cwd } = flags!;
-
-  if (outputFile) {
-    writeOutputFile(outputFile, cwd, result);
+  if (flags && flags['output-file']) {
+    writeOutputFile(flags['output-file'], flags.cwd, result);
   } else {
     ui.styledJSON(result);
   }

--- a/packages/cli/src/tasks/project-meta-task.ts
+++ b/packages/cli/src/tasks/project-meta-task.ts
@@ -41,7 +41,7 @@ export default class ProjectMetaTask implements MetaTask {
     let package_ = this.context.pkg;
     let repositoryInfo = await getRepositoryInfo(this.context.cliFlags.cwd, this.context.paths);
 
-    let { config, task, format, outputFile, excludePaths } = this.context.cliFlags;
+    let { config, task, format } = this.context.cliFlags;
     let analyzedFiles = normalizePaths(this.context.paths, this.context.cliFlags.cwd);
 
     result.data = {
@@ -63,8 +63,8 @@ export default class ProjectMetaTask implements MetaTask {
           config,
           task,
           format,
-          outputFile,
-          excludePaths,
+          outputFile: this.context.cliFlags['output-file'],
+          excludePaths: this.context.cliFlags['exclude-paths'],
         },
       },
 

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -6,9 +6,9 @@ export type RunFlags = {
   category: string[] | undefined;
   group: string[] | undefined;
   task: string[] | undefined;
-  listTasks: boolean;
+  'list-tasks': boolean;
   format: string;
-  outputFile: string;
-  excludePaths: string[] | undefined;
+  'output-file': string;
+  'exclude-paths': string[] | undefined;
   verbose: boolean;
 };

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -21,14 +21,14 @@ const DEFAULT_FLAGS: RunFlags = {
   version: undefined,
   help: undefined,
   config: undefined,
-  excludePaths: undefined,
+  'exclude-paths': undefined,
   cwd: process.cwd(),
   category: undefined,
   group: undefined,
   task: undefined,
-  listTasks: false,
+  'list-tasks': false,
   format: 'stdout',
-  outputFile: '',
+  'output-file': '',
   verbose: false,
 };
 


### PR DESCRIPTION
Checkup's existing flags used `camelCase` for flags with compound words. This feels less natural, as many CLIs use `kebab-case`. This change converts the existing compound words to kebab case.

```shell
❯ checkup --help
A health checkup for your project

USAGE
  $ checkup [run] PATHS

ARGUMENTS
  PATHS  The paths that checkup will operate on. If no paths are provided, checkup will run on the entire directory beginning
         at --cwd.

OPTIONS
  -c, --config=config                Use this configuration, overriding .checkuprc.* if present.

  -d, --cwd=cwd                      The path referring to the root directory that Checkup will run in

  -e, --exclude-paths=exclude-paths  Paths to exclude from checkup. If paths are provided via command line and via checkup
                                     config, command line paths will be used.

  -f, --format=stdout|json           [default: stdout] The output format, one of stdout, json

  -h, --help                         show CLI help

  -l, --list-tasks                   List all available tasks to run.

  -o, --output-file=output-file      Specify file to write JSON output to. Requires the `--format` flag to be set to `json`

  -t, --task=task                    Runs specific tasks specified by the fully qualified task name in the format
                                     pluginName/taskName. Can be used multiple times.

  -v, --version                      show CLI version

  --category=category                Runs specific tasks specified by category. Can be used multiple times.

  --group=group                      Runs specific tasks specified by group. Can be used multiple times.

  --verbose
```