### PR TITLE
Populating `Result.kind` field

### DIFF
--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-dependencies-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`dependencies-task detects Ember dependencies as JSON 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "message": Object {
       "text": "ember core libraries",
     },
@@ -29,6 +30,7 @@ Array [
     "ruleId": "ember-dependencies",
   },
   Object {
+    "kind": "informational",
     "message": Object {
       "text": "ember addon dependencies",
     },
@@ -47,6 +49,7 @@ Array [
     "ruleId": "ember-dependencies",
   },
   Object {
+    "kind": "notApplicable",
     "message": Object {
       "text": "No results found",
     },
@@ -59,6 +62,7 @@ Array [
     "ruleId": "ember-dependencies",
   },
   Object {
+    "kind": "informational",
     "message": Object {
       "text": "ember-cli addon dependencies",
     },
@@ -81,6 +85,7 @@ Array [
     "ruleId": "ember-dependencies",
   },
   Object {
+    "kind": "informational",
     "message": Object {
       "text": "ember-cli addon devDependencies",
     },

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-in-repo-addons-engines-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-in-repo-addons-engines-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`ember-in-repo-addons-engines-task can read task as JSON 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -24,6 +25,7 @@ Array [
     "ruleId": "ember-in-repo-addons-engines",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -45,6 +47,7 @@ Array [
     "ruleId": "ember-in-repo-addons-engines",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -66,6 +69,7 @@ Array [
     "ruleId": "ember-in-repo-addons-engines",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-octane-migration-status-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-octane-migration-status-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`ember-octane-migration-status-task detects octane migration status for non-octane addon and outputs to json 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -30,6 +31,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -57,6 +59,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -84,6 +87,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -111,6 +115,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -138,6 +143,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -165,6 +171,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -192,6 +199,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -219,6 +227,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -246,6 +255,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -273,6 +283,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -300,6 +311,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -327,6 +339,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -354,6 +367,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -381,6 +395,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -408,6 +423,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -435,6 +451,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -462,6 +479,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -489,6 +507,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -516,6 +535,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -543,6 +563,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -570,6 +591,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -602,6 +624,7 @@ Array [
 exports[`ember-octane-migration-status-task detects octane migration status for non-octane app and outputs to json 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -629,6 +652,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -656,6 +680,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -683,6 +708,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -710,6 +736,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -737,6 +764,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -764,6 +792,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -791,6 +820,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -818,6 +848,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -845,6 +876,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -872,6 +904,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -899,6 +932,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -926,6 +960,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -953,6 +988,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -980,6 +1016,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1007,6 +1044,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1034,6 +1072,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1061,6 +1100,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1088,6 +1128,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1115,6 +1156,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1142,6 +1184,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -1169,6 +1212,7 @@ Array [
     "ruleId": "ember-octane-migration-status",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-template-lint-summary-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-template-lint-summary-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`ember-emplate-lint-summary-task summarizes eslint and outputs to JSON 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -30,6 +31,7 @@ Array [
     "ruleId": "ember-template-lint-summary",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -57,6 +59,7 @@ Array [
     "ruleId": "ember-template-lint-summary",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -84,6 +87,7 @@ Array [
     "ruleId": "ember-template-lint-summary",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-test-type-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-test-type-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`ember-test-types-task only renders todos/only test types if they a value > 0 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -30,6 +31,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -57,6 +59,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -89,6 +92,7 @@ Array [
 exports[`ember-test-types-task returns all the test types found in the app and outputs to json 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -116,6 +120,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -143,6 +148,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -170,6 +176,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -197,6 +204,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -224,6 +232,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -251,6 +260,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -278,6 +288,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -305,6 +316,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -332,6 +344,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -359,6 +372,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -386,6 +400,7 @@ Array [
     "ruleId": "ember-test-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-types-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-types-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`types-task returns all the types (including nested) found in the app and outputs to JSON 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -24,6 +25,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -45,6 +47,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -66,6 +69,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -87,6 +91,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -108,6 +113,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -129,6 +135,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -150,6 +157,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -171,6 +179,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -192,6 +201,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -213,6 +223,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -234,6 +245,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -255,6 +267,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -276,6 +289,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -297,6 +311,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -318,6 +333,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -339,6 +355,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -360,6 +377,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -381,6 +399,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -402,6 +421,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -428,6 +448,7 @@ Array [
 exports[`types-task returns all the types found in the app and outputs to JSON 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -449,6 +470,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -470,6 +492,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -491,6 +514,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -512,6 +536,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -533,6 +558,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -554,6 +580,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -575,6 +602,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -596,6 +624,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -617,6 +646,7 @@ Array [
     "ruleId": "ember-types",
   },
   Object {
+    "kind": "informational",
     "locations": Array [
       Object {
         "physicalLocation": Object {

--- a/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
@@ -39,6 +39,7 @@ describe('ember-template-lint-disable-task', () => {
     expect(result).toMatchInlineSnapshot(`
       Array [
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {
@@ -65,6 +66,7 @@ describe('ember-template-lint-disable-task', () => {
           "ruleId": "ember-template-lint-disables",
         },
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {
@@ -91,6 +93,7 @@ describe('ember-template-lint-disable-task', () => {
           "ruleId": "ember-template-lint-disables",
         },
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {

--- a/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
@@ -69,9 +69,15 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
     });
 
     return Object.keys(testTypes).flatMap((key) => {
-      return sarifBuilder.fromLintResults(this, testTypes[key], {
-        method: testTypes[key][0].method,
-      });
+      return sarifBuilder.fromLintResults(
+        this,
+        testTypes[key],
+        {
+          method: testTypes[key][0].method,
+        },
+        {},
+        'informational'
+      );
     });
   }
 }

--- a/packages/checkup-plugin-javascript/__tests__/__snapshots__/eslint-summary-task-test.ts.snap
+++ b/packages/checkup-plugin-javascript/__tests__/__snapshots__/eslint-summary-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`eslint-summary-task summarizes eslint and outputs to JSON 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {
@@ -30,6 +31,7 @@ Array [
     "ruleId": "eslint-summary",
   },
   Object {
+    "kind": "fail",
     "locations": Array [
       Object {
         "physicalLocation": Object {

--- a/packages/checkup-plugin-javascript/__tests__/__snapshots__/outdated-dependencies-task-test.ts.snap
+++ b/packages/checkup-plugin-javascript/__tests__/__snapshots__/outdated-dependencies-task-test.ts.snap
@@ -3,6 +3,7 @@
 exports[`outdated-dependencies-task detects outdated dependencies as JSON 1`] = `
 Array [
   Object {
+    "kind": "informational",
     "message": Object {
       "text": "major",
     },
@@ -26,6 +27,7 @@ Array [
     "ruleId": "outdated-dependencies",
   },
   Object {
+    "kind": "informational",
     "message": Object {
       "text": "minor",
     },

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -51,6 +51,7 @@ describe('eslint-disable-task', () => {
     expect(result.sort()).toMatchInlineSnapshot(`
       Array [
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {
@@ -77,6 +78,7 @@ describe('eslint-disable-task', () => {
           "ruleId": "eslint-disables",
         },
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {
@@ -103,6 +105,7 @@ describe('eslint-disable-task', () => {
           "ruleId": "eslint-disables",
         },
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {
@@ -129,6 +132,7 @@ describe('eslint-disable-task', () => {
           "ruleId": "eslint-disables",
         },
         Object {
+          "kind": "fail",
           "locations": Array [
             Object {
               "physicalLocation": Object {


### PR DESCRIPTION
This field is used to specify the nature of the Results.

For `Results` being built `fromLintResults`, I set default as `fail` for `Result.kind`.
For `Results` that represent the fact that no results were found, I set `Result.kind` as `notApplicable`
For all other `Results`, default for `Result.kind` is `informational`. This can be optionally overridden at the Task level