### PR TITLE
Adding some abstractions to generate-plugin-test to reduce churn

### DIFF
--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -1,65 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`plugin generator generates plugin into existing directory with defaults 1`] = `
-"{
-  \\"name\\": \\"checkup-plugin-bar\\",
-  \\"description\\": \\"Checkup plugin\\",
-  \\"version\\": \\"0.0.0\\",
-  \\"author\\": \\"\\",
-  \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^1.0.0-beta.0\\",
-    \\"tslib\\": \\"^1\\"
-  },
-  \\"devDependencies\\": {
-    \\"@checkup/plugin\\": \\"^1.0.0-beta.0\\",
-    \\"@checkup/test-helpers\\": \\"^1.0.0-beta.0\\",
-    \\"@types/jest\\": \\"^25.1.3\\",
-    \\"@types/node\\": \\"^13\\",
-    \\"@typescript-eslint/eslint-plugin\\": \\"^3.5.0\\",
-    \\"@typescript-eslint/parser\\": \\"^3.5.0\\",
-    \\"eslint\\": \\"^7.5.0\\",
-    \\"eslint-config-prettier\\": \\"^6.11.0\\",
-    \\"eslint-plugin-jest\\": \\"^23.8.2\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prettier\\": \\"^3.1.3\\",
-    \\"jest\\": \\"^25.1.0\\",
-    \\"prettier\\": \\"^2.0.5\\",
-    \\"ts-jest\\": \\"^25.2.1\\",
-    \\"ts-node\\": \\"^8\\",
-    \\"typescript\\": \\"^3.8\\"
-  },
-  \\"engines\\": {
-    \\"node\\": \\">= 12.11.*\\"
-  },
-  \\"files\\": [
-    \\"/lib\\"
-  ],
-  \\"keywords\\": [
-    \\"checkup-plugin\\"
-  ],
-  \\"license\\": \\"MIT\\",
-  \\"repository\\": \\"\\",
-  \\"scripts\\": {
-    \\"build\\": \\"yarn clean && tsc\\",
-    \\"build:watch\\": \\"yarn build -w\\",
-    \\"clean\\": \\"rm -rf lib\\",
-    \\"docs:generate\\": \\"checkup-plugin docs\\",
-    \\"lint\\": \\"eslint . --cache --ext .ts\\",
-    \\"test\\": \\"jest --no-cache\\"
-  },
-  \\"types\\": \\"lib/index.d.ts\\",
-  \\"main\\": \\"lib/index.js\\"
-}
-"
-`;
-
-exports[`plugin generator generates plugin into existing directory with defaults 2`] = `
 "lib 
 node_modules
 "
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 3`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 2`] = `
 "{
   \\"root\\": true,
   \\"parser\\": \\"@typescript-eslint/parser\\",
@@ -102,12 +49,12 @@ exports[`plugin generator generates plugin into existing directory with defaults
 }"
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 4`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 3`] = `
 "lib
 .eslintcache"
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 5`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 4`] = `
 "module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
@@ -115,7 +62,7 @@ exports[`plugin generator generates plugin into existing directory with defaults
 };"
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 6`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 5`] = `
 "# checkup-plugin-bar
 
 Checkup plugin
@@ -136,7 +83,7 @@ Checkup plugin
 "
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 7`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 6`] = `
 "module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json'],
@@ -157,7 +104,7 @@ exports[`plugin generator generates plugin into existing directory with defaults
 "
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 8`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 7`] = `
 "{
   \\"compilerOptions\\": {
     \\"declaration\\": true,
@@ -176,7 +123,7 @@ exports[`plugin generator generates plugin into existing directory with defaults
 "
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 9`] = `
+exports[`plugin generator generates plugin into existing directory with defaults 8`] = `
 "import { RegistrationArgs, getPluginName } from '@checkup/core';
 
 export function register(args: RegistrationArgs) {
@@ -186,7 +133,13 @@ export function register(args: RegistrationArgs) {
 "
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 10`] = `""`;
+exports[`plugin generator generates plugin into existing directory with defaults 9`] = `""`;
+
+exports[`plugin generator generates plugin into existing directory with defaults 10`] = `
+Array [
+  ".gitkeep",
+]
+`;
 
 exports[`plugin generator generates plugin into existing directory with defaults 11`] = `
 Array [
@@ -200,58 +153,13 @@ Array [
 ]
 `;
 
-exports[`plugin generator generates plugin into existing directory with defaults 13`] = `
-Array [
-  ".gitkeep",
-]
-`;
-
 exports[`plugin generator generates plugin with JavaScript defaults 1`] = `
-"{
-  \\"name\\": \\"checkup-plugin-my-plugin\\",
-  \\"description\\": \\"Checkup plugin\\",
-  \\"version\\": \\"0.0.0\\",
-  \\"author\\": \\"\\",
-  \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^1.0.0-beta.0\\"
-  },
-  \\"devDependencies\\": {
-    \\"@checkup/test-helpers\\": \\"^1.0.0-beta.0\\",
-    \\"eslint\\": \\"^7.5.0\\",
-    \\"eslint-config-prettier\\": \\"^6.11.0\\",
-    \\"eslint-plugin-jest\\": \\"^23.8.2\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prettier\\": \\"^3.1.3\\",
-    \\"jest\\": \\"^25.1.0\\",
-    \\"prettier\\": \\"^2.0.5\\"
-  },
-  \\"engines\\": {
-    \\"node\\": \\">= 12.11.*\\"
-  },
-  \\"files\\": [
-    \\"/lib\\"
-  ],
-  \\"keywords\\": [
-    \\"checkup-plugin\\"
-  ],
-  \\"license\\": \\"MIT\\",
-  \\"repository\\": \\"\\",
-  \\"scripts\\": {
-    \\"lint\\": \\"eslint . --cache\\",
-    \\"test\\": \\"jest --no-cache\\"
-  },
-  \\"main\\": \\"lib/index.js\\"
-}
-"
-`;
-
-exports[`plugin generator generates plugin with JavaScript defaults 2`] = `
 "lib 
 node_modules
 "
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 3`] = `
+exports[`plugin generator generates plugin with JavaScript defaults 2`] = `
 "{
   \\"root\\": true,
   \\"parser\\": \\"babel-eslint\\",
@@ -292,12 +200,12 @@ exports[`plugin generator generates plugin with JavaScript defaults 3`] = `
 }"
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 4`] = `
+exports[`plugin generator generates plugin with JavaScript defaults 3`] = `
 "lib
 .eslintcache"
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 5`] = `
+exports[`plugin generator generates plugin with JavaScript defaults 4`] = `
 "module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
@@ -305,7 +213,7 @@ exports[`plugin generator generates plugin with JavaScript defaults 5`] = `
 };"
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 6`] = `
+exports[`plugin generator generates plugin with JavaScript defaults 5`] = `
 "# checkup-plugin-my-plugin
 
 Checkup plugin
@@ -326,7 +234,7 @@ Checkup plugin
 "
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 7`] = `
+exports[`plugin generator generates plugin with JavaScript defaults 6`] = `
 "module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['js', 'json'],
@@ -346,7 +254,7 @@ exports[`plugin generator generates plugin with JavaScript defaults 7`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 8`] = `
+exports[`plugin generator generates plugin with JavaScript defaults 7`] = `
 "let { getPluginName } = require('@checkup/core');
 
 module.exports = {
@@ -358,7 +266,13 @@ module.exports = {
 "
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 9`] = `""`;
+exports[`plugin generator generates plugin with JavaScript defaults 8`] = `""`;
+
+exports[`plugin generator generates plugin with JavaScript defaults 9`] = `
+Array [
+  ".gitkeep",
+]
+`;
 
 exports[`plugin generator generates plugin with JavaScript defaults 10`] = `
 Array [
@@ -372,72 +286,13 @@ Array [
 ]
 `;
 
-exports[`plugin generator generates plugin with JavaScript defaults 12`] = `
-Array [
-  ".gitkeep",
-]
-`;
-
 exports[`plugin generator generates plugin with custom options 1`] = `
-"{
-  \\"name\\": \\"checkup-plugin-my-plugin\\",
-  \\"description\\": \\"My custom plugin\\",
-  \\"version\\": \\"0.0.0\\",
-  \\"author\\": \\"scalvert <steve.calvert@gmail.com>\\",
-  \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^1.0.0-beta.0\\",
-    \\"tslib\\": \\"^1\\"
-  },
-  \\"devDependencies\\": {
-    \\"@checkup/plugin\\": \\"^1.0.0-beta.0\\",
-    \\"@checkup/test-helpers\\": \\"^1.0.0-beta.0\\",
-    \\"@types/jest\\": \\"^25.1.3\\",
-    \\"@types/node\\": \\"^13\\",
-    \\"@typescript-eslint/eslint-plugin\\": \\"^3.5.0\\",
-    \\"@typescript-eslint/parser\\": \\"^3.5.0\\",
-    \\"eslint\\": \\"^7.5.0\\",
-    \\"eslint-config-prettier\\": \\"^6.11.0\\",
-    \\"eslint-plugin-jest\\": \\"^23.8.2\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prettier\\": \\"^3.1.3\\",
-    \\"jest\\": \\"^25.1.0\\",
-    \\"prettier\\": \\"^2.0.5\\",
-    \\"ts-jest\\": \\"^25.2.1\\",
-    \\"ts-node\\": \\"^8\\",
-    \\"typescript\\": \\"^3.8\\"
-  },
-  \\"engines\\": {
-    \\"node\\": \\">= 12.11.*\\"
-  },
-  \\"files\\": [
-    \\"/lib\\"
-  ],
-  \\"keywords\\": [
-    \\"checkup-plugin\\"
-  ],
-  \\"license\\": \\"MIT\\",
-  \\"repository\\": \\"http://github.com/scalvert/checkup-plugin-my-plugin\\",
-  \\"scripts\\": {
-    \\"build\\": \\"yarn clean && tsc\\",
-    \\"build:watch\\": \\"yarn build -w\\",
-    \\"clean\\": \\"rm -rf lib\\",
-    \\"docs:generate\\": \\"checkup-plugin docs\\",
-    \\"lint\\": \\"eslint . --cache --ext .ts\\",
-    \\"test\\": \\"jest --no-cache\\"
-  },
-  \\"types\\": \\"lib/index.d.ts\\",
-  \\"main\\": \\"lib/index.js\\"
-}
-"
-`;
-
-exports[`plugin generator generates plugin with custom options 2`] = `
 "lib 
 node_modules
 "
 `;
 
-exports[`plugin generator generates plugin with custom options 3`] = `
+exports[`plugin generator generates plugin with custom options 2`] = `
 "{
   \\"root\\": true,
   \\"parser\\": \\"@typescript-eslint/parser\\",
@@ -480,12 +335,12 @@ exports[`plugin generator generates plugin with custom options 3`] = `
 }"
 `;
 
-exports[`plugin generator generates plugin with custom options 4`] = `
+exports[`plugin generator generates plugin with custom options 3`] = `
 "lib
 .eslintcache"
 `;
 
-exports[`plugin generator generates plugin with custom options 5`] = `
+exports[`plugin generator generates plugin with custom options 4`] = `
 "module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
@@ -493,7 +348,7 @@ exports[`plugin generator generates plugin with custom options 5`] = `
 };"
 `;
 
-exports[`plugin generator generates plugin with custom options 6`] = `
+exports[`plugin generator generates plugin with custom options 5`] = `
 "# checkup-plugin-my-plugin
 
 My custom plugin
@@ -514,7 +369,7 @@ My custom plugin
 "
 `;
 
-exports[`plugin generator generates plugin with custom options 7`] = `
+exports[`plugin generator generates plugin with custom options 6`] = `
 "module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json'],
@@ -535,7 +390,7 @@ exports[`plugin generator generates plugin with custom options 7`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with custom options 8`] = `
+exports[`plugin generator generates plugin with custom options 7`] = `
 "{
   \\"compilerOptions\\": {
     \\"declaration\\": true,
@@ -554,7 +409,7 @@ exports[`plugin generator generates plugin with custom options 8`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with custom options 9`] = `
+exports[`plugin generator generates plugin with custom options 8`] = `
 "import { RegistrationArgs, getPluginName } from '@checkup/core';
 
 export function register(args: RegistrationArgs) {
@@ -564,7 +419,13 @@ export function register(args: RegistrationArgs) {
 "
 `;
 
-exports[`plugin generator generates plugin with custom options 10`] = `""`;
+exports[`plugin generator generates plugin with custom options 9`] = `""`;
+
+exports[`plugin generator generates plugin with custom options 10`] = `
+Array [
+  ".gitkeep",
+]
+`;
 
 exports[`plugin generator generates plugin with custom options 11`] = `
 Array [
@@ -578,72 +439,13 @@ Array [
 ]
 `;
 
-exports[`plugin generator generates plugin with custom options 13`] = `
-Array [
-  ".gitkeep",
-]
-`;
-
 exports[`plugin generator generates plugin with defaults 1`] = `
-"{
-  \\"name\\": \\"checkup-plugin-my-plugin\\",
-  \\"description\\": \\"Checkup plugin\\",
-  \\"version\\": \\"0.0.0\\",
-  \\"author\\": \\"\\",
-  \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^1.0.0-beta.0\\",
-    \\"tslib\\": \\"^1\\"
-  },
-  \\"devDependencies\\": {
-    \\"@checkup/plugin\\": \\"^1.0.0-beta.0\\",
-    \\"@checkup/test-helpers\\": \\"^1.0.0-beta.0\\",
-    \\"@types/jest\\": \\"^25.1.3\\",
-    \\"@types/node\\": \\"^13\\",
-    \\"@typescript-eslint/eslint-plugin\\": \\"^3.5.0\\",
-    \\"@typescript-eslint/parser\\": \\"^3.5.0\\",
-    \\"eslint\\": \\"^7.5.0\\",
-    \\"eslint-config-prettier\\": \\"^6.11.0\\",
-    \\"eslint-plugin-jest\\": \\"^23.8.2\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prettier\\": \\"^3.1.3\\",
-    \\"jest\\": \\"^25.1.0\\",
-    \\"prettier\\": \\"^2.0.5\\",
-    \\"ts-jest\\": \\"^25.2.1\\",
-    \\"ts-node\\": \\"^8\\",
-    \\"typescript\\": \\"^3.8\\"
-  },
-  \\"engines\\": {
-    \\"node\\": \\">= 12.11.*\\"
-  },
-  \\"files\\": [
-    \\"/lib\\"
-  ],
-  \\"keywords\\": [
-    \\"checkup-plugin\\"
-  ],
-  \\"license\\": \\"MIT\\",
-  \\"repository\\": \\"\\",
-  \\"scripts\\": {
-    \\"build\\": \\"yarn clean && tsc\\",
-    \\"build:watch\\": \\"yarn build -w\\",
-    \\"clean\\": \\"rm -rf lib\\",
-    \\"docs:generate\\": \\"checkup-plugin docs\\",
-    \\"lint\\": \\"eslint . --cache --ext .ts\\",
-    \\"test\\": \\"jest --no-cache\\"
-  },
-  \\"types\\": \\"lib/index.d.ts\\",
-  \\"main\\": \\"lib/index.js\\"
-}
-"
-`;
-
-exports[`plugin generator generates plugin with defaults 2`] = `
 "lib 
 node_modules
 "
 `;
 
-exports[`plugin generator generates plugin with defaults 3`] = `
+exports[`plugin generator generates plugin with defaults 2`] = `
 "{
   \\"root\\": true,
   \\"parser\\": \\"@typescript-eslint/parser\\",
@@ -686,12 +488,12 @@ exports[`plugin generator generates plugin with defaults 3`] = `
 }"
 `;
 
-exports[`plugin generator generates plugin with defaults 4`] = `
+exports[`plugin generator generates plugin with defaults 3`] = `
 "lib
 .eslintcache"
 `;
 
-exports[`plugin generator generates plugin with defaults 5`] = `
+exports[`plugin generator generates plugin with defaults 4`] = `
 "module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
@@ -699,7 +501,7 @@ exports[`plugin generator generates plugin with defaults 5`] = `
 };"
 `;
 
-exports[`plugin generator generates plugin with defaults 6`] = `
+exports[`plugin generator generates plugin with defaults 5`] = `
 "# checkup-plugin-my-plugin
 
 Checkup plugin
@@ -720,7 +522,7 @@ Checkup plugin
 "
 `;
 
-exports[`plugin generator generates plugin with defaults 7`] = `
+exports[`plugin generator generates plugin with defaults 6`] = `
 "module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json'],
@@ -741,7 +543,7 @@ exports[`plugin generator generates plugin with defaults 7`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with defaults 8`] = `
+exports[`plugin generator generates plugin with defaults 7`] = `
 "{
   \\"compilerOptions\\": {
     \\"declaration\\": true,
@@ -760,7 +562,7 @@ exports[`plugin generator generates plugin with defaults 8`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with defaults 9`] = `
+exports[`plugin generator generates plugin with defaults 8`] = `
 "import { RegistrationArgs, getPluginName } from '@checkup/core';
 
 export function register(args: RegistrationArgs) {
@@ -770,7 +572,13 @@ export function register(args: RegistrationArgs) {
 "
 `;
 
-exports[`plugin generator generates plugin with defaults 10`] = `""`;
+exports[`plugin generator generates plugin with defaults 9`] = `""`;
+
+exports[`plugin generator generates plugin with defaults 10`] = `
+Array [
+  ".gitkeep",
+]
+`;
 
 exports[`plugin generator generates plugin with defaults 11`] = `
 Array [
@@ -784,72 +592,13 @@ Array [
 ]
 `;
 
-exports[`plugin generator generates plugin with defaults 13`] = `
-Array [
-  ".gitkeep",
-]
-`;
-
 exports[`plugin generator generates plugin with defaults in custom path 1`] = `
-"{
-  \\"name\\": \\"checkup-plugin-my-plugin\\",
-  \\"description\\": \\"Checkup plugin\\",
-  \\"version\\": \\"0.0.0\\",
-  \\"author\\": \\"\\",
-  \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^1.0.0-beta.0\\",
-    \\"tslib\\": \\"^1\\"
-  },
-  \\"devDependencies\\": {
-    \\"@checkup/plugin\\": \\"^1.0.0-beta.0\\",
-    \\"@checkup/test-helpers\\": \\"^1.0.0-beta.0\\",
-    \\"@types/jest\\": \\"^25.1.3\\",
-    \\"@types/node\\": \\"^13\\",
-    \\"@typescript-eslint/eslint-plugin\\": \\"^3.5.0\\",
-    \\"@typescript-eslint/parser\\": \\"^3.5.0\\",
-    \\"eslint\\": \\"^7.5.0\\",
-    \\"eslint-config-prettier\\": \\"^6.11.0\\",
-    \\"eslint-plugin-jest\\": \\"^23.8.2\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prettier\\": \\"^3.1.3\\",
-    \\"jest\\": \\"^25.1.0\\",
-    \\"prettier\\": \\"^2.0.5\\",
-    \\"ts-jest\\": \\"^25.2.1\\",
-    \\"ts-node\\": \\"^8\\",
-    \\"typescript\\": \\"^3.8\\"
-  },
-  \\"engines\\": {
-    \\"node\\": \\">= 12.11.*\\"
-  },
-  \\"files\\": [
-    \\"/lib\\"
-  ],
-  \\"keywords\\": [
-    \\"checkup-plugin\\"
-  ],
-  \\"license\\": \\"MIT\\",
-  \\"repository\\": \\"\\",
-  \\"scripts\\": {
-    \\"build\\": \\"yarn clean && tsc\\",
-    \\"build:watch\\": \\"yarn build -w\\",
-    \\"clean\\": \\"rm -rf lib\\",
-    \\"docs:generate\\": \\"checkup-plugin docs\\",
-    \\"lint\\": \\"eslint . --cache --ext .ts\\",
-    \\"test\\": \\"jest --no-cache\\"
-  },
-  \\"types\\": \\"lib/index.d.ts\\",
-  \\"main\\": \\"lib/index.js\\"
-}
-"
-`;
-
-exports[`plugin generator generates plugin with defaults in custom path 2`] = `
 "lib 
 node_modules
 "
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 3`] = `
+exports[`plugin generator generates plugin with defaults in custom path 2`] = `
 "{
   \\"root\\": true,
   \\"parser\\": \\"@typescript-eslint/parser\\",
@@ -892,12 +641,12 @@ exports[`plugin generator generates plugin with defaults in custom path 3`] = `
 }"
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 4`] = `
+exports[`plugin generator generates plugin with defaults in custom path 3`] = `
 "lib
 .eslintcache"
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 5`] = `
+exports[`plugin generator generates plugin with defaults in custom path 4`] = `
 "module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
@@ -905,7 +654,7 @@ exports[`plugin generator generates plugin with defaults in custom path 5`] = `
 };"
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 6`] = `
+exports[`plugin generator generates plugin with defaults in custom path 5`] = `
 "# checkup-plugin-my-plugin
 
 Checkup plugin
@@ -926,7 +675,7 @@ Checkup plugin
 "
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 7`] = `
+exports[`plugin generator generates plugin with defaults in custom path 6`] = `
 "module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json'],
@@ -947,7 +696,7 @@ exports[`plugin generator generates plugin with defaults in custom path 7`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 8`] = `
+exports[`plugin generator generates plugin with defaults in custom path 7`] = `
 "{
   \\"compilerOptions\\": {
     \\"declaration\\": true,
@@ -966,7 +715,7 @@ exports[`plugin generator generates plugin with defaults in custom path 8`] = `
 "
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 9`] = `
+exports[`plugin generator generates plugin with defaults in custom path 8`] = `
 "import { RegistrationArgs, getPluginName } from '@checkup/core';
 
 export function register(args: RegistrationArgs) {
@@ -976,7 +725,13 @@ export function register(args: RegistrationArgs) {
 "
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 10`] = `""`;
+exports[`plugin generator generates plugin with defaults in custom path 9`] = `""`;
+
+exports[`plugin generator generates plugin with defaults in custom path 10`] = `
+Array [
+  ".gitkeep",
+]
+`;
 
 exports[`plugin generator generates plugin with defaults in custom path 11`] = `
 Array [
@@ -990,72 +745,13 @@ Array [
 ]
 `;
 
-exports[`plugin generator generates plugin with defaults in custom path 13`] = `
-Array [
-  ".gitkeep",
-]
-`;
-
 exports[`plugin generator generates plugin with unmodified name with defaults 1`] = `
-"{
-  \\"name\\": \\"checkup-plugin-foo\\",
-  \\"description\\": \\"Checkup plugin\\",
-  \\"version\\": \\"0.0.0\\",
-  \\"author\\": \\"\\",
-  \\"dependencies\\": {
-    \\"@checkup/core\\": \\"^1.0.0-beta.0\\",
-    \\"tslib\\": \\"^1\\"
-  },
-  \\"devDependencies\\": {
-    \\"@checkup/plugin\\": \\"^1.0.0-beta.0\\",
-    \\"@checkup/test-helpers\\": \\"^1.0.0-beta.0\\",
-    \\"@types/jest\\": \\"^25.1.3\\",
-    \\"@types/node\\": \\"^13\\",
-    \\"@typescript-eslint/eslint-plugin\\": \\"^3.5.0\\",
-    \\"@typescript-eslint/parser\\": \\"^3.5.0\\",
-    \\"eslint\\": \\"^7.5.0\\",
-    \\"eslint-config-prettier\\": \\"^6.11.0\\",
-    \\"eslint-plugin-jest\\": \\"^23.8.2\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prettier\\": \\"^3.1.3\\",
-    \\"jest\\": \\"^25.1.0\\",
-    \\"prettier\\": \\"^2.0.5\\",
-    \\"ts-jest\\": \\"^25.2.1\\",
-    \\"ts-node\\": \\"^8\\",
-    \\"typescript\\": \\"^3.8\\"
-  },
-  \\"engines\\": {
-    \\"node\\": \\">= 12.11.*\\"
-  },
-  \\"files\\": [
-    \\"/lib\\"
-  ],
-  \\"keywords\\": [
-    \\"checkup-plugin\\"
-  ],
-  \\"license\\": \\"MIT\\",
-  \\"repository\\": \\"\\",
-  \\"scripts\\": {
-    \\"build\\": \\"yarn clean && tsc\\",
-    \\"build:watch\\": \\"yarn build -w\\",
-    \\"clean\\": \\"rm -rf lib\\",
-    \\"docs:generate\\": \\"checkup-plugin docs\\",
-    \\"lint\\": \\"eslint . --cache --ext .ts\\",
-    \\"test\\": \\"jest --no-cache\\"
-  },
-  \\"types\\": \\"lib/index.d.ts\\",
-  \\"main\\": \\"lib/index.js\\"
-}
-"
-`;
-
-exports[`plugin generator generates plugin with unmodified name with defaults 2`] = `
 "lib 
 node_modules
 "
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 3`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 2`] = `
 "{
   \\"root\\": true,
   \\"parser\\": \\"@typescript-eslint/parser\\",
@@ -1098,12 +794,12 @@ exports[`plugin generator generates plugin with unmodified name with defaults 3`
 }"
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 4`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 3`] = `
 "lib
 .eslintcache"
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 5`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 4`] = `
 "module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
@@ -1111,7 +807,7 @@ exports[`plugin generator generates plugin with unmodified name with defaults 5`
 };"
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 6`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 5`] = `
 "# checkup-plugin-foo
 
 Checkup plugin
@@ -1132,7 +828,7 @@ Checkup plugin
 "
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 7`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 6`] = `
 "module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json'],
@@ -1153,7 +849,7 @@ exports[`plugin generator generates plugin with unmodified name with defaults 7`
 "
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 8`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 7`] = `
 "{
   \\"compilerOptions\\": {
     \\"declaration\\": true,
@@ -1172,7 +868,7 @@ exports[`plugin generator generates plugin with unmodified name with defaults 8`
 "
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 9`] = `
+exports[`plugin generator generates plugin with unmodified name with defaults 8`] = `
 "import { RegistrationArgs, getPluginName } from '@checkup/core';
 
 export function register(args: RegistrationArgs) {
@@ -1182,7 +878,13 @@ export function register(args: RegistrationArgs) {
 "
 `;
 
-exports[`plugin generator generates plugin with unmodified name with defaults 10`] = `""`;
+exports[`plugin generator generates plugin with unmodified name with defaults 9`] = `""`;
+
+exports[`plugin generator generates plugin with unmodified name with defaults 10`] = `
+Array [
+  ".gitkeep",
+]
+`;
 
 exports[`plugin generator generates plugin with unmodified name with defaults 11`] = `
 Array [
@@ -1191,12 +893,6 @@ Array [
 `;
 
 exports[`plugin generator generates plugin with unmodified name with defaults 12`] = `
-Array [
-  ".gitkeep",
-]
-`;
-
-exports[`plugin generator generates plugin with unmodified name with defaults 13`] = `
 Array [
   ".gitkeep",
 ]

--- a/packages/cli/__tests__/generators/generate-plugin-test.ts
+++ b/packages/cli/__tests__/generators/generate-plugin-test.ts
@@ -6,6 +6,52 @@ import { generatePlugin } from '../__utils__/generator-utils';
 describe('plugin generator', () => {
   let tmp: string;
 
+  let expectedTsPackageJsonObject = {
+    name: expect.any(String),
+    description: expect.any(String),
+    version: expect.any(String),
+    author: expect.any(String),
+    dependencies: {
+      '@checkup/core': expect.any(String),
+      tslib: expect.any(String),
+    },
+    devDependencies: {
+      '@checkup/plugin': expect.any(String),
+      '@checkup/test-helpers': expect.any(String),
+      '@types/jest': expect.any(String),
+      '@types/node': expect.any(String),
+      '@typescript-eslint/eslint-plugin': expect.any(String),
+      '@typescript-eslint/parser': expect.any(String),
+      eslint: expect.any(String),
+      'eslint-config-prettier': expect.any(String),
+      'eslint-plugin-jest': expect.any(String),
+      'eslint-plugin-node': expect.any(String),
+      'eslint-plugin-prettier': expect.any(String),
+      jest: expect.any(String),
+      prettier: expect.any(String),
+      'ts-jest': expect.any(String),
+      'ts-node': expect.any(String),
+      typescript: expect.any(String),
+    },
+    engines: {
+      node: expect.any(String),
+    },
+    files: ['/lib'],
+    keywords: ['checkup-plugin'],
+    license: 'MIT',
+    repository: expect.any(String),
+    scripts: {
+      build: 'yarn clean && tsc',
+      'build:watch': 'yarn build -w',
+      clean: 'rm -rf lib',
+      'docs:generate': 'checkup-plugin docs',
+      lint: 'eslint . --cache --ext .ts',
+      test: 'jest --no-cache',
+    },
+    types: 'lib/index.d.ts',
+    main: 'lib/index.js',
+  };
+
   beforeEach(() => {
     tmp = createTmpDir();
   });
@@ -15,7 +61,10 @@ describe('plugin generator', () => {
 
     let root = testRoot(dir);
 
-    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(JSON.parse(root.file('package.json').contents)).toMatchObject(
+      expectedTsPackageJsonObject
+    );
+
     expect(root.file('.eslintignore').contents).toMatchSnapshot();
     expect(root.file('.eslintrc').contents).toMatchSnapshot();
     expect(root.file('.gitignore').contents).toMatchSnapshot();
@@ -35,7 +84,9 @@ describe('plugin generator', () => {
 
     let root = testRoot(dir);
 
-    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(JSON.parse(root.file('package.json').contents)).toMatchObject(
+      expectedTsPackageJsonObject
+    );
     expect(root.file('.eslintignore').contents).toMatchSnapshot();
     expect(root.file('.eslintrc').contents).toMatchSnapshot();
     expect(root.file('.gitignore').contents).toMatchSnapshot();
@@ -55,7 +106,38 @@ describe('plugin generator', () => {
 
     let root = testRoot(dir);
 
-    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(JSON.parse(root.file('package.json').contents)).toMatchObject({
+      name: expect.any(String),
+      description: expect.any(String),
+      version: expect.any(String),
+      author: expect.any(String),
+      dependencies: {
+        '@checkup/core': expect.any(String),
+      },
+      devDependencies: {
+        '@checkup/test-helpers': expect.any(String),
+        eslint: expect.any(String),
+        'eslint-config-prettier': expect.any(String),
+        'eslint-plugin-jest': expect.any(String),
+        'eslint-plugin-node': expect.any(String),
+        'eslint-plugin-prettier': expect.any(String),
+        jest: expect.any(String),
+        prettier: expect.any(String),
+      },
+      engines: {
+        node: expect.any(String),
+      },
+      files: ['/lib'],
+      keywords: ['checkup-plugin'],
+      license: 'MIT',
+      repository: expect.any(String),
+      scripts: {
+        lint: 'eslint . --cache',
+        test: 'jest --no-cache',
+      },
+      main: 'lib/index.js',
+    });
+
     expect(root.file('.eslintignore').contents).toMatchSnapshot();
     expect(root.file('.eslintrc').contents).toMatchSnapshot();
     expect(root.file('.gitignore').contents).toMatchSnapshot();
@@ -74,7 +156,9 @@ describe('plugin generator', () => {
 
     let root = testRoot(dir);
 
-    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(JSON.parse(root.file('package.json').contents)).toMatchObject(
+      expectedTsPackageJsonObject
+    );
     expect(root.file('.eslintignore').contents).toMatchSnapshot();
     expect(root.file('.eslintrc').contents).toMatchSnapshot();
     expect(root.file('.gitignore').contents).toMatchSnapshot();
@@ -96,7 +180,9 @@ describe('plugin generator', () => {
 
     let root = testRoot(existingDir);
 
-    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(JSON.parse(root.file('package.json').contents)).toMatchObject(
+      expectedTsPackageJsonObject
+    );
     expect(root.file('.eslintignore').contents).toMatchSnapshot();
     expect(root.file('.eslintrc').contents).toMatchSnapshot();
     expect(root.file('.gitignore').contents).toMatchSnapshot();
@@ -126,7 +212,9 @@ describe('plugin generator', () => {
 
     let root = testRoot(dir);
 
-    expect(root.file('package.json').contents).toMatchSnapshot();
+    expect(JSON.parse(root.file('package.json').contents)).toMatchObject(
+      expectedTsPackageJsonObject
+    );
     expect(root.file('.eslintignore').contents).toMatchSnapshot();
     expect(root.file('.eslintrc').contents).toMatchSnapshot();
     expect(root.file('.gitignore').contents).toMatchSnapshot();


### PR DESCRIPTION
Previously, every time we published a new version, these snapshots would have to be updated. In reality, we don't care about the values of the different fields in the package.json, just the keys. Updated test to use matchers and only verify the keys