### PR TITLE
Extend lint tasks with custom config

### DIFF
--- a/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember-octane/src/tasks/ember-octane-migration-status-task.ts
@@ -93,8 +93,8 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
     let createEslintParser = this.context.parsers.get('eslint')!;
     let createEmberTemplateLintParser = this.context.parsers.get('ember-template-lint')!;
 
-    this.eslintParser = createEslintParser(OCTANE_ES_LINT_CONFIG);
-    this.templateLinter = createEmberTemplateLintParser(OCTANE_TEMPLATE_LINT_CONFIG);
+    this.eslintParser = createEslintParser(OCTANE_ES_LINT_CONFIG, this.config);
+    this.templateLinter = createEmberTemplateLintParser(OCTANE_TEMPLATE_LINT_CONFIG, this.config);
   }
 
   async run(): Promise<Result[]> {

--- a/packages/core/__tests__/__fixtures__/simple.js
+++ b/packages/core/__tests__/__fixtures__/simple.js
@@ -1,0 +1,3 @@
+function foo() {
+  return 'foo';
+}

--- a/packages/core/__tests__/parsers/ember-template-lint-parser-test.ts
+++ b/packages/core/__tests__/parsers/ember-template-lint-parser-test.ts
@@ -6,7 +6,7 @@ import { TemplateLintConfig } from '../../src/types/ember-template-lint';
 
 const TemplateLinter = require('ember-template-lint');
 
-describe('eslint-parser', () => {
+describe('ember-template-lint-parser', () => {
   it('can create an eslint parser', () => {
     let config: TemplateLintConfig = {};
 

--- a/packages/core/__tests__/parsers/ember-template-lint-parser-test.ts
+++ b/packages/core/__tests__/parsers/ember-template-lint-parser-test.ts
@@ -1,0 +1,49 @@
+import {
+  createParser,
+  EmberTemplateLintParser,
+} from '../../src/parsers/ember-template-lint-parser';
+import { TemplateLintConfig } from '../../src/types/ember-template-lint';
+
+const TemplateLinter = require('ember-template-lint');
+
+describe('eslint-parser', () => {
+  it('can create an eslint parser', () => {
+    let config: TemplateLintConfig = {};
+
+    let parser: EmberTemplateLintParser = createParser(config) as EmberTemplateLintParser;
+
+    expect(parser.engine).toBeInstanceOf(TemplateLinter);
+    expect(Object.keys(parser.engine.config)).toMatchInlineSnapshot(`
+      Array [
+        "rules",
+        "pending",
+        "overrides",
+        "ignore",
+        "extends",
+        "plugins",
+        "loadedRules",
+        "loadedConfigurations",
+        "_processed",
+      ]
+    `);
+  });
+
+  it('can create an eslint parser with custom rule configuration', () => {
+    let config: TemplateLintConfig = {
+      rules: {
+        'block-indentation': ['error', 6],
+      },
+    };
+
+    let parser: EmberTemplateLintParser = createParser(config) as EmberTemplateLintParser;
+    let optionsForRule = parser.engine.config.rules['block-indentation'];
+
+    expect(parser.engine).toBeInstanceOf(TemplateLinter);
+    expect(optionsForRule).toMatchInlineSnapshot(`
+      Object {
+        "config": 6,
+        "severity": 2,
+      }
+    `);
+  });
+});

--- a/packages/core/__tests__/parsers/eslint-parser-test.ts
+++ b/packages/core/__tests__/parsers/eslint-parser-test.ts
@@ -1,0 +1,76 @@
+import { CLIEngine } from 'eslint';
+import { resolve } from 'path';
+import { createParser, ESLintParser } from '../../src/parsers/eslint-parser';
+import { ESLintOptions } from '../../src/types/parsers';
+
+const SIMPLE_FILE_PATH = resolve('..', '__fixtures__/simple.js');
+
+describe('eslint-parser', () => {
+  it('can create an eslint parser', () => {
+    let config: ESLintOptions = {
+      parser: 'babel-eslint',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+          legacyDecorators: true,
+        },
+      },
+      envs: ['browser'],
+    };
+
+    let parser: ESLintParser = createParser(config) as ESLintParser;
+    let configForFile = parser.engine.getConfigForFile(SIMPLE_FILE_PATH);
+
+    expect(parser.engine).toBeInstanceOf(CLIEngine);
+    expect(Object.keys(configForFile)).toMatchInlineSnapshot(`
+      Array [
+        "env",
+        "globals",
+        "noInlineConfig",
+        "parser",
+        "parserOptions",
+        "plugins",
+        "reportUnusedDisableDirectives",
+        "rules",
+        "settings",
+        "ignorePatterns",
+      ]
+    `);
+  });
+
+  it('can create an eslint parser with custom rule configuration', () => {
+    let config: ESLintOptions = {
+      parser: 'babel-eslint',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+          legacyDecorators: true,
+        },
+      },
+      envs: ['browser'],
+      rules: {
+        'no-tabs': [
+          'error',
+          {
+            allowIndentationTabs: true,
+          },
+        ],
+      },
+    };
+
+    let parser: ESLintParser = createParser(config) as ESLintParser;
+    let configForFile = parser.engine.getConfigForFile(SIMPLE_FILE_PATH);
+
+    expect(parser.engine).toBeInstanceOf(CLIEngine);
+    expect(configForFile.rules!['no-tabs']).toMatchInlineSnapshot(`
+      Array [
+        "error",
+        Object {
+          "allowIndentationTabs": true,
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "chalk": "^4.0.0",
     "cli-ux": "^5.5.1",
     "debug": "^4.3.1",
+    "deepmerge": "^4.2.2",
     "ember-template-lint": "^2.14.0",
     "eslint": "^7.16.0",
     "fs-extra": "^9.0.1",

--- a/packages/core/src/parsers/ember-template-lint-parser.ts
+++ b/packages/core/src/parsers/ember-template-lint-parser.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as deepmerge from 'deepmerge';
 
 import { CreateParser, Parser } from '../types/parsers';
 import {
@@ -7,6 +8,7 @@ import {
   TemplateLintReport,
   TemplateLintResult,
 } from '../types/ember-template-lint';
+import { TaskConfig } from '../types/config';
 
 const TemplateLinter = require('ember-template-lint');
 
@@ -51,9 +53,14 @@ class EmberTemplateLintParser implements Parser<TemplateLintReport> {
 }
 
 let createParser: CreateParser<TemplateLintConfig, Parser<TemplateLintReport>> = function (
-  config: TemplateLintConfig
+  config: TemplateLintConfig,
+  taskConfig?: TaskConfig
 ) {
+  if (taskConfig && taskConfig.emberTemplateLintConfig) {
+    config = deepmerge(config, taskConfig.emberTemplateLintConfig);
+  }
+
   return new EmberTemplateLintParser(config);
 };
 
-export { createParser };
+export { createParser, EmberTemplateLintParser };

--- a/packages/core/src/parsers/eslint-parser.ts
+++ b/packages/core/src/parsers/eslint-parser.ts
@@ -1,6 +1,8 @@
 import { CreateParser, Parser } from '../types/parsers';
+import * as deepmerge from 'deepmerge';
 
 import { CLIEngine, Rule } from 'eslint';
+import { TaskConfig } from '../types/config';
 
 class ESLintParser implements Parser<CLIEngine.LintReport> {
   engine: CLIEngine;
@@ -24,9 +26,14 @@ class ESLintParser implements Parser<CLIEngine.LintReport> {
 }
 
 let createParser: CreateParser<CLIEngine.Options, Parser<CLIEngine.LintReport>> = function (
-  config: CLIEngine.Options
+  config: CLIEngine.Options,
+  taskConfig?: TaskConfig
 ) {
+  if (taskConfig && taskConfig.eslintConfig) {
+    config = deepmerge(config, taskConfig.eslintConfig);
+  }
+
   return new ESLintParser(config);
 };
 
-export { createParser };
+export { createParser, ESLintParser };

--- a/packages/core/src/types/parsers.ts
+++ b/packages/core/src/types/parsers.ts
@@ -1,4 +1,5 @@
 import { CLIEngine, Linter } from 'eslint';
+import { TaskConfig } from './config';
 
 const EmberTemplateLinter = require('ember-template-lint').TemplateLinter;
 
@@ -10,7 +11,7 @@ export interface Parser<ParserReport> {
 }
 
 export interface CreateParser<ParserOptions, TParser = Parser<ParserReport>> {
-  (config: ParserOptions): TParser;
+  (config: ParserOptions, taskConfig?: TaskConfig): TParser;
 }
 
 export type TemplateLinter = typeof EmberTemplateLinter;


### PR DESCRIPTION
Implements #828 

Allows for configuring tasks-based eslint/ember-template-lint configs via the config file's task configs.

Example:

```json
{
  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
  "excludePaths": ["**/foo"],
  "plugins": ["checkup-plugin-bar"],
  "tasks": {
    "bar/baz": ["on", {
      "eslintConfig": {
        //...
      }
    }],
    "bar/booze": ["on", {
      "emberTemplateLintConfig": {
        //...
      }
    }]
  }
}

```