### PR TITLE
Filtering out eslint results that indicate a rule was not found

### DIFF
--- a/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
+++ b/packages/cli/__tests__/commands/__snapshots__/run-test.ts.snap
@@ -135,6 +135,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -158,6 +159,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -181,12 +183,14 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 === Fake 1
 
 Foo Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -210,12 +214,14 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 === Fake 1
 
 Foo Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -239,12 +245,14 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 === Fake 1
 
 Foo Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -268,6 +276,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 Foo Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -291,6 +300,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 Foo Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -314,6 +324,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 
@@ -337,6 +348,7 @@ This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
 File Count Task
 
+Total: 0
 ■ hi (0)
 
 

--- a/packages/cli/src/reporters/verbose-console-reporter.ts
+++ b/packages/cli/src/reporters/verbose-console-reporter.ts
@@ -181,6 +181,9 @@ function getReportComponent(taskResults: Result[]) {
   );
 
   ui.section(groupedTaskResults[0].properties?.taskDisplayName, () => {
+    const totalResults = sumOccurrences(groupedTaskResults);
+    ui.log(`Total: ${totalResults}`);
+
     groupedTaskResults.forEach((result) => {
       if (result.message.text === NO_RESULTS_FOUND) {
         renderEmptyResult(result);


### PR DESCRIPTION
When you run eslint parser on files that `eslint-disable` rules that are not defined  in the parser, it throws an error

An example would be error: `Definition for rule 'ember-best-practices/no-side-effect-cp' was not found.` being added from a file that has `/* eslint-enable ember-best-practices/no-side-effect-cp */`, when `ember-best-practices` rules are not being run in the Task

Filtered thought out of Results and added a `Total:` count in the default verbose console output