### PR TITLE
Exporting task runner as public API

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,1 @@
+export { default as CheckupTaskRunner } from './api/checkup-task-runner';


### PR DESCRIPTION
The last beta missed exporting the `CheckupTaskRunner` class, which is the core API that's expected to be used programmatically. This PR fixes that.