### PR TITLE
bugfix: Fix checkup versions in plugin

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -231,12 +231,12 @@ exports[`plugin generator generates plugin with JavaScript defaults 1`] = `
   \\"version\\": \\"0.0.0\\",
   \\"author\\": \\"\\",
   \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^0.0.1\\",
+    \\"@checkup/core\\": \\"^0.13.2\\",
     \\"@oclif/command\\": \\"^1\\",
     \\"@oclif/config\\": \\"^1\\"
   },
   \\"devDependencies\\": {
-    \\"@checkup/test-helpers\\": \\"^0.0.1\\",
+    \\"@checkup/test-helpers\\": \\"^0.13.2\\",
     \\"@oclif/dev-cli\\": \\"^1\\",
     \\"eslint\\": \\"^7.5.0\\",
     \\"eslint-config-prettier\\": \\"^6.11.0\\",

--- a/packages/cli/src/generators/plugin.ts
+++ b/packages/cli/src/generators/plugin.ts
@@ -3,6 +3,7 @@ import * as chalk from 'chalk';
 import { Answers } from 'inquirer';
 import BaseGenerator from './base-generator';
 import { join } from 'path';
+import { readJsonSync } from 'fs-extra';
 import { readdirSync, existsSync } from 'fs';
 import { CheckupError } from '@checkup/core';
 
@@ -71,6 +72,8 @@ export default class PluginGenerator extends BaseGenerator {
       ]);
     }
 
+    const checkupVersion = readJsonSync(join(__dirname, '../../package.json')).version;
+    this.options.checkupVersion = checkupVersion;
     this.options.typescript = this.answers.typescript;
     this.options.description = this.answers.description;
     this.options.author = this.answers.author;

--- a/packages/cli/templates/src/plugin/package.json.js.ejs
+++ b/packages/cli/templates/src/plugin/package.json.js.ejs
@@ -4,12 +4,12 @@
   "version": "0.0.0",
   "author": "<%- author %>",
   "dependencies": {
-    "@checkup/core": "^0.0.1",
+    "@checkup/core": "^<%- checkupVersion %>",
     "@oclif/command": "^1",
     "@oclif/config": "^1"
   },
   "devDependencies": {
-    "@checkup/test-helpers": "^0.0.1",
+    "@checkup/test-helpers": "^<%- checkupVersion %>",
     "@oclif/dev-cli": "^1",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
This fixes an issue where the checkup versions are stale when stamping
out a new plugin leaving the developer with a completely broken setup.