### PR TITLE
Fixing task config overrides merging correctly

### DIFF
--- a/packages/core/__tests__/utils/merge-lint-config-test.ts
+++ b/packages/core/__tests__/utils/merge-lint-config-test.ts
@@ -1,0 +1,217 @@
+import { mergeLintConfig } from '../../src/utils/merge-lint-config';
+import { TemplateLintConfig } from '../../src/types/ember-template-lint';
+import { CLIEngine } from 'eslint';
+
+describe('mergeLintConfig', () => {
+  describe('eslint', () => {
+    it('should merge strings and tuples when strings are leftmost, tuple takes precedence', () => {
+      let original: CLIEngine.Options = {
+        rules: {
+          'fake-eslint-rule': 'error',
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-eslint-rule': [
+            'warn',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-eslint-rule": Array [
+              "warn",
+              Object {
+                "prop1": "error",
+                "prop2": "off",
+              },
+            ],
+          },
+        }
+      `);
+    });
+
+    it('should merge strings and tuples when tuples are leftmost, string takes precedence', () => {
+      let original: CLIEngine.Options = {
+        rules: {
+          'fake-eslint-rule': [
+            'warn',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-eslint-rule': 'error',
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-eslint-rule": "error",
+          },
+        }
+      `);
+    });
+
+    it('should merge rule tuples when there are rule overrides', () => {
+      let original: CLIEngine.Options = {
+        rules: {
+          'fake-eslint-rule': [
+            'warn',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-eslint-rule': [
+            'error',
+            {
+              prop1: 'warn',
+              prop2: 'off',
+              prop3: 'error',
+            },
+          ],
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-eslint-rule": Array [
+              "error",
+              Object {
+                "prop1": "warn",
+                "prop2": "off",
+                "prop3": "error",
+              },
+            ],
+          },
+        }
+      `);
+    });
+  });
+
+  describe('ember-template-lint', () => {
+    it('should merge strings and tuples when strings are leftmost, tuple takes precedence', () => {
+      let original: TemplateLintConfig = {
+        rules: {
+          'fake-ember-template-lint-rule': 'error',
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-ember-template-lint-rule': [
+            'warn',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-ember-template-lint-rule": Array [
+              "warn",
+              Object {
+                "prop1": "error",
+                "prop2": "off",
+              },
+            ],
+          },
+        }
+      `);
+    });
+
+    it('should merge strings and tuples when tuples are leftmost, string takes precedence', () => {
+      let original: TemplateLintConfig = {
+        rules: {
+          'fake-ember-template-lint-rule': [
+            'warn',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-ember-template-lint-rule': 'error',
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-ember-template-lint-rule": "error",
+          },
+        }
+      `);
+    });
+
+    it('should merge rule tuples when there are rule overrides', () => {
+      let original: TemplateLintConfig = {
+        rules: {
+          'fake-ember-template-lint-rule': [
+            'warn',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-ember-template-lint-rule': [
+            'error',
+            {
+              prop1: 'warn',
+              prop2: 'off',
+              prop3: 'error',
+            },
+          ],
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-ember-template-lint-rule": Array [
+              "error",
+              Object {
+                "prop1": "warn",
+                "prop2": "off",
+                "prop3": "error",
+              },
+            ],
+          },
+        }
+      `);
+    });
+  });
+});

--- a/packages/core/__tests__/utils/merge-lint-config-test.ts
+++ b/packages/core/__tests__/utils/merge-lint-config-test.ts
@@ -107,6 +107,47 @@ describe('mergeLintConfig', () => {
         }
       `);
     });
+
+    it('should merge rule tuples when there are rule overrides with true merge', () => {
+      let original: CLIEngine.Options = {
+        rules: {
+          'fake-eslint-rule': [
+            'error',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-eslint-rule': [
+            'error',
+            {
+              prop1: 'warn',
+              prop3: 'error',
+            },
+          ],
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-eslint-rule": Array [
+              "error",
+              Object {
+                "prop1": "warn",
+                "prop2": "off",
+                "prop3": "error",
+              },
+            ],
+          },
+        }
+      `);
+    });
   });
 
   describe('ember-template-lint', () => {
@@ -192,6 +233,47 @@ describe('mergeLintConfig', () => {
             {
               prop1: 'warn',
               prop2: 'off',
+              prop3: 'error',
+            },
+          ],
+        },
+      };
+
+      expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
+        Object {
+          "rules": Object {
+            "fake-ember-template-lint-rule": Array [
+              "error",
+              Object {
+                "prop1": "warn",
+                "prop2": "off",
+                "prop3": "error",
+              },
+            ],
+          },
+        }
+      `);
+    });
+
+    it('should merge rule tuples when there are rule overrides with true merge', () => {
+      let original: TemplateLintConfig = {
+        rules: {
+          'fake-ember-template-lint-rule': [
+            'error',
+            {
+              prop1: 'error',
+              prop2: 'off',
+            },
+          ],
+        },
+      };
+
+      let overrides = {
+        rules: {
+          'fake-ember-template-lint-rule': [
+            'error',
+            {
+              prop1: 'warn',
               prop3: 'error',
             },
           ],

--- a/packages/core/src/parsers/ember-template-lint-parser.ts
+++ b/packages/core/src/parsers/ember-template-lint-parser.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import * as deepmerge from 'deepmerge';
 
 import { CreateParser, Parser } from '../types/parsers';
 import {
@@ -9,6 +8,7 @@ import {
   TemplateLintResult,
 } from '../types/ember-template-lint';
 import { TaskConfig } from '../types/config';
+import { mergeLintConfig } from '../utils/merge-lint-config';
 
 const TemplateLinter = require('ember-template-lint');
 
@@ -57,7 +57,7 @@ let createParser: CreateParser<TemplateLintConfig, Parser<TemplateLintReport>> =
   taskConfig?: TaskConfig
 ) {
   if (taskConfig && taskConfig.emberTemplateLintConfig) {
-    config = deepmerge(config, taskConfig.emberTemplateLintConfig);
+    config = mergeLintConfig(config, taskConfig.emberTemplateLintConfig);
   }
 
   return new EmberTemplateLintParser(config);

--- a/packages/core/src/parsers/eslint-parser.ts
+++ b/packages/core/src/parsers/eslint-parser.ts
@@ -1,7 +1,6 @@
-import { CreateParser, Parser } from '../types/parsers';
-import * as deepmerge from 'deepmerge';
-
 import { CLIEngine, Rule } from 'eslint';
+import { mergeLintConfig } from '../utils/merge-lint-config';
+import { CreateParser, Parser } from '../types/parsers';
 import { TaskConfig } from '../types/config';
 
 class ESLintParser implements Parser<CLIEngine.LintReport> {
@@ -30,7 +29,7 @@ let createParser: CreateParser<CLIEngine.Options, Parser<CLIEngine.LintReport>> 
   taskConfig?: TaskConfig
 ) {
   if (taskConfig && taskConfig.eslintConfig) {
-    config = deepmerge(config, taskConfig.eslintConfig);
+    config = mergeLintConfig(config, taskConfig.eslintConfig);
   }
 
   return new ESLintParser(config);

--- a/packages/core/src/utils/merge-lint-config.ts
+++ b/packages/core/src/utils/merge-lint-config.ts
@@ -1,0 +1,35 @@
+import * as deepmerge from 'deepmerge';
+import { CLIEngine } from 'eslint';
+import { TemplateLintConfig } from '../types/ember-template-lint';
+
+export function mergeLintConfig(
+  config: TemplateLintConfig | CLIEngine.Options,
+  taskLintConfig: { [key: string]: any }
+) {
+  let initialMerge = deepmerge(config, taskLintConfig);
+
+  if (initialMerge.rules) {
+    let rules = initialMerge.rules;
+    let ruleIds = Object.keys(rules);
+
+    ruleIds.forEach((ruleId: string) => {
+      let ruleConfig = rules[ruleId];
+      let firstTuplePart = '';
+      let secondTuplePart = {};
+
+      if (Array.isArray(ruleConfig) && ruleConfig.length > 2) {
+        for (const [i, element] of ruleConfig.entries()) {
+          if (i % 2 === 0) {
+            firstTuplePart = element;
+          } else {
+            secondTuplePart = Object.assign(secondTuplePart, element);
+          }
+        }
+
+        rules[ruleId] = [firstTuplePart, secondTuplePart];
+      }
+    });
+  }
+
+  return initialMerge;
+}


### PR DESCRIPTION
The `deepmerge` package used to facilitate the deep merge of task configs overriding eslint or ember-template-lint configurations for a task was incorrectly merging tuple options. When it encountered two tuples, since they are arrays it would attempt to concat them, resulting in an incorrect structure.

## Example of incorrect merge

Linting config:

```js
{
  rules: {
    'fake-eslint-rule': [
      'warn',
      {
         prop1: 'error',
         prop2: 'off',
      },
    ],
 },
}
```

Task config:

```js
{
  rules: {
    'fake-eslint-rule': [
      'error',
      {
         prop1: 'warn',
         prop2: 'off',
      },
    ],
 },
}
```

Merged configs:

```js
{
  rules: {
    'fake-eslint-rule': [
      'warn',
      {
         prop1: 'error',
         prop2: 'off',
      },
      'error',
      {
         prop1: 'warn',
         prop2: 'off',
      },
    ],
 },
}
```

## Example of correct merge

```js
{
  rules: {
    'fake-eslint-rule': [
      'error',
      {
         prop1: 'warn',
         prop2: 'off',
      },
    ],
 },
}
```