### PR TITLE
Removing `output-map` from verbose-console-reporter

### DIFF
--- a/checkup.code-workspace
+++ b/checkup.code-workspace
@@ -13,7 +13,8 @@
   },
   "settings": {
     "files.exclude": {
-      "**/node_modules/**": true
+      "**/node_modules/**": true,
+      "**/lib/**": true
     },
     "typescript.tsdk": "node_modules/typescript/lib",
     "editor.formatOnSave": true

--- a/packages/checkup-plugin-ember/package.json
+++ b/packages/checkup-plugin-ember/package.json
@@ -42,7 +42,8 @@
     "hooks": {
       "register-info-tasks": "./lib/hooks/register-info-tasks",
       "register-migration-tasks": "./lib/hooks/register-migration-tasks",
-      "register-actions": "./lib/hooks/register-actions"
+      "register-actions": "./lib/hooks/register-actions",
+      "register-task-reporter": "./lib/hooks/register-task-reporters"
     }
   },
   "publishConfig": {

--- a/packages/checkup-plugin-ember/src/hooks/register-task-reporters.ts
+++ b/packages/checkup-plugin-ember/src/hooks/register-task-reporters.ts
@@ -1,0 +1,15 @@
+import { Hook } from '@oclif/config';
+import { RegisterTaskReporterArgs } from '@checkup/core';
+import { report as reportEmberTestTypes } from '../reporters/ember-test-types-reporter';
+import { report as reportEmberOctaneMigrationStatus } from '../reporters/ember-octane-migration-status-reporter';
+import { report as reportEmberTemplateLintSummary } from '../reporters/ember-template-lint-summary-reporter';
+
+const hook: Hook<RegisterTaskReporterArgs> = async function ({
+  registerTaskReporter,
+}: RegisterTaskReporterArgs) {
+  registerTaskReporter('ember-test-types', reportEmberTestTypes);
+  registerTaskReporter('ember-octane-migration-status', reportEmberOctaneMigrationStatus);
+  registerTaskReporter('ember-template-lint-summary', reportEmberTemplateLintSummary);
+};
+
+export default hook;

--- a/packages/checkup-plugin-ember/src/reporters/ember-octane-migration-status-reporter.ts
+++ b/packages/checkup-plugin-ember/src/reporters/ember-octane-migration-status-reporter.ts
@@ -1,0 +1,37 @@
+import {
+  groupDataByField,
+  NO_RESULTS_FOUND,
+  reduceResults,
+  sumOccurrences,
+  ui,
+  renderEmptyResult,
+} from '@checkup/core';
+import { Result } from 'sarif';
+
+export function report(taskResults: Result[]) {
+  ui.section(taskResults[0].properties?.taskDisplayName, () => {
+    ui.log(`${ui.emphasize('Octane Violations')}: ${sumOccurrences(taskResults)}`);
+    ui.blankLine();
+
+    let groupedTaskResults = groupDataByField(taskResults, 'properties.resultGroup');
+
+    groupedTaskResults.forEach((resultGroup: Result[]) => {
+      let groupedTaskResultsByLintRuleId = reduceResults(
+        groupDataByField(resultGroup, 'properties.lintRuleId')
+      );
+
+      ui.subHeader(groupedTaskResultsByLintRuleId[0].properties?.resultGroup);
+      ui.valuesList(
+        groupedTaskResultsByLintRuleId.map((result) => {
+          if (result.message.text === NO_RESULTS_FOUND) {
+            renderEmptyResult(result);
+          } else {
+            return { title: result.properties?.lintRuleId, count: result.occurrenceCount };
+          }
+        }),
+        'violations'
+      );
+      ui.blankLine();
+    });
+  });
+}

--- a/packages/checkup-plugin-ember/src/reporters/ember-template-lint-summary-reporter.ts
+++ b/packages/checkup-plugin-ember/src/reporters/ember-template-lint-summary-reporter.ts
@@ -1,0 +1,6 @@
+import { renderLintingSummaryResult } from '@checkup/core';
+import { Result } from 'sarif';
+
+export function report(taskResults: Result[]) {
+  renderLintingSummaryResult(taskResults);
+}

--- a/packages/checkup-plugin-ember/src/reporters/ember-test-types-reporter.ts
+++ b/packages/checkup-plugin-ember/src/reporters/ember-test-types-reporter.ts
@@ -1,0 +1,44 @@
+import {
+  groupDataByField,
+  NO_RESULTS_FOUND,
+  reduceResults,
+  sumOccurrences,
+  ui,
+  renderEmptyResult,
+} from '@checkup/core';
+import { Result } from 'sarif';
+
+export function report(taskResults: Result[]) {
+  let groupedTaskResults = groupDataByField(taskResults, 'message.text');
+
+  ui.section(taskResults[0].properties?.taskDisplayName, () => {
+    groupedTaskResults.forEach((resultGroup: Result[]) => {
+      let groupedTaskResultsByMethod = reduceResults(
+        groupDataByField(resultGroup, 'properties.method')
+      );
+      ui.subHeader(groupedTaskResultsByMethod[0].message.text);
+      ui.valuesList(
+        groupedTaskResultsByMethod.map((result) => {
+          if (result.message.text === NO_RESULTS_FOUND) {
+            renderEmptyResult(result);
+          } else {
+            return { title: result.properties?.method, count: result.occurrenceCount };
+          }
+        })
+      );
+      ui.blankLine();
+    });
+
+    ui.subHeader('tests by type');
+    ui.sectionedBar(
+      groupedTaskResults.map((results: Result[]) => {
+        return {
+          title: results[0].message.text,
+          count: sumOccurrences(results),
+        };
+      }),
+      sumOccurrences(taskResults),
+      'tests'
+    );
+  });
+}

--- a/packages/checkup-plugin-javascript/package.json
+++ b/packages/checkup-plugin-javascript/package.json
@@ -40,7 +40,8 @@
     ],
     "hooks": {
       "register-info-tasks": "./lib/hooks/register-info-tasks",
-      "register-actions": "./lib/hooks/register-actions"
+      "register-actions": "./lib/hooks/register-actions",
+      "register-task-reporter": "./lib/hooks/register-task-reporters"
     }
   },
   "publishConfig": {

--- a/packages/checkup-plugin-javascript/src/hooks/register-task-reporters.ts
+++ b/packages/checkup-plugin-javascript/src/hooks/register-task-reporters.ts
@@ -1,0 +1,13 @@
+import { Hook } from '@oclif/config';
+import { RegisterTaskReporterArgs } from '@checkup/core';
+import { report as reportEslintSummary } from '../reporters/eslint-summary-reporter';
+import { report as reportOutdatedDependencies } from '../reporters/outdated-dependencies-reporter';
+
+const hook: Hook<RegisterTaskReporterArgs> = async function ({
+  registerTaskReporter,
+}: RegisterTaskReporterArgs) {
+  registerTaskReporter('eslint-summary', reportEslintSummary);
+  registerTaskReporter('outdated-dependencies', reportOutdatedDependencies);
+};
+
+export default hook;

--- a/packages/checkup-plugin-javascript/src/reporters/eslint-summary-reporter.ts
+++ b/packages/checkup-plugin-javascript/src/reporters/eslint-summary-reporter.ts
@@ -1,0 +1,6 @@
+import { renderLintingSummaryResult } from '@checkup/core';
+import { Result } from 'sarif';
+
+export function report(taskResults: Result[]) {
+  renderLintingSummaryResult(taskResults);
+}

--- a/packages/checkup-plugin-javascript/src/reporters/outdated-dependencies-reporter.ts
+++ b/packages/checkup-plugin-javascript/src/reporters/outdated-dependencies-reporter.ts
@@ -1,0 +1,18 @@
+import { NO_RESULTS_FOUND, sumOccurrences, ui, renderEmptyResult } from '@checkup/core';
+import { Result } from 'sarif';
+
+export function report(taskResults: Result[]) {
+  ui.section(taskResults[0].properties?.taskDisplayName, () => {
+    ui.sectionedBar(
+      taskResults.map((result: Result) => {
+        if (result.message.text === NO_RESULTS_FOUND) {
+          renderEmptyResult(result);
+        } else {
+          return { title: result.message.text, count: result.occurrenceCount };
+        }
+      }),
+      sumOccurrences(taskResults),
+      'dependencies'
+    );
+  });
+}

--- a/packages/cli/src/reporters/verbose-console-reporter.ts
+++ b/packages/cli/src/reporters/verbose-console-reporter.ts
@@ -7,107 +7,12 @@ import {
   NO_RESULTS_FOUND,
   sumOccurrences,
   reduceResults,
+  renderEmptyResult,
 } from '@checkup/core';
 import * as cleanStack from 'clean-stack';
 import { startCase } from 'lodash';
 import { Invocation, Log, Notification, Result, Run } from 'sarif';
 import { renderActions, renderCLIInfo, renderInfo, renderLinesOfCode } from './reporter-utils';
-
-let outputMap: { [taskName: string]: (taskResults: Result[]) => void } = {
-  'ember-dependencies': function (taskResults: Result[]) {
-    if (!taskResults.some((result: Result) => result.properties?.data !== undefined)) {
-      return;
-    }
-
-    ui.section(taskResults[0].properties?.taskDisplayName, () => {
-      taskResults.forEach((result: Result) => {
-        if (result.message.text === NO_RESULTS_FOUND) {
-          renderEmptyResult(result);
-        } else {
-          ui.value({ title: result.message.text, count: result.properties?.data.length });
-        }
-      });
-    });
-  },
-  'ember-test-types': function (taskResults: Result[]) {
-    let groupedTaskResults = groupDataByField(taskResults, 'message.text');
-
-    ui.section(taskResults[0].properties?.taskDisplayName, () => {
-      groupedTaskResults.forEach((resultGroup: Result[]) => {
-        let groupedTaskResultsByMethod = reduceResults(
-          groupDataByField(resultGroup, 'properties.method')
-        );
-        ui.subHeader(groupedTaskResultsByMethod[0].message.text);
-        ui.valuesList(
-          groupedTaskResultsByMethod.map((result) => {
-            if (result.message.text === NO_RESULTS_FOUND) {
-              renderEmptyResult(result);
-            } else {
-              return { title: result.properties?.method, count: result.occurrenceCount };
-            }
-          })
-        );
-        ui.blankLine();
-      });
-
-      ui.subHeader('tests by type');
-      ui.sectionedBar(
-        groupedTaskResults.map((results: Result[]) => {
-          return {
-            title: results[0].message.text,
-            count: sumOccurrences(results),
-          };
-        }),
-        sumOccurrences(taskResults),
-        'tests'
-      );
-    });
-  },
-  'ember-octane-migration-status': function (taskResults: Result[]) {
-    ui.section(taskResults[0].properties?.taskDisplayName, () => {
-      ui.log(`${ui.emphasize('Octane Violations')}: ${sumOccurrences(taskResults)}`);
-      ui.blankLine();
-
-      let groupedTaskResults = groupDataByField(taskResults, 'properties.resultGroup');
-
-      groupedTaskResults.forEach((resultGroup: Result[]) => {
-        let groupedTaskResultsByLintRuleId = reduceResults(
-          groupDataByField(resultGroup, 'properties.lintRuleId')
-        );
-
-        ui.subHeader(groupedTaskResultsByLintRuleId[0].properties?.resultGroup);
-        ui.valuesList(
-          groupedTaskResultsByLintRuleId.map((result) => {
-            if (result.message.text === NO_RESULTS_FOUND) {
-              renderEmptyResult(result);
-            } else {
-              return { title: result.properties?.lintRuleId, count: result.occurrenceCount };
-            }
-          }),
-          'violations'
-        );
-        ui.blankLine();
-      });
-    });
-  },
-  'ember-template-lint-summary': renderLintingSummaryResult,
-  'eslint-summary': renderLintingSummaryResult,
-  'outdated-dependencies': function (taskResults: Result[]) {
-    ui.section(taskResults[0].properties?.taskDisplayName, () => {
-      ui.sectionedBar(
-        taskResults.map((result: Result) => {
-          if (result.message.text === NO_RESULTS_FOUND) {
-            renderEmptyResult(result);
-          } else {
-            return { title: result.message.text, count: result.occurrenceCount };
-          }
-        }),
-        sumOccurrences(taskResults),
-        'dependencies'
-      );
-    });
-  },
-};
 
 export function report(result: Log) {
   let metaData = result.properties as CheckupMetadata;
@@ -156,7 +61,7 @@ function renderTaskResults(pluginTaskResults: Result[] | undefined): void {
 function getTaskReporter(taskResult: Result[]) {
   let taskName = taskResult[0].ruleId as string;
   let registeredTaskReporters = getRegisteredTaskReporters();
-  let reporter = outputMap[taskName] || registeredTaskReporters.get(taskName) || getReportComponent;
+  let reporter = registeredTaskReporters.get(taskName) || getReportComponent;
 
   if (typeof reporter === 'undefined') {
     throw new CheckupError(
@@ -166,13 +71,6 @@ function getTaskReporter(taskResult: Result[]) {
   }
 
   return reporter;
-}
-
-export function renderEmptyResult(taskResult: Result) {
-  ui.value({
-    title: taskResult.properties?.consoleMessage || taskResult.properties?.taskDisplayName,
-    count: 0,
-  });
 }
 
 function getReportComponent(taskResults: Result[]) {
@@ -234,30 +132,4 @@ function renderTimings(timings: Record<string, number>) {
     }
   );
   ui.blankLine();
-}
-
-function renderLintingSummaryResult(taskResults: Result[]) {
-  let groupedTaskResultsByType = groupDataByField(taskResults, 'properties.type');
-
-  ui.section(taskResults[0].properties?.taskDisplayName, () => {
-    groupedTaskResultsByType.forEach((resultGroup: Result[]) => {
-      let groupedTaskResultsByLintRule = reduceResults(
-        groupDataByField(resultGroup, 'properties.lintRuleId')
-      ).sort((a, b) => (b.occurrenceCount || 0) - (a.occurrenceCount || 0));
-      let totalCount = sumOccurrences(groupedTaskResultsByLintRule);
-      if (totalCount) {
-        ui.subHeader(`${groupedTaskResultsByLintRule[0].properties?.type}s: (${totalCount})`);
-        ui.valuesList(
-          groupedTaskResultsByLintRule.map((result) => {
-            if (result.message.text === NO_RESULTS_FOUND) {
-              renderEmptyResult(result);
-            } else {
-              return { title: result.properties?.lintRuleId, count: result?.occurrenceCount };
-            }
-          })
-        );
-        ui.blankLine();
-      }
-    });
-  });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export { ui } from './utils/ui';
 export { getFilePaths, getFilePathsAsync } from './utils/get-paths';
 export { FilePathArray } from './utils/file-path-array';
 export { sumOccurrences, reduceResults } from './utils/sarif-utils';
+export { renderEmptyResult, renderLintingSummaryResult } from './utils/verbose-reporter-utils';
 
 export { byRuleId, byRuleIds, bySeverity } from './data/filters';
 export { toPercent, groupDataByField } from './data/formatters';

--- a/packages/core/src/utils/verbose-reporter-utils.ts
+++ b/packages/core/src/utils/verbose-reporter-utils.ts
@@ -1,0 +1,38 @@
+import { NO_RESULTS_FOUND } from '../data/sarif';
+import { groupDataByField } from '../data/formatters';
+import { reduceResults, sumOccurrences } from './sarif-utils';
+import { ui } from './ui';
+import { Result } from 'sarif';
+
+export function renderEmptyResult(taskResult: Result) {
+  ui.value({
+    title: taskResult.properties?.consoleMessage || taskResult.properties?.taskDisplayName,
+    count: 0,
+  });
+}
+
+export function renderLintingSummaryResult(taskResults: Result[]) {
+  let groupedTaskResultsByType = groupDataByField(taskResults, 'properties.type');
+
+  ui.section(taskResults[0].properties?.taskDisplayName, () => {
+    groupedTaskResultsByType.forEach((resultGroup: Result[]) => {
+      let groupedTaskResultsByLintRule = reduceResults(
+        groupDataByField(resultGroup, 'properties.lintRuleId')
+      ).sort((a, b) => (b.occurrenceCount || 0) - (a.occurrenceCount || 0));
+      let totalCount = sumOccurrences(groupedTaskResultsByLintRule);
+      if (totalCount) {
+        ui.subHeader(`${groupedTaskResultsByLintRule[0].properties?.type}s: (${totalCount})`);
+        ui.valuesList(
+          groupedTaskResultsByLintRule.map((result) => {
+            if (result.message.text === NO_RESULTS_FOUND) {
+              renderEmptyResult(result);
+            } else {
+              return { title: result.properties?.lintRuleId, count: result?.occurrenceCount };
+            }
+          })
+        );
+        ui.blankLine();
+      }
+    });
+  });
+}


### PR DESCRIPTION
This is the first in a series of refactors to verbose-console-reporter. There will also be a change where some additional util functions (similar to `renderLintingSummaryResult`) exposed to offer an additional layer of options between using ui library and building result per task directly, and just using the current default behavior.

This change simply removes `output-map` and all task specific code from verbose-console-reporter, and moves it to the plugins directly. Our internal plugins should register custom reporters the same way we would expect an external plugin to. There are no functionality changes in this PR, just moving existing custom cases (where necessary) to plugins