### PR TITLE
Fixes loop in ember-template-lint-parser

### DIFF
--- a/packages/core/src/parsers/ember-template-lint-parser.ts
+++ b/packages/core/src/parsers/ember-template-lint-parser.ts
@@ -27,21 +27,21 @@ class EmberTemplateLintParser implements Parser<TemplateLintReport> {
       template: fs.readFileSync(path, { encoding: 'utf8' }),
     }));
 
-    let results: TemplateLintResult[] = await Promise.all(
-      sources.map(async ({ path, template }) => {
-        let messages: TemplateLintMessage[] = await this.engine.verify({
-          source: template,
-          filePath: path,
-        });
+    let results: TemplateLintResult[] = [];
 
-        return {
-          messages,
-          errorCount: messages.length,
-          filePath: path,
-          source: template,
-        };
-      })
-    );
+    for (let { path, template } of sources) {
+      let messages: TemplateLintMessage[] = await this.engine.verify({
+        source: template,
+        filePath: path,
+      });
+
+      results.push({
+        messages,
+        errorCount: messages.length,
+        filePath: path,
+        source: template,
+      });
+    }
 
     let errorCount = results
       .map(({ errorCount }) => errorCount)


### PR DESCRIPTION
Changes the loop used in `ember-template-lint-parser` to use a `for..of` vs a `Promise.all`. This addresses issues where, for large applications, using a `Promise.all` was temporarily inflating memory and causing OOMs. 