### PR TITLE
    Removing empty Results from Result[]

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
@@ -48,18 +48,6 @@ Array [
   },
   Object {
     "message": Object {
-      "text": "No results found",
-    },
-    "properties": Object {
-      "category": "dependencies",
-      "consoleMessage": "ember addon devDependencies",
-      "group": "ember",
-      "taskDisplayName": "Ember Dependencies",
-    },
-    "ruleId": "ember-dependencies",
-  },
-  Object {
-    "message": Object {
       "text": "ember-cli addon dependencies",
     },
     "occurrenceCount": 2,

--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -121,6 +121,27 @@ AVAILABLE TASKS
 "
 `;
 
+exports[`@checkup/cli normal cli output should render list of tasks with no results in verbose mode 1`] = `
+"
+Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
+
+This project is 0 days old, with 0 days active days, 0 commits and 0 files.
+
+■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
+■ js (2)
+■ hbs (1)
+
+
+No Results Found For
+
+■ Task Without Results
+
+checkup v0.0.0
+config dd17cda1fc2eb2bc6bb5206b41fc1a84
+
+"
+`;
+
 exports[`@checkup/cli normal cli output should run a single task if the tasks option is specified with a single task 1`] = `
 "
 Checkup report generated for checkup-app v0.0.0 (6 files analyzed)
@@ -131,12 +152,10 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
+■ File Count Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -154,12 +173,10 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
+■ File Count Task
 
 checkup v0.0.0
 config 2910e38984c8092494a42c88b642b9de
@@ -177,18 +194,11 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
-=== Fake 1
-
-Foo Task
-
-■ hi (0)
-
+■ Foo Task
+■ File Count Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -206,18 +216,11 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
-=== Fake 1
-
-Foo Task
-
-■ hi (0)
-
+■ Foo Task
+■ File Count Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -235,18 +238,11 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
-=== Fake 1
-
-Foo Task
-
-■ hi (0)
-
+■ File Count Task
+■ Foo Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -264,12 +260,10 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 1
 
-Foo Task
+No Results Found For
 
-■ hi (0)
-
+■ Foo Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -287,12 +281,10 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (2)
 ■ hbs (1)
 
-=== Fake 1
 
-Foo Task
+No Results Found For
 
-■ hi (0)
-
+■ Foo Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -310,12 +302,10 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ hbs (2)
 ■ js (1)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
+■ File Count Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84
@@ -333,12 +323,10 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 ■ js (4)
 ■ hbs (2)
 
-=== Fake 2
 
-File Count Task
+No Results Found For
 
-■ hi (0)
-
+■ File Count Task
 
 checkup v0.0.0
 config dd17cda1fc2eb2bc6bb5206b41fc1a84

--- a/packages/cli/__tests__/commands/run-test.ts
+++ b/packages/cli/__tests__/commands/run-test.ts
@@ -47,6 +47,18 @@ class FileCountTask extends BaseTask implements Task {
     return buildResultsFromProperties(this, [], 'hi');
   }
 }
+class TaskWithNoResults extends BaseTask implements Task {
+  taskName = 'no-results-task';
+  taskDisplayName = 'Task Without Results';
+  category = 'fake3';
+
+  constructor(context: TaskContext) {
+    super('fake', context);
+  }
+  async run(): Promise<Result[]> {
+    return [];
+  }
+}
 
 describe('@checkup/cli', () => {
   describe('normal cli output', () => {
@@ -160,6 +172,21 @@ describe('@checkup/cli', () => {
       _registerTaskForTesting(new FileCountTask(getTaskContext()));
 
       await runCommand(['run', '--task', 'fake/file-count', '--cwd', project.baseDir, '--verbose']);
+
+      expect(stdout()).toMatchSnapshot();
+    });
+
+    it('should render list of tasks with no results in verbose mode', async () => {
+      _registerTaskForTesting(new TaskWithNoResults(getTaskContext()));
+
+      await runCommand([
+        'run',
+        '--task',
+        'fake/no-results-task',
+        '--cwd',
+        project.baseDir,
+        '--verbose',
+      ]);
 
       expect(stdout()).toMatchSnapshot();
     });

--- a/packages/core/src/data/builders.ts
+++ b/packages/core/src/data/builders.ts
@@ -3,8 +3,6 @@ import { LintResult, TaskError, Task } from '../types/tasks';
 import { TemplateLintMessage, TemplateLintResult } from '../types/ember-template-lint';
 import { Result, Location, Notification } from 'sarif';
 
-export const NO_RESULTS_FOUND = 'No results found';
-
 /**
  * @param lintResult {LintResult}
  * @returns Location[]
@@ -62,7 +60,7 @@ export function buildResultsFromLintResult(
   additionalData: object = {}
 ): Result[] {
   if (lintResults.length === 0) {
-    return buildEmptyResult(taskContext);
+    return [];
   }
 
   return lintResults.map((lintResult) => {
@@ -95,7 +93,7 @@ export function buildResultsFromPathArray(
   message: string
 ): Result[] {
   if (paths.length === 0) {
-    return buildEmptyResult(taskContext, message);
+    return [];
   }
 
   return paths.map((path) => {
@@ -124,7 +122,7 @@ export function buildResultsFromProperties(
   message: string
 ): Result[] {
   if (data.length === 0) {
-    return buildEmptyResult(taskContext, message);
+    return [];
   }
 
   return [
@@ -134,26 +132,6 @@ export function buildResultsFromProperties(
       occurrenceCount: data.length,
       properties: {
         data: data,
-        ...{
-          taskDisplayName: taskContext.taskDisplayName,
-          category: taskContext.category,
-          group: taskContext.group,
-        },
-      },
-    },
-  ];
-}
-
-function buildEmptyResult(
-  taskContext: Pick<Task, 'taskName' | 'taskDisplayName' | 'category' | 'group'>,
-  consoleMessage?: string
-): Result[] {
-  return [
-    {
-      message: { text: NO_RESULTS_FOUND },
-      ruleId: taskContext.taskName,
-      properties: {
-        consoleMessage,
         ...{
           taskDisplayName: taskContext.taskDisplayName,
           category: taskContext.category,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,6 @@ export {
   buildNotificationsFromTaskErrors,
   normalizePath,
   normalizePaths,
-  NO_RESULTS_FOUND,
 } from './data/builders';
 
 export * from './types/cli';

--- a/packages/core/src/utils/ui.ts
+++ b/packages/core/src/utils/ui.ts
@@ -153,6 +153,12 @@ export const ui: typeof ux & { [key: string]: any } = Object.assign(ux, {
     );
   },
 
+  stringsList(strings: string[], color: chalk.Chalk = ui.randomColor()) {
+    strings.forEach((string) => {
+      ui.log(`${color('■')} ${string}`);
+    });
+  },
+
   randomColor() {
     const colors = this.colors();
     return colors[Math.floor(Math.random() * colors.length)];


### PR DESCRIPTION
Right now, when a task doesnt find any data for results, it creates sort of an empty Result with the message 'No results found' for a given task. This was a hack put in when we realized that Results couldn't have an occurrenceCount of 0. This doesnt really align with the principle of what SARIF spec wants - its basically just creating a Result with occurrenceCount = 0 without setting occurrenceCount... more confusing than bug in the first place.

This change removes that hack, and only returns actual/meaningful Results. In the verbose-console-reporter, added function that renders a list of the tasks without results found, so it will be clearer for humans consuming this data.

Now, tasks without Results will render like this: 
```
No Results Found For
■ Ember In-Repo Addons / Engines
■ Number of template-lint-disable Usages
```  