### PR TITLE
Fixing bug in pretty formatter conditional

### DIFF
--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -24,7 +24,7 @@ export default class PrettyFormatter {
 
   constructor(options: ReportOptions) {
     this.options = options;
-    this.consoleWriter = new ConsoleWriter(options.outputFile !== '' ? 'file' : 'console');
+    this.consoleWriter = new ConsoleWriter(options.outputFile ? 'file' : 'console');
     this.formatArgs = { writer: this.consoleWriter };
   }
 


### PR DESCRIPTION
Pretty formatter checked for outputFile !== '', but when outputFile was undefined, it didn't meet that condition, but should still be writing to console.