### PR TITLE
Removing `appendCheckupProperties` and doing it directly in the builders

### DIFF
--- a/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
@@ -103,11 +103,10 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
       this.runTemplateLint(),
     ]);
 
-    let octaneResults = buildResult(
+    return this.buildResult(
       [...esLintReport.results, ...templateLintReport.results],
       this.context.cliFlags.cwd
     );
-    return octaneResults.map((octaneResult) => this.appendCheckupProperties(octaneResult));
   }
 
   private async runEsLint(): Promise<ESLintReport> {
@@ -121,36 +120,36 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
 
     return this.templateLinter.execute(hbsPaths);
   }
-}
 
-function buildResult(lintingResults: (ESLintResult | TemplateLintResult)[], cwd: string): Result[] {
-  let rawData = lintingResults.reduce((resultDataItems, lintingResults) => {
-    let messages = (<any>lintingResults.messages).map(
-      (lintMessage: ESLintMessage | TemplateLintMessage) => {
-        return buildLintResultDataItem(lintMessage, cwd, lintingResults.filePath);
-      }
-    );
+  buildResult(lintingResults: (ESLintResult | TemplateLintResult)[], cwd: string): Result[] {
+    let rawData = lintingResults.reduce((resultDataItems, lintingResults) => {
+      let messages = (<any>lintingResults.messages).map(
+        (lintMessage: ESLintMessage | TemplateLintMessage) => {
+          return buildLintResultDataItem(lintMessage, cwd, lintingResults.filePath);
+        }
+      );
 
-    resultDataItems.push(...messages);
+      resultDataItems.push(...messages);
 
-    return resultDataItems;
-  }, [] as LintResult[]);
+      return resultDataItems;
+    }, [] as LintResult[]);
 
-  return [
-    { key: 'Native Classes', rules: NATIVE_CLASS_RULES },
-    { key: 'Tagless Components', rules: TAGLESS_COMPONENTS_RULES },
-    { key: 'Glimmer Components', rules: GLIMMER_COMPONENTS_RULES },
-    { key: 'Tracked Propeties', rules: TRACKED_PROPERTIES_RULES },
-    { key: 'Angle Brackets Syntax', rules: ANGLE_BRACKETS_SYNTAX_RULES },
-    { key: 'Named Arguments', rules: NAMED_ARGUMENTS_RULES },
-    { key: 'Own Properties', rules: OWN_PROPERTIES_RULES },
-    { key: 'Modifiers', rules: USE_MODIFIERS_RULES },
-  ].flatMap(({ rules, key }) => {
-    let rulesGroupForKey = groupDataByField(byRuleIds(rawData, rules), 'lintRuleId');
-    return rulesGroupForKey.flatMap((rulesForKey) => {
-      return buildResultsFromLintResult(rulesForKey, {
-        resultGroup: key,
+    return [
+      { key: 'Native Classes', rules: NATIVE_CLASS_RULES },
+      { key: 'Tagless Components', rules: TAGLESS_COMPONENTS_RULES },
+      { key: 'Glimmer Components', rules: GLIMMER_COMPONENTS_RULES },
+      { key: 'Tracked Propeties', rules: TRACKED_PROPERTIES_RULES },
+      { key: 'Angle Brackets Syntax', rules: ANGLE_BRACKETS_SYNTAX_RULES },
+      { key: 'Named Arguments', rules: NAMED_ARGUMENTS_RULES },
+      { key: 'Own Properties', rules: OWN_PROPERTIES_RULES },
+      { key: 'Modifiers', rules: USE_MODIFIERS_RULES },
+    ].flatMap(({ rules, key }) => {
+      let rulesGroupForKey = groupDataByField(byRuleIds(rawData, rules), 'lintRuleId');
+      return rulesGroupForKey.flatMap((rulesForKey) => {
+        return buildResultsFromLintResult(this, rulesForKey, {
+          resultGroup: key,
+        });
       });
     });
-  });
+  }
 }

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -19,29 +19,34 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
     let packageJson = this.context.pkg;
 
     let coreLibraries = buildResultsFromProperties(
+      this,
       [
         findDependency(packageJson, 'ember-source'),
         findDependency(packageJson, 'ember-cli'),
         findDependency(packageJson, 'ember-data'),
       ],
       'ember core libraries'
-    ).map((result) => this.appendCheckupProperties(result));
+    );
     let emberDependencies = buildResultsFromProperties(
+      this,
       findDependencies(packageJson.dependencies, emberAddonFilter),
       'ember addon dependencies'
-    ).map((result) => this.appendCheckupProperties(result));
+    );
     let emberDevDependencies = buildResultsFromProperties(
+      this,
       findDependencies(packageJson.devDependencies, emberAddonFilter),
       'ember addon devDependencies'
-    ).map((result) => this.appendCheckupProperties(result));
+    );
     let emberCliDependencies = buildResultsFromProperties(
+      this,
       findDependencies(packageJson.dependencies, emberCliAddonFilter),
       'ember-cli addon dependencies'
-    ).map((result) => this.appendCheckupProperties(result));
+    );
     let emberCliDevDependencies = buildResultsFromProperties(
+      this,
       findDependencies(packageJson.devDependencies, emberCliAddonFilter),
       'ember-cli addon devDependencies'
-    ).map((result) => this.appendCheckupProperties(result));
+    );
 
     return [
       ...coreLibraries,

--- a/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
@@ -29,12 +29,8 @@ export default class EmberInRepoAddonsEnginesTask extends BaseTask implements Ta
     });
 
     return [
-      ...buildResultsFromPathArray(inRepoAddons.sort(), 'in-repo addons').map((result) =>
-        this.appendCheckupProperties(result)
-      ),
-      ...buildResultsFromPathArray(inRepoEngines.sort(), 'in-repo engines').map((result) =>
-        this.appendCheckupProperties(result)
-      ),
+      ...buildResultsFromPathArray(this, inRepoAddons.sort(), 'in-repo addons'),
+      ...buildResultsFromPathArray(this, inRepoEngines.sort(), 'in-repo engines'),
     ];
   }
 }

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
@@ -23,9 +23,7 @@ export default class EmberTemplateLintDisableTask extends BaseTask implements Ta
     let hbsPaths = this.context.paths.filterByGlob('**/*.hbs');
     let templateLintDisables = await getTemplateLintDisables(hbsPaths, this.context.cliFlags.cwd);
 
-    return buildResultsFromLintResult(templateLintDisables).map((result) =>
-      this.appendCheckupProperties(result)
-    );
+    return buildResultsFromLintResult(this, templateLintDisables);
   }
 }
 

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
@@ -60,15 +60,15 @@ export default class TemplateLintSummaryTask extends BaseTask implements Task {
     let lintingWarnings = groupDataByField(bySeverity(lintResults, 1), 'lintRuleId');
 
     let errorsResult = lintingErrors.flatMap((lintingError) => {
-      return buildResultsFromLintResult(lintingError, {
+      return buildResultsFromLintResult(this, lintingError, {
         type: 'error',
-      }).map((result) => this.appendCheckupProperties(result));
+      });
     });
 
     let warningsResult = lintingWarnings.flatMap((lintingWarning) => {
-      return buildResultsFromLintResult(lintingWarning, {
+      return buildResultsFromLintResult(this, lintingWarning, {
         type: 'warning',
-      }).map((result) => this.appendCheckupProperties(result));
+      });
     });
 
     return [...errorsResult, ...warningsResult];

--- a/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
@@ -32,8 +32,7 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
   async run(): Promise<Result[]> {
     let esLintReport = await this.runEsLint();
 
-    let results = this.buildResult(esLintReport, this.context.cliFlags.cwd);
-    return results.map((result) => this.appendCheckupProperties(result));
+    return this.buildResult(esLintReport, this.context.cliFlags.cwd);
   }
 
   private async runEsLint(): Promise<ESLintReport> {
@@ -70,7 +69,7 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
     });
 
     return Object.keys(testTypes).flatMap((key) => {
-      return buildResultsFromLintResult(testTypes[key], {
+      return buildResultsFromLintResult(this, testTypes[key], {
         method: testTypes[key][0].method,
       });
     });

--- a/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
@@ -24,9 +24,10 @@ export default class EmberTypesTask extends BaseTask implements Task {
     let types = SEARCH_PATTERNS.flatMap((pattern) => {
       let files = this.context.paths.filterByGlob(pattern.pattern);
       return buildResultsFromPathArray(
+        this,
         normalizePaths(files, this.context.cliFlags.cwd),
         pattern.patternName
-      ).map((type) => this.appendCheckupProperties(type));
+      );
     });
 
     return types;

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -26,9 +26,7 @@ export default class EslintDisableTask extends BaseTask implements Task {
     let jsPaths = this.context.paths.filterByGlob('**/*.js');
     let eslintDisables: LintResult[] = await getEslintDisables(jsPaths, this.context.cliFlags.cwd);
 
-    return buildResultsFromLintResult(eslintDisables).map((result) =>
-      this.appendCheckupProperties(result)
-    );
+    return buildResultsFromLintResult(this, eslintDisables);
   }
 }
 

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -59,14 +59,14 @@ export class EslintSummaryTask extends BaseTask implements Task {
     let lintingWarnings = groupDataByField(bySeverity(transformedData, 1), 'lintRuleId');
 
     let errorsResult = lintingErrors.flatMap((lintingError) => {
-      return buildResultsFromLintResult(lintingError, {
+      return buildResultsFromLintResult(this, lintingError, {
         type: 'error',
-      }).map((result) => this.appendCheckupProperties(result));
+      });
     });
     let warningsResult = lintingWarnings.flatMap((lintingWarning) => {
-      return buildResultsFromLintResult(lintingWarning, {
+      return buildResultsFromLintResult(this, lintingWarning, {
         type: 'warning',
-      }).map((result) => this.appendCheckupProperties(result));
+      });
     });
 
     return [...errorsResult, ...warningsResult];

--- a/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
@@ -68,9 +68,7 @@ export default class OutdatedDependenciesTask extends BaseTask implements Task {
     let groupedDependencies = groupDataByField(outdatedDependencies, 'semverBump');
 
     return groupedDependencies.flatMap((dependencyGroup) =>
-      buildResultsFromProperties(dependencyGroup, dependencyGroup[0].semverBump).map((result) =>
-        this.appendCheckupProperties(result)
-      )
+      buildResultsFromProperties(this, dependencyGroup, dependencyGroup[0].semverBump)
     );
   }
 }

--- a/packages/cli/__tests__/__snapshots__/meta-task-list-test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/meta-task-list-test.ts.snap
@@ -1,13 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MetaTaskList runTasks will run all registered tasks 1`] = `
-Object {
-  "fake-meta-task": "fake meta task is being run",
+MockMetaTaskResult {
+  "meta": Object {
+    "taskDisplayName": "Fake Meta Task",
+    "taskName": "fake-meta-task",
+  },
+  "result": "fake meta task is being run",
 }
 `;
 
 exports[`MetaTaskList runTasks will run all registered tasks 2`] = `
-Object {
-  "other-fake-meta-task": "other fake meta task is being run",
+MockMetaTaskResult {
+  "meta": Object {
+    "taskDisplayName": "Other Fake Meta Task",
+    "taskName": "other-fake-meta-task",
+  },
+  "result": "other fake meta task is being run",
 }
 `;

--- a/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
+++ b/packages/cli/__tests__/__utils__/mock-meta-task-result.ts
@@ -7,10 +7,7 @@ export default class MockMetaTaskResult extends BaseMetaTaskResult implements Me
   constructor(meta: TaskIdentifier, public result: any) {
     super(meta);
   }
-
-  appendCheckupProperties() {
-    return {
-      [this.meta.taskName]: this.result,
-    };
+  getData() {
+    return { [this.meta.taskName]: this.result };
   }
 }

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -135,7 +135,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -158,7 +158,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -181,13 +181,13 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (-NaN)
+■ hi (0)
 
 === Fake 1
 
 Foo Task
 
-■ hi (-NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -210,13 +210,13 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (-NaN)
+■ hi (0)
 
 === Fake 1
 
 Foo Task
 
-■ hi (-NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -239,13 +239,13 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (-NaN)
+■ hi (0)
 
 === Fake 1
 
 Foo Task
 
-■ hi (-NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -268,7 +268,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 Foo Task
 
-■ hi (-NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -291,7 +291,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 Foo Task
 
-■ hi (-NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -314,7 +314,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (NaN)
+■ hi (0)
 
 
 checkup v0.0.0
@@ -337,7 +337,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
-■ hi (NaN)
+■ hi (0)
 
 
 checkup v0.0.0

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -1,4 +1,10 @@
-import { BaseTask, normalizePath, Task, TaskContext } from '@checkup/core';
+import {
+  BaseTask,
+  normalizePath,
+  Task,
+  TaskContext,
+  buildResultsFromProperties,
+} from '@checkup/core';
 import {
   CheckupProject,
   clearStdout,
@@ -24,7 +30,7 @@ class FooTask extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' }, occurrenceCount: 0 })];
+    return buildResultsFromProperties(this, [], 'hi');
   }
 }
 
@@ -38,7 +44,7 @@ class FileCountTask extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' }, occurrenceCount: 0 })];
+    return buildResultsFromProperties(this, [], 'hi');
   }
 }
 

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -11,7 +11,7 @@ export default class MyFooTask extends BaseTask {
 
 
   async run() {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -72,7 +72,7 @@ export default class MyFooTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -133,7 +133,7 @@ export default class MyFooTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -195,7 +195,7 @@ export default class MyFooTask extends BaseTask implements Task {
   group = 'bar';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -257,7 +257,7 @@ export default class MyFooTask extends BaseTask implements Task {
   group = 'bar';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -319,7 +319,7 @@ export default class MyFooTask extends BaseTask implements Task {
   group = 'bar';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -380,7 +380,7 @@ export default class MyFooTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "
@@ -427,7 +427,7 @@ export default class MyBarTask extends BaseTask implements Task {
   category = '';
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }
 "

--- a/packages/cli/__tests__/meta-task-list-test.ts
+++ b/packages/cli/__tests__/meta-task-list-test.ts
@@ -71,9 +71,13 @@ describe('MetaTaskList', () => {
 
     let [result, errors] = await taskList.runTask('fake-meta-task');
 
-    expect(result!.appendCheckupProperties()).toMatchInlineSnapshot(`
-      Object {
-        "fake-meta-task": "fake meta task is being run",
+    expect(result!).toMatchInlineSnapshot(`
+      MockMetaTaskResult {
+        "meta": Object {
+          "taskDisplayName": "Fake Meta Task",
+          "taskName": "fake-meta-task",
+        },
+        "result": "fake meta task is being run",
       }
     `);
     expect(errors).toHaveLength(0);
@@ -87,8 +91,8 @@ describe('MetaTaskList', () => {
 
     let [results, errors] = await taskList.runTasks();
 
-    expect(results[0].appendCheckupProperties()).toMatchSnapshot();
-    expect(results[1].appendCheckupProperties()).toMatchSnapshot();
+    expect(results[0]).toMatchSnapshot();
+    expect(results[1]).toMatchSnapshot();
     expect(errors).toHaveLength(0);
   });
 });

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -16,7 +16,17 @@ class InsightsTaskHigh extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          category: this.category,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 
@@ -30,7 +40,17 @@ class InsightsTaskLow extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          category: this.category,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 
@@ -44,7 +64,17 @@ class RecommendationsTaskHigh extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          category: this.category,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 
@@ -58,7 +88,17 @@ class RecommendationsTaskLow extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          category: this.category,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 
@@ -72,7 +112,17 @@ class MigrationTaskHigh extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          category: this.category,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 
@@ -86,7 +136,17 @@ class MigrationTaskLow extends BaseTask implements Task {
     super('fake', context);
   }
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          category: this.category,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 
@@ -115,7 +175,16 @@ class TaskWithoutCategory extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    return [this.appendCheckupProperties({ message: { text: 'hi' } })];
+    return [
+      {
+        message: { text: 'hi' },
+        properties: {
+          taskDisplayName: this.taskDisplayName,
+          group: this.group,
+        },
+        ruleId: this.taskName,
+      },
+    ];
   }
 }
 

--- a/packages/cli/__tests__/tasks/project-meta-task-test.ts
+++ b/packages/cli/__tests__/tasks/project-meta-task-test.ts
@@ -51,79 +51,85 @@ describe('project-meta-task', () => {
       ).run();
       const taskResult = <ProjectMetaTaskResult>result;
 
-      expect(taskResult.appendCheckupProperties()).toMatchInlineSnapshot(`
-        Object {
-          "analyzedFiles": FilePathArray [
-            ".git/HEAD",
-            ".git/config",
-            ".git/description",
-            ".git/hooks/applypatch-msg.sample",
-            ".git/hooks/commit-msg.sample",
-            ".git/hooks/fsmonitor-watchman.sample",
-            ".git/hooks/post-update.sample",
-            ".git/hooks/pre-applypatch.sample",
-            ".git/hooks/pre-commit.sample",
-            ".git/hooks/pre-merge-commit.sample",
-            ".git/hooks/pre-push.sample",
-            ".git/hooks/pre-rebase.sample",
-            ".git/hooks/pre-receive.sample",
-            ".git/hooks/prepare-commit-msg.sample",
-            ".git/hooks/update.sample",
-            ".git/info/exclude",
-            "index.hbs",
-            "index.js",
-            "index.scss",
-            "index.whatever",
-            "package.json",
-          ],
-          "analyzedFilesCount": 21,
-          "cli": Object {
-            "args": Object {
-              "paths": Array [],
-            },
-            "config": Object {
-              "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-              "excludePaths": Array [],
-              "plugins": Array [],
-              "tasks": Object {},
-            },
-            "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
-            "flags": Object {
-              "config": undefined,
-              "excludePaths": undefined,
-              "format": "stdout",
-              "outputFile": "",
-              "task": undefined,
-            },
-            "schema": 1,
-            "version": "0.0.0",
-          },
-          "project": Object {
-            "name": "checkup-app",
-            "repository": Object {
-              "activeDays": "0 days",
-              "age": "0 days",
-              "linesOfCode": Object {
-                "total": 15,
-                "types": Array [
-                  Object {
-                    "extension": "scss",
-                    "total": 10,
-                  },
-                  Object {
-                    "extension": "js",
-                    "total": 4,
-                  },
-                  Object {
-                    "extension": "hbs",
-                    "total": 1,
-                  },
-                ],
+      expect(taskResult).toMatchInlineSnapshot(`
+        ProjectMetaTaskResult {
+          "data": Object {
+            "analyzedFiles": FilePathArray [
+              ".git/HEAD",
+              ".git/config",
+              ".git/description",
+              ".git/hooks/applypatch-msg.sample",
+              ".git/hooks/commit-msg.sample",
+              ".git/hooks/fsmonitor-watchman.sample",
+              ".git/hooks/post-update.sample",
+              ".git/hooks/pre-applypatch.sample",
+              ".git/hooks/pre-commit.sample",
+              ".git/hooks/pre-merge-commit.sample",
+              ".git/hooks/pre-push.sample",
+              ".git/hooks/pre-rebase.sample",
+              ".git/hooks/pre-receive.sample",
+              ".git/hooks/prepare-commit-msg.sample",
+              ".git/hooks/update.sample",
+              ".git/info/exclude",
+              "index.hbs",
+              "index.js",
+              "index.scss",
+              "index.whatever",
+              "package.json",
+            ],
+            "analyzedFilesCount": 21,
+            "cli": Object {
+              "args": Object {
+                "paths": Array [],
               },
-              "totalCommits": 0,
-              "totalFiles": 0,
+              "config": Object {
+                "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+                "excludePaths": Array [],
+                "plugins": Array [],
+                "tasks": Object {},
+              },
+              "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
+              "flags": Object {
+                "config": undefined,
+                "excludePaths": undefined,
+                "format": "stdout",
+                "outputFile": "",
+                "task": undefined,
+              },
+              "schema": 1,
+              "version": "0.0.0",
             },
-            "version": "0.0.0",
+            "project": Object {
+              "name": "checkup-app",
+              "repository": Object {
+                "activeDays": "0 days",
+                "age": "0 days",
+                "linesOfCode": Object {
+                  "total": 15,
+                  "types": Array [
+                    Object {
+                      "extension": "scss",
+                      "total": 10,
+                    },
+                    Object {
+                      "extension": "js",
+                      "total": 4,
+                    },
+                    Object {
+                      "extension": "hbs",
+                      "total": 1,
+                    },
+                  ],
+                },
+                "totalCommits": 0,
+                "totalFiles": 0,
+              },
+              "version": "0.0.0",
+            },
+          },
+          "meta": Object {
+            "taskDisplayName": "Project",
+            "taskName": "project",
           },
         }
       `);
@@ -144,46 +150,52 @@ describe('project-meta-task', () => {
         })
       ).run();
 
-      expect(result.appendCheckupProperties()).toMatchInlineSnapshot(`
-        Object {
-          "analyzedFiles": FilePathArray [],
-          "analyzedFilesCount": 0,
-          "cli": Object {
-            "args": Object {
-              "paths": Array [],
-            },
-            "config": Object {
-              "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-              "excludePaths": Array [],
-              "plugins": Array [
-                "checkup-plugin-ember",
-              ],
-              "tasks": Object {},
-            },
-            "configHash": "2f97c4acdec7c73cce0b6c3e3e0cedc2",
-            "flags": Object {
-              "config": undefined,
-              "excludePaths": undefined,
-              "format": "stdout",
-              "outputFile": "",
-              "task": undefined,
-            },
-            "schema": 1,
-            "version": "0.0.0",
-          },
-          "project": Object {
-            "name": "checkup-app",
-            "repository": Object {
-              "activeDays": "0 days",
-              "age": "0 days",
-              "linesOfCode": Object {
-                "total": 0,
-                "types": Array [],
+      expect(result).toMatchInlineSnapshot(`
+        ProjectMetaTaskResult {
+          "data": Object {
+            "analyzedFiles": FilePathArray [],
+            "analyzedFilesCount": 0,
+            "cli": Object {
+              "args": Object {
+                "paths": Array [],
               },
-              "totalCommits": 0,
-              "totalFiles": 0,
+              "config": Object {
+                "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+                "excludePaths": Array [],
+                "plugins": Array [
+                  "checkup-plugin-ember",
+                ],
+                "tasks": Object {},
+              },
+              "configHash": "2f97c4acdec7c73cce0b6c3e3e0cedc2",
+              "flags": Object {
+                "config": undefined,
+                "excludePaths": undefined,
+                "format": "stdout",
+                "outputFile": "",
+                "task": undefined,
+              },
+              "schema": 1,
+              "version": "0.0.0",
             },
-            "version": "0.0.0",
+            "project": Object {
+              "name": "checkup-app",
+              "repository": Object {
+                "activeDays": "0 days",
+                "age": "0 days",
+                "linesOfCode": Object {
+                  "total": 0,
+                  "types": Array [],
+                },
+                "totalCommits": 0,
+                "totalFiles": 0,
+              },
+              "version": "0.0.0",
+            },
+          },
+          "meta": Object {
+            "taskDisplayName": "Project",
+            "taskName": "project",
           },
         }
       `);

--- a/packages/cli/src/get-log.ts
+++ b/packages/cli/src/get-log.ts
@@ -11,10 +11,7 @@ export function getLog(
   taskList: TaskList,
   executedTasks: Task[]
 ): Log {
-  let _info = Object.assign(
-    {},
-    ...info.map((result) => result.appendCheckupProperties())
-  ) as CheckupMetadata;
+  let _info = Object.assign({}, ...info.map((result) => result.getData())) as CheckupMetadata;
 
   return {
     version: '2.1.0',

--- a/packages/cli/src/results/project-meta-task-result.ts
+++ b/packages/cli/src/results/project-meta-task-result.ts
@@ -7,7 +7,7 @@ import { JsonObject } from 'type-fest';
 export default class ProjectMetaTaskResult extends BaseMetaTaskResult implements MetaTaskResult {
   data!: CheckupMetadata;
 
-  appendCheckupProperties() {
+  getData() {
     return (this.data as unknown) as JsonObject;
   }
 }

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,4 +1,4 @@
-import { JsonMetaTaskResult, TaskIdentifier } from '@checkup/core';
+import { TaskIdentifier, JsonMetaTaskResult } from '@checkup/core';
 
 export default {};
 
@@ -10,5 +10,5 @@ export interface MetaTask {
 
 export interface MetaTaskResult {
   meta: TaskIdentifier;
-  appendCheckupProperties: () => JsonMetaTaskResult;
+  getData: () => JsonMetaTaskResult;
 }

--- a/packages/cli/templates/src/task/src/tasks/task.js.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.js.ejs
@@ -10,6 +10,6 @@ export default class <%- taskClass %> extends BaseTask {
 
 
   async run() {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }

--- a/packages/cli/templates/src/task/src/tasks/task.ts.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.ts.ejs
@@ -10,6 +10,6 @@ export default class <%- taskClass %> extends BaseTask implements Task {
   <%_ } _%>
 
   async run(): Promise<Result[]> {
-    return this.appendCheckupProperties([]);
+    return [];
   }
 }

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -5,9 +5,6 @@ import { TaskContext, TaskName } from './types/tasks';
 import { TaskConfig, ConfigValue } from './types/config';
 import { getShorthandName } from './utils/plugin-name';
 import { parseConfigTuple } from './config';
-
-import { Result } from 'sarif';
-
 export default abstract class BaseTask {
   abstract taskName: TaskName;
   abstract taskDisplayName: string;
@@ -45,19 +42,6 @@ export default abstract class BaseTask {
 
   get fullyQualifiedTaskName() {
     return `${this._pluginName}/${this.taskName}`;
-  }
-
-  appendCheckupProperties(result: Result) {
-    result.properties = {
-      ...result.properties,
-      ...{
-        taskDisplayName: this.taskDisplayName,
-        category: this.category,
-        group: this.group,
-      },
-    };
-    result.ruleId = this.taskName;
-    return result;
   }
 
   private _parseConfig() {

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -39,7 +39,6 @@ export interface Task {
   readonly enabled: boolean;
 
   run: () => Promise<Result[]>;
-  appendCheckupProperties: (result: Result) => Result;
 }
 
 export type ActionItem = string | string[] | { columns: string[]; rows: object[] };


### PR DESCRIPTION
Setting properties around what Task a Result is coming from in the builders directly, instead of doing it as a second step in `appendCheckupProperties` 