### PR TITLE
Speeds up tests by using local link to @checkup/core in generated plugins

### DIFF
--- a/packages/cli/__tests__/__utils__/fake-project.ts
+++ b/packages/cli/__tests__/__utils__/fake-project.ts
@@ -1,15 +1,19 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import * as helpers from 'yeoman-test';
 
 import { CheckupProject } from '@checkup/test-helpers';
 import { generatePlugin, generateTask } from './generator-utils';
 
 import type { Answers } from 'inquirer';
+import { mkdirp, symlink } from 'fs-extra';
 
 export class FakeProject extends CheckupProject {
   async addPlugin(options: helpers.Dictionary<any> = {}, prompts: Answers = {}) {
     let pluginDir = await generatePlugin(options, prompts, join(this.baseDir, 'node_modules'));
-    this.install(pluginDir);
+    let coreDir = join(this.baseDir, 'node_modules', '@checkup', 'core');
+
+    await mkdirp(coreDir);
+    await symlink(coreDir, resolve('../../..', 'core'));
 
     return pluginDir;
   }

--- a/packages/cli/__tests__/__utils__/fake-project.ts
+++ b/packages/cli/__tests__/__utils__/fake-project.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, dirname } from 'path';
 import * as helpers from 'yeoman-test';
 
 import { CheckupProject } from '@checkup/test-helpers';
@@ -10,10 +10,13 @@ import { mkdirp, symlink } from 'fs-extra';
 export class FakeProject extends CheckupProject {
   async addPlugin(options: helpers.Dictionary<any> = {}, prompts: Answers = {}) {
     let pluginDir = await generatePlugin(options, prompts, join(this.baseDir, 'node_modules'));
-    let coreDir = join(this.baseDir, 'node_modules', '@checkup', 'core');
+    let coreDir = join(pluginDir, 'node_modules', '@checkup', 'core');
 
-    await mkdirp(coreDir);
-    await symlink(coreDir, resolve('../../..', 'core'));
+    // we create a self-referential link to the core package within the generated plugin. This
+    // allows us to generate plugins, and test the APIs for the latest version of core that is
+    // referenced via the plugins' node_modules.
+    await mkdirp(dirname(coreDir));
+    await symlink(join(__dirname, '../../..', 'core'), coreDir);
 
     return pluginDir;
   }

--- a/packages/cli/__tests__/__utils__/fake-project.ts
+++ b/packages/cli/__tests__/__utils__/fake-project.ts
@@ -10,13 +10,14 @@ import { mkdirp, symlink } from 'fs-extra';
 export class FakeProject extends CheckupProject {
   async addPlugin(options: helpers.Dictionary<any> = {}, prompts: Answers = {}) {
     let pluginDir = await generatePlugin(options, prompts, join(this.baseDir, 'node_modules'));
-    let coreDir = join(pluginDir, 'node_modules', '@checkup', 'core');
+    let source = join(__dirname, '../../..', 'core');
+    let target = join(pluginDir, 'node_modules', '@checkup', 'core');
 
     // we create a self-referential link to the core package within the generated plugin. This
     // allows us to generate plugins, and test the APIs for the latest version of core that is
     // referenced via the plugins' node_modules.
-    await mkdirp(dirname(coreDir));
-    await symlink(join(__dirname, '../../..', 'core'), coreDir);
+    await mkdirp(dirname(target));
+    await symlink(source, target);
 
     return pluginDir;
   }

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -118,7 +118,6 @@ describe('cli-test', () => {
   });
 
   it('should output list of available tasks', async () => {
-    // project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -194,7 +193,6 @@ describe('cli-test', () => {
   });
 
   it('should run a single task if the tasks option is specified with a single task', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -217,7 +215,7 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -239,7 +237,6 @@ describe('cli-test', () => {
   });
 
   it('should run with timing if CHECKUP_TIMING=1', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -268,7 +265,6 @@ describe('cli-test', () => {
   });
 
   it('should run multiple tasks if the tasks option is specified with multiple tasks', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -304,7 +300,7 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -330,7 +326,6 @@ describe('cli-test', () => {
   });
 
   it('should run only one task if the category option is specified', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -358,7 +353,7 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -380,7 +375,6 @@ describe('cli-test', () => {
   });
 
   it('should run multiple tasks if the category option is specified with multiple categories', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -408,7 +402,7 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -436,7 +430,6 @@ describe('cli-test', () => {
   });
 
   it('should run only one task if the group option is specified', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -464,7 +457,7 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -486,7 +479,6 @@ describe('cli-test', () => {
   });
 
   it('should run multiple tasks if the group option is specified with multiple groups', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -514,7 +506,7 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
@@ -540,7 +532,6 @@ describe('cli-test', () => {
   });
 
   it('should run a task if its passed in via command line, even if it is turned "off" in config', async () => {
-    project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -563,13 +554,19 @@ describe('cli-test', () => {
 
     expect(result.stdout).toMatchInlineSnapshot(`
       "
-      Checkup report generated for checkup-app v0.0.0 (7 files analyzed)
+      Checkup report generated for checkup-app v0.0.0 (5 files analyzed)
 
       This project is 0 days old, with 0 days active days, 0 commits and 0 files.
 
       ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 3 lines of code
       ■ js (2)
       ■ hbs (1)
+
+      === Best Practices
+
+      File Count
+
+      ■ file-count result (1)
 
 
       checkup v0.0.0

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -118,7 +118,7 @@ describe('cli-test', () => {
   });
 
   it('should output list of available tasks', async () => {
-    project.install();
+    // project.install();
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }

--- a/packages/test-helpers/src/checkup-fixturify-project.ts
+++ b/packages/test-helpers/src/checkup-fixturify-project.ts
@@ -2,11 +2,11 @@
 
 import { CheckupConfig, mergeConfig, FilePathArray } from '@checkup/core';
 
-import { PackageJson } from 'type-fest';
-import Project from 'fixturify-project';
-import { execSync } from 'child_process';
 import { join, resolve } from 'path';
+import { execSync } from 'child_process';
+import Project from 'fixturify-project';
 import stringify from 'json-stable-stringify';
+import type { PackageJson } from 'type-fest';
 
 const walkSync = require('walk-sync');
 


### PR DESCRIPTION
Uses a symlink to the @checkup/core directory in the project during tests.