### PR TITLE
Removes format from RunOptions to clean up Node API

### DIFF
--- a/packages/cli/__tests__/__utils__/sarif-match-object.ts
+++ b/packages/cli/__tests__/__utils__/sarif-match-object.ts
@@ -5,7 +5,7 @@ export const sarifLogMatcher = {
     analyzedFiles: expect.any(Array),
     analyzedFilesCount: expect.any(Number),
     cli: {
-      args: expect.any(Array),
+      options: expect.any(Array),
       config: {
         $schema:
           'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json',
@@ -14,7 +14,6 @@ export const sarifLogMatcher = {
         tasks: {},
       },
       configHash: expect.any(String),
-      flags: expect.any(Object),
       schema: 1,
       version: '0.0.0',
     },
@@ -40,11 +39,6 @@ export const sarifLogMatcher = {
         {
           arguments: expect.any(Array),
           endTimeUtc: expect.any(String),
-          environmentVariables: {
-            cwd: expect.any(String),
-            format: expect.stringMatching(/stdout|json/),
-            outputFile: '',
-          },
           executionSuccessful: true,
           startTimeUtc: expect.any(String),
           toolExecutionNotifications: [],

--- a/packages/cli/__tests__/checkup-task-runner-test.ts
+++ b/packages/cli/__tests__/checkup-task-runner-test.ts
@@ -55,14 +55,12 @@ describe('checkup-task-runner', () => {
     let taskRunner = new CheckupTaskRunner({
       paths: [],
       cwd: '.',
-      format: 'stdout',
       outputFile: '',
     });
 
     expect(taskRunner.options).toEqual({
       paths: [],
       cwd: '.',
-      format: 'stdout',
       outputFile: '',
     });
   });
@@ -71,7 +69,6 @@ describe('checkup-task-runner', () => {
     let taskRunner = new CheckupTaskRunner({
       paths: [],
       cwd: project.baseDir,
-      format: 'stdout',
       outputFile: '',
     });
 
@@ -82,7 +79,6 @@ describe('checkup-task-runner', () => {
     let taskRunner = new CheckupTaskRunner({
       paths: ['.'],
       cwd: project.baseDir,
-      format: 'stdout',
       outputFile: '',
     });
 

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -98,7 +98,6 @@ checkup <command> [options]`
           config: argv.config as string,
           cwd: argv.cwd as string,
           categories: argv.category as string[],
-          format: argv.format as string,
           groups: argv.group as string[],
           tasks: argv.task as string[],
           outputFile: argv.outputFile as string,

--- a/packages/cli/src/formatters/get-formatter.ts
+++ b/packages/cli/src/formatters/get-formatter.ts
@@ -11,22 +11,23 @@ export interface ReportOptions {
 }
 
 export function getFormatter(options: ReportOptions) {
-  if (options.verbose) {
-    return new VerboseFormatter(options);
-  }
+  let mergedOptions = Object.assign({}, { format: 'stdout' }, options);
 
-  switch (options.format) {
+  switch (mergedOptions.format) {
     case OutputFormat.stdout: {
-      return new SummaryFormatter(options);
+      if (mergedOptions.verbose) {
+        return new VerboseFormatter(mergedOptions);
+      }
+      return new SummaryFormatter(mergedOptions);
     }
 
     case OutputFormat.json: {
-      return new JsonFormatter(options);
+      return new JsonFormatter(mergedOptions);
     }
   }
 
   throw new CheckupError(ErrorKind.FormatterNotFound, {
-    format: options.format,
+    format: mergedOptions.format,
     validFormats: [...Object.values(OutputFormat)],
   });
 }

--- a/packages/cli/src/get-log.ts
+++ b/packages/cli/src/get-log.ts
@@ -26,11 +26,6 @@ function getInvocation(
     arguments: unparse(options),
     executionSuccessful: true,
     endTimeUtc: new Date().toJSON(),
-    environmentVariables: {
-      cwd: options.cwd,
-      outputFile: options.outputFile,
-      format: options.format,
-    },
     toolExecutionNotifications: sarifBuilder.notifications.fromTaskErrors(errors),
     startTimeUtc: startTime,
   };
@@ -94,8 +89,6 @@ function getConfigHash(checkupConfig: CheckupConfig) {
 async function getCheckupMetadata(taskContext: TaskContext): Promise<CheckupMetadata> {
   let package_ = taskContext.pkg;
   let repositoryInfo = await getRepositoryInfo(taskContext.options.cwd, taskContext.paths);
-
-  let { config, tasks, format } = taskContext.options;
   let analyzedFiles = trimAllCwd(taskContext.paths, taskContext.options.cwd);
 
   return {
@@ -110,14 +103,7 @@ async function getCheckupMetadata(taskContext: TaskContext): Promise<CheckupMeta
       config: taskContext.config,
       version: getVersion(),
       schema: 1,
-      args: unparse(taskContext.options),
-      flags: {
-        config,
-        tasks,
-        format,
-        outputFile: taskContext.options.outputFile,
-        excludePaths: taskContext.options.excludePaths,
-      },
+      options: unparse(taskContext.options),
     },
 
     analyzedFiles,

--- a/packages/core/src/types/checkup-result.ts
+++ b/packages/core/src/types/checkup-result.ts
@@ -1,3 +1,4 @@
+import { RunOptions } from './cli';
 import { CheckupConfig } from './config';
 
 export type IndexableObject = { [key: string]: any };
@@ -31,16 +32,7 @@ export interface CheckupMetadata {
     configHash: string;
     config: CheckupConfig;
     version: string;
-    args: {
-      paths: string[];
-    };
-    flags: {
-      config?: string;
-      tasks?: string[];
-      format: string;
-      outputFile?: string;
-      excludePaths?: string[];
-    };
+    options: RunOptions;
   };
   analyzedFiles: string[];
   analyzedFilesCount: number;

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -21,7 +21,6 @@ export type RunOptions = {
   config?: string;
   categories?: string[];
   excludePaths?: string[];
-  format: string;
   groups?: string[];
   listTasks?: boolean;
   outputFile: string;

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -34,7 +34,6 @@ const DEFAULT_OPTIONS: RunOptions = {
   groups: undefined,
   tasks: undefined,
   listTasks: false,
-  format: 'stdout',
   outputFile: '',
 };
 


### PR DESCRIPTION
As discussed, cleans up `RunOptions` to exclude `format`.