### PR TITLE
Fixes verbose output when using generator utils in tests

### DIFF
--- a/packages/cli/src/generators/task.ts
+++ b/packages/cli/src/generators/task.ts
@@ -47,6 +47,8 @@ export default class TaskGenerator extends BaseGenerator {
     const defaults = {
       typescript: true,
       commandType: 'info',
+      category: '',
+      group: '',
     };
 
     if (this.options.defaults) {


### PR DESCRIPTION
When using the generator utils in tests, there was some excessively verbose output indicating that the `group` question didn't have an answer provided, mainly due to our defaults not including a default for that property. This PR adds defaults for both `category` and `group` questions.