### PR TITLE
Improve type definition for error kind map

### DIFF
--- a/packages/core/src/errors/checkup-error.ts
+++ b/packages/core/src/errors/checkup-error.ts
@@ -15,6 +15,9 @@ export default class CheckupError extends Error {
 
   constructor(kind: ErrorKind, options: ErrorDetailOptions = {}) {
     let details = ERROR_BY_KIND[kind];
+    if (!details) {
+      throw new Error(`ErrorKind provided missing from ERROR_BY_KIND map: ${ErrorKind}`)
+    }
 
     super(details.message(options));
 

--- a/packages/core/src/errors/checkup-error.ts
+++ b/packages/core/src/errors/checkup-error.ts
@@ -16,7 +16,7 @@ export default class CheckupError extends Error {
   constructor(kind: ErrorKind, options: ErrorDetailOptions = {}) {
     let details = ERROR_BY_KIND[kind];
     if (!details) {
-      throw new Error(`ErrorKind provided missing from ERROR_BY_KIND map: ${ErrorKind}`)
+      throw new Error(`ErrorKind provided missing from ERROR_BY_KIND map: ${ErrorKind}`);
     }
 
     super(details.message(options));

--- a/packages/core/src/errors/error-kind.ts
+++ b/packages/core/src/errors/error-kind.ts
@@ -33,7 +33,7 @@ export interface ErrorDetails {
 
 export type ErrorDetailOptions = Record<string, any> & { error?: Error };
 
-export const ERROR_BY_KIND: { [key: string]: ErrorDetails } = {
+export const ERROR_BY_KIND: { [Key in ErrorKind]?: ErrorDetails } = {
   [ErrorKind.ConfigNotValid]: {
     message: () => `Configuration not valid`,
     callToAction: () =>


### PR DESCRIPTION
By typing the map based on the enum used in its keys you get better feedback when indexing it. This also helps the compiler understand the resulting value may be undefined and forces that condition to be handled instead of failing with something useless like"undefined is not a function".

An alternative would be to define ERROR_BY_KIND keys for the remaining ErrorKind values, in which case the resulting value would never be undefined.