### PR TITLE
Removing output-file from CheckupTaskRunner

### DIFF
--- a/packages/cli/__tests__/checkup-task-runner-test.ts
+++ b/packages/cli/__tests__/checkup-task-runner-test.ts
@@ -55,13 +55,11 @@ describe('checkup-task-runner', () => {
     let taskRunner = new CheckupTaskRunner({
       paths: [],
       cwd: '.',
-      outputFile: '',
     });
 
     expect(taskRunner.options).toEqual({
       paths: [],
       cwd: '.',
-      outputFile: '',
     });
   });
 
@@ -69,7 +67,6 @@ describe('checkup-task-runner', () => {
     let taskRunner = new CheckupTaskRunner({
       paths: [],
       cwd: project.baseDir,
-      outputFile: '',
     });
 
     expect(await taskRunner.run()).toMatchObject(sarifLogMatcher);
@@ -79,7 +76,6 @@ describe('checkup-task-runner', () => {
     let taskRunner = new CheckupTaskRunner({
       paths: ['.'],
       cwd: project.baseDir,
-      outputFile: '',
     });
 
     taskRunner.tasks.registerTask(new FileCountTask(getTaskContext()));

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -101,7 +101,6 @@ checkup <command> [options]`
           categories: argv.category as string[],
           groups: argv.group as string[],
           tasks: argv.task as string[],
-          outputFile: argv.outputFile as string,
         });
 
         if (!argv.paths || (argv.paths as string[]).length === 0) {
@@ -124,7 +123,7 @@ checkup <command> [options]`
 
           let formatter = getFormatter({
             cwd: argv.cwd as string,
-            format: argv.format as string,
+            format: argv.format as OutputFormat,
             outputFile: argv.outputFile as string,
           });
 

--- a/packages/cli/src/formatters/get-formatter.ts
+++ b/packages/cli/src/formatters/get-formatter.ts
@@ -5,7 +5,7 @@ import JsonFormatter from './json';
 
 export interface ReportOptions {
   cwd: string;
-  format: string;
+  format: OutputFormat;
   outputFile?: string;
 }
 

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -2,20 +2,6 @@ import { ConsoleWriter } from '../utils/console-writer';
 import { Task, TaskContext, TaskName, TaskActionsEvaluator, TaskFormatter } from './tasks';
 import { ParserName, CreateParser, ParserOptions, Parser, ParserReport } from './parsers';
 
-export type RunFlags = {
-  version: void;
-  help: void;
-  config: string | undefined;
-  cwd: string;
-  category: string[] | undefined;
-  group: string[] | undefined;
-  task: string[] | undefined;
-  'list-tasks': boolean;
-  format: string;
-  'output-file': string;
-  'exclude-paths': string[] | undefined;
-};
-
 export type RunOptions = {
   cwd: string;
   config?: string;
@@ -23,7 +9,6 @@ export type RunOptions = {
   excludePaths?: string[];
   groups?: string[];
   listTasks?: boolean;
-  outputFile: string;
   paths: string[];
   tasks?: string[];
 };

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -1,5 +1,4 @@
 import {
-  RunFlags,
   CheckupConfig,
   FilePathArray,
   TaskContext,
@@ -18,7 +17,6 @@ import { CONFIG_SCHEMA_URL } from '@checkup/core';
 
 type TaskContextArgs = {
   cliArguments: string[];
-  cliFlags: Partial<RunFlags>;
   options: Partial<RunOptions>;
   config: Partial<CheckupConfig>;
   pkg: PackageJson;
@@ -34,7 +32,6 @@ const DEFAULT_OPTIONS: RunOptions = {
   groups: undefined,
   tasks: undefined,
   listTasks: false,
-  outputFile: '',
 };
 
 const DEFAULT_CONFIG: CheckupConfig = {


### PR DESCRIPTION
output-file only should be needed by the formatter, not the task runner. Also deleted some dead stuff