### PR TITLE
Adds ability to specify custom formatters

### DIFF
--- a/packages/checkup-plugin-ember/src/formatters/ember-octane-migration-status-formatter.ts
+++ b/packages/checkup-plugin-ember/src/formatters/ember-octane-migration-status-formatter.ts
@@ -3,17 +3,17 @@ import {
   NO_RESULTS_FOUND,
   reduceResults,
   sumOccurrences,
-  FormatArgs,
+  FormatterArgs,
   renderEmptyResult,
 } from '@checkup/core';
 import { Result } from 'sarif';
 
-export function format(taskResults: Result[], formatArgs: FormatArgs) {
-  formatArgs.writer.section(taskResults[0].properties?.taskDisplayName, () => {
-    formatArgs.writer.log(
-      `${formatArgs.writer.emphasize('Octane Violations')}: ${sumOccurrences(taskResults)}`
+export function format(taskResults: Result[], args: FormatterArgs) {
+  args.writer.section(taskResults[0].properties?.taskDisplayName, () => {
+    args.writer.log(
+      `${args.writer.emphasize('Octane Violations')}: ${sumOccurrences(taskResults)}`
     );
-    formatArgs.writer.blankLine();
+    args.writer.blankLine();
 
     let groupedTaskResults = groupDataByField(taskResults, 'properties.resultGroup');
 
@@ -22,8 +22,8 @@ export function format(taskResults: Result[], formatArgs: FormatArgs) {
         groupDataByField(resultGroup, 'properties.lintRuleId')
       );
 
-      formatArgs.writer.subHeader(groupedTaskResultsByLintRuleId[0].properties?.resultGroup);
-      formatArgs.writer.valuesList(
+      args.writer.subHeader(groupedTaskResultsByLintRuleId[0].properties?.resultGroup);
+      args.writer.valuesList(
         groupedTaskResultsByLintRuleId.map((result) => {
           return result.message.text === NO_RESULTS_FOUND
             ? renderEmptyResult(result)
@@ -34,7 +34,7 @@ export function format(taskResults: Result[], formatArgs: FormatArgs) {
         }),
         'violations'
       );
-      formatArgs.writer.blankLine();
+      args.writer.blankLine();
     });
   });
 }

--- a/packages/checkup-plugin-ember/src/formatters/ember-template-lint-summary-formatter.ts
+++ b/packages/checkup-plugin-ember/src/formatters/ember-template-lint-summary-formatter.ts
@@ -1,6 +1,6 @@
-import { FormatArgs, renderLintingSummaryResult } from '@checkup/core';
+import { FormatterArgs, renderLintingSummaryResult } from '@checkup/core';
 import { Result } from 'sarif';
 
-export function format(taskResults: Result[], formatArgs: FormatArgs) {
-  renderLintingSummaryResult(taskResults, formatArgs);
+export function format(taskResults: Result[], args: FormatterArgs) {
+  renderLintingSummaryResult(taskResults, args);
 }

--- a/packages/checkup-plugin-ember/src/formatters/ember-test-types-formatter.ts
+++ b/packages/checkup-plugin-ember/src/formatters/ember-test-types-formatter.ts
@@ -1,5 +1,5 @@
 import {
-  FormatArgs,
+  FormatterArgs,
   groupDataByField,
   NO_RESULTS_FOUND,
   reduceResults,
@@ -8,16 +8,16 @@ import {
 } from '@checkup/core';
 import { Result } from 'sarif';
 
-export function format(taskResults: Result[], formatArgs: FormatArgs) {
+export function format(taskResults: Result[], args: FormatterArgs) {
   let groupedTaskResults = groupDataByField(taskResults, 'message.text');
 
-  formatArgs.writer.section(taskResults[0].properties?.taskDisplayName, () => {
+  args.writer.section(taskResults[0].properties?.taskDisplayName, () => {
     groupedTaskResults.forEach((resultGroup: Result[]) => {
       let groupedTaskResultsByMethod = reduceResults(
         groupDataByField(resultGroup, 'properties.method')
       );
-      formatArgs.writer.subHeader(groupedTaskResultsByMethod[0].message.text as string);
-      formatArgs.writer.valuesList(
+      args.writer.subHeader(groupedTaskResultsByMethod[0].message.text as string);
+      args.writer.valuesList(
         groupedTaskResultsByMethod.map((result) => {
           return result.message.text === NO_RESULTS_FOUND
             ? renderEmptyResult(result)
@@ -27,11 +27,11 @@ export function format(taskResults: Result[], formatArgs: FormatArgs) {
               };
         })
       );
-      formatArgs.writer.blankLine();
+      args.writer.blankLine();
     });
 
-    formatArgs.writer.subHeader('tests by type');
-    formatArgs.writer.sectionedBar(
+    args.writer.subHeader('tests by type');
+    args.writer.sectionedBar(
       groupedTaskResults.map((results: Result[]) => {
         return {
           title: results[0].message.text || '',

--- a/packages/checkup-plugin-javascript/src/formatters/eslint-summary-formatter.ts
+++ b/packages/checkup-plugin-javascript/src/formatters/eslint-summary-formatter.ts
@@ -1,6 +1,6 @@
-import { FormatArgs, renderLintingSummaryResult } from '@checkup/core';
+import { FormatterArgs, renderLintingSummaryResult } from '@checkup/core';
 import { Result } from 'sarif';
 
-export function format(taskResults: Result[], formatArgs: FormatArgs) {
-  renderLintingSummaryResult(taskResults, formatArgs);
+export function format(taskResults: Result[], args: FormatterArgs) {
+  renderLintingSummaryResult(taskResults, args);
 }

--- a/packages/checkup-plugin-javascript/src/formatters/outdated-dependencies-formatter.ts
+++ b/packages/checkup-plugin-javascript/src/formatters/outdated-dependencies-formatter.ts
@@ -1,9 +1,9 @@
-import { NO_RESULTS_FOUND, sumOccurrences, renderEmptyResult, FormatArgs } from '@checkup/core';
+import { NO_RESULTS_FOUND, sumOccurrences, renderEmptyResult, FormatterArgs } from '@checkup/core';
 import { Result } from 'sarif';
 
-export function format(taskResults: Result[], formatArgs: FormatArgs) {
-  formatArgs.writer.section(taskResults[0].properties?.taskDisplayName, () => {
-    formatArgs.writer.sectionedBar(
+export function format(taskResults: Result[], args: FormatterArgs) {
+  args.writer.section(taskResults[0].properties?.taskDisplayName, () => {
+    args.writer.sectionedBar(
       taskResults.map((result: Result) => {
         return result.message.text === NO_RESULTS_FOUND
           ? renderEmptyResult(result)

--- a/packages/cli/__tests__/__fixtures__/checkup-formatter-test/index.js
+++ b/packages/cli/__tests__/__fixtures__/checkup-formatter-test/index.js
@@ -1,0 +1,12 @@
+class CustomFormatter {
+  constructor(args = {}) {
+    this.args = args;
+  }
+
+  format(results) {
+    this.args.writer.log('Custom formatter output');
+    this.args.writer.log(results);
+  }
+}
+
+module.exports = CustomFormatter;

--- a/packages/cli/__tests__/__fixtures__/checkup-formatter-test/package.json
+++ b/packages/cli/__tests__/__fixtures__/checkup-formatter-test/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "checkup-formatter-test",
+  "version": "1.0.0",
+  "description": "test formatter to show how to package formatters and use them."
+}

--- a/packages/cli/__tests__/__utils__/fake-project.ts
+++ b/packages/cli/__tests__/__utils__/fake-project.ts
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path';
+import { join } from 'path';
 import * as helpers from 'yeoman-test';
 
 import { CheckupProject } from '@checkup/test-helpers';
 
 import type { Answers } from 'inquirer';
-import { mkdirp, symlink } from 'fs-extra';
 import { generatePlugin, generateTask } from './generator-utils';
 
 export class FakeProject extends CheckupProject {
@@ -16,8 +15,7 @@ export class FakeProject extends CheckupProject {
     // we create a self-referential link to the core package within the generated plugin. This
     // allows us to generate plugins, and test the APIs for the latest version of core that is
     // referenced via the plugins' node_modules.
-    await mkdirp(dirname(target));
-    await symlink(source, target);
+    this.symlinkPackage(source, target);
 
     return pluginDir;
   }

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -16,5 +16,5 @@ module.exports = {
       statements: 100,
     },
   },
-  testPathIgnorePatterns: ['/__utils__/'],
+  testPathIgnorePatterns: ['/__utils__/', '/__fixtures__/'],
 };

--- a/packages/cli/src/formatters/formatter-utils.ts
+++ b/packages/cli/src/formatters/formatter-utils.ts
@@ -1,48 +1,48 @@
-import { Action, CheckupMetadata, FormatArgs } from '@checkup/core';
+import { Action, CheckupMetadata, FormatterArgs } from '@checkup/core';
 import { yellow, bold } from 'chalk';
 
-export function renderActions(actions: Action[], formatArgs: FormatArgs): void {
+export function renderActions(actions: Action[], args: FormatterArgs): void {
   if (actions && actions.length > 0) {
-    formatArgs.writer.categoryHeader('Actions');
+    args.writer.categoryHeader('Actions');
     actions.forEach((action: Action) => {
-      formatArgs.writer.log(`${yellow('■')} ${bold(action.summary)} (${action.details})`);
+      args.writer.log(`${yellow('■')} ${bold(action.summary)} (${action.details})`);
     });
-    formatArgs.writer.blankLine();
+    args.writer.blankLine();
   }
 }
 
-export function renderInfo(info: CheckupMetadata, formatArgs: FormatArgs) {
+export function renderInfo(info: CheckupMetadata, args: FormatterArgs) {
   let { analyzedFilesCount, project } = info;
   let { name, version, repository } = project;
 
   let analyzedFilesMessage =
     repository.totalFiles !== analyzedFilesCount
-      ? ` (${formatArgs.writer.emphasize(`${analyzedFilesCount} files`)} analyzed)`
+      ? ` (${args.writer.emphasize(`${analyzedFilesCount} files`)} analyzed)`
       : '';
 
-  formatArgs.writer.blankLine();
-  formatArgs.writer.log(
-    `Checkup report generated for ${formatArgs.writer.emphasize(
+  args.writer.blankLine();
+  args.writer.log(
+    `Checkup report generated for ${args.writer.emphasize(
       `${name} v${version}`
     )}${analyzedFilesMessage}`
   );
-  formatArgs.writer.blankLine();
-  formatArgs.writer.log(
-    `This project is ${formatArgs.writer.emphasize(
+  args.writer.blankLine();
+  args.writer.log(
+    `This project is ${args.writer.emphasize(
       `${repository.age} old`
-    )}, with ${formatArgs.writer.emphasize(
+    )}, with ${args.writer.emphasize(
       `${repository.activeDays} active days`
-    )}, ${formatArgs.writer.emphasize(
-      `${repository.totalCommits} commits`
-    )} and ${formatArgs.writer.emphasize(`${repository.totalFiles} files`)}.`
+    )}, ${args.writer.emphasize(`${repository.totalCommits} commits`)} and ${args.writer.emphasize(
+      `${repository.totalFiles} files`
+    )}.`
   );
-  formatArgs.writer.blankLine();
+  args.writer.blankLine();
 }
 
-export function renderLinesOfCode(info: CheckupMetadata, formatArgs: FormatArgs) {
+export function renderLinesOfCode(info: CheckupMetadata, args: FormatterArgs) {
   let { repository } = info.project;
 
-  formatArgs.writer.sectionedBar(
+  args.writer.sectionedBar(
     repository.linesOfCode.types.map((type) => {
       return { title: type.extension, count: type.total };
     }),
@@ -50,13 +50,13 @@ export function renderLinesOfCode(info: CheckupMetadata, formatArgs: FormatArgs)
     'lines of code'
   );
 
-  formatArgs.writer.blankLine();
+  args.writer.blankLine();
 }
 
-export function renderCLIInfo(info: CheckupMetadata, formatArgs: FormatArgs) {
+export function renderCLIInfo(info: CheckupMetadata, args: FormatterArgs) {
   let { version: cliVersion, configHash } = info.cli;
 
-  formatArgs.writer.dimmed(`checkup v${cliVersion}`);
-  formatArgs.writer.dimmed(`config ${configHash}`);
-  formatArgs.writer.blankLine();
+  args.writer.dimmed(`checkup v${cliVersion}`);
+  args.writer.dimmed(`config ${configHash}`);
+  args.writer.blankLine();
 }

--- a/packages/cli/src/formatters/json.ts
+++ b/packages/cli/src/formatters/json.ts
@@ -1,22 +1,19 @@
 import { Log } from 'sarif';
-import { ConsoleWriter } from '@checkup/core';
+import { FormatterArgs } from '@checkup/core';
 import { writeResultFile } from './file-writer';
-import { ReportOptions } from './get-formatter';
 
 export default class JsonFormatter {
-  options: ReportOptions;
-  consoleWriter: ConsoleWriter;
+  args: FormatterArgs;
 
-  constructor(options: ReportOptions) {
-    this.options = options;
-    this.consoleWriter = new ConsoleWriter();
+  constructor(options: FormatterArgs) {
+    this.args = options;
   }
 
   format(result: Log) {
-    if (this.options.outputFile) {
-      writeResultFile(result, this.options.cwd, this.options.outputFile);
+    if (this.args.outputFile) {
+      writeResultFile(result, this.args.cwd, this.args.outputFile);
     } else {
-      this.consoleWriter.styledJSON(result);
+      this.args.writer.styledJSON(result);
     }
   }
 }

--- a/packages/cli/src/formatters/summary.ts
+++ b/packages/cli/src/formatters/summary.ts
@@ -1,42 +1,37 @@
-import { CheckupMetadata, ConsoleWriter, FormatArgs } from '@checkup/core';
+import { CheckupMetadata, FormatterArgs } from '@checkup/core';
 import { Log } from 'sarif';
 import { success } from 'log-symbols';
 import { renderActions, renderCLIInfo, renderInfo } from './formatter-utils';
 import { writeResultFile } from './file-writer';
-import { ReportOptions } from './get-formatter';
 
 export default class SummaryFormatter {
-  options: ReportOptions;
-  consoleWriter: ConsoleWriter;
-  formatArgs: FormatArgs;
+  args: FormatterArgs;
 
-  constructor(options: ReportOptions) {
-    this.options = options;
-    this.consoleWriter = new ConsoleWriter();
-    this.formatArgs = { writer: this.consoleWriter };
+  constructor(args: FormatterArgs) {
+    this.args = args;
   }
 
   format(result: Log) {
-    let { cwd, outputFile } = this.options;
     let { rules } = result.runs[0].tool.driver;
     let metaData = result.properties as CheckupMetadata;
 
-    renderInfo(metaData, this.formatArgs);
+    renderInfo(metaData, this.args);
 
-    this.consoleWriter.log('Checkup ran the following task(s) successfully:');
+    this.args.writer.log('Checkup ran the following task(s) successfully:');
+
     rules!
       .map((rule) => rule.id)
       .sort()
       .forEach((taskName) => {
-        this.consoleWriter.log(`${success} ${taskName}`);
+        this.args.writer.log(`${success} ${taskName}`);
       });
 
-    writeResultFile(result, cwd, outputFile);
+    writeResultFile(result, this.args.cwd, this.args.outputFile);
 
-    renderActions(result.properties?.actions, this.formatArgs);
+    renderActions(result.properties?.actions, this.args);
 
-    this.consoleWriter.blankLine();
+    this.args.writer.blankLine();
 
-    renderCLIInfo(metaData, this.formatArgs);
+    renderCLIInfo(metaData, this.args);
   }
 }

--- a/packages/core/src/errors/error-kind.ts
+++ b/packages/core/src/errors/error-kind.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import * as chalk from 'chalk';
 
 export enum ErrorKind {
   None,
@@ -118,7 +118,9 @@ export const ERROR_BY_KIND: { [key: string]: ErrorDetails } = {
     message: (options: ErrorDetailOptions) =>
       `No valid format found for ${chalk.bold.white(options.format)}`,
     callToAction: (options: ErrorDetailOptions) =>
-      `Valid formats are ${chalk.bold.white(options.validFormats.join(', '))}`,
+      `Valid formats are ${chalk.bold.white(
+        options.validFormats.join(', ')
+      )}, or provide a custom formatter.`,
     errorCode: 1,
   },
 

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -1,5 +1,12 @@
 import { ConsoleWriter } from '../utils/console-writer';
-import { Task, TaskContext, TaskName, TaskActionsEvaluator, TaskFormatter } from './tasks';
+import {
+  Task,
+  TaskContext,
+  TaskName,
+  TaskActionsEvaluator,
+  TaskFormatter,
+  OutputFormat,
+} from './tasks';
 import { ParserName, CreateParser, ParserOptions, Parser, ParserReport } from './parsers';
 
 export type RunOptions = {
@@ -35,6 +42,10 @@ export interface RegisterableTaskList {
   registerTask(task: Task): void;
 }
 
-export interface FormatArgs {
-  writer: ConsoleWriter;
+export interface FormatterOptions {
+  cwd: string;
+  format: OutputFormat;
+  outputFile?: string;
 }
+
+export type FormatterArgs = FormatterOptions & { writer: ConsoleWriter };

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -4,7 +4,7 @@ import { FilePathArray } from '../utils/file-path-array';
 import { CreateParser, Parser, ParserName, ParserOptions, ParserReport } from './parsers';
 
 import { CheckupConfig, TaskConfig } from './config';
-import { RunOptions, FormatArgs } from './cli';
+import { RunOptions, FormatterArgs } from './cli';
 
 export type RegisterTaskArgs = {
   context: TaskContext;
@@ -13,7 +13,7 @@ export type RegisterTaskArgs = {
 
 export type TaskActionsEvaluator = (taskResults: Result[], taskConfig: TaskConfig) => Action[];
 
-export type TaskFormatter = (taskResults: Result[], formatArgs: FormatArgs) => void;
+export type TaskFormatter = (taskResults: Result[], args: FormatterArgs) => void;
 
 interface TaskList {
   registerTask(task: Task): void;

--- a/packages/core/src/utils/pretty-formatter-utils.ts
+++ b/packages/core/src/utils/pretty-formatter-utils.ts
@@ -1,7 +1,7 @@
 import { Result } from 'sarif';
 import { NO_RESULTS_FOUND } from '../data/sarif';
 import { groupDataByField } from '../data/formatters';
-import { FormatArgs } from '../types/cli';
+import { FormatterArgs } from '../types/cli';
 import { reduceResults, sumOccurrences } from './sarif-utils';
 
 export function renderEmptyResult(taskResult: Result) {
@@ -11,20 +11,20 @@ export function renderEmptyResult(taskResult: Result) {
   };
 }
 
-export function renderLintingSummaryResult(taskResults: Result[], formatArgs: FormatArgs) {
+export function renderLintingSummaryResult(taskResults: Result[], args: FormatterArgs) {
   let groupedTaskResultsByType = groupDataByField(taskResults, 'properties.type');
 
-  formatArgs.writer.section(taskResults[0].properties?.taskDisplayName, () => {
+  args.writer.section(taskResults[0].properties?.taskDisplayName, () => {
     groupedTaskResultsByType.forEach((resultGroup: Result[]) => {
       let groupedTaskResultsByLintRule = reduceResults(
         groupDataByField(resultGroup, 'properties.lintRuleId')
       ).sort((a, b) => (b.occurrenceCount || 0) - (a.occurrenceCount || 0));
       let totalCount = sumOccurrences(groupedTaskResultsByLintRule);
       if (totalCount) {
-        formatArgs.writer.subHeader(
+        args.writer.subHeader(
           `${groupedTaskResultsByLintRule[0].properties?.type}s: (${totalCount})`
         );
-        formatArgs.writer.valuesList(
+        args.writer.valuesList(
           groupedTaskResultsByLintRule.map((result) => {
             return result.message.text === NO_RESULTS_FOUND
               ? renderEmptyResult(result)
@@ -34,7 +34,7 @@ export function renderLintingSummaryResult(taskResults: Result[], formatArgs: Fo
                 };
           })
         );
-        formatArgs.writer.blankLine();
+        args.writer.blankLine();
       }
     });
   });

--- a/packages/test-helpers/src/checkup-fixturify-project.ts
+++ b/packages/test-helpers/src/checkup-fixturify-project.ts
@@ -1,11 +1,13 @@
 'use strict';
 
-import { join, resolve } from 'path';
+import { join, resolve, dirname } from 'path';
 import { execSync } from 'child_process';
 import { CheckupConfig, mergeConfig, FilePathArray } from '@checkup/core';
+import * as fixturify from 'fixturify';
 import Project from 'fixturify-project';
 import stringify from 'json-stable-stringify';
 import type { PackageJson } from 'type-fest';
+import { symlinkSync, mkdirpSync } from 'fs-extra';
 
 const walkSync = require('walk-sync');
 
@@ -29,10 +31,21 @@ export default class CheckupFixturifyProject extends Project {
     });
   }
 
+  write(dirJSON: fixturify.DirJSON) {
+    Object.assign(this.files, dirJSON);
+    this.writeSync();
+  }
+
   writeSync() {
     super.writeSync(...arguments);
     this._hasWritten = true;
   }
+
+  symlinkPackage(source: string, target: string) {
+    mkdirpSync(dirname(target));
+    symlinkSync(source, target);
+  }
+
   /**
    * Add a checkup config file to the project
    *


### PR DESCRIPTION
Allows the ability to specify custom formatters.

Using a relative path:

```sh
checkup run . --format ./my-custom-formatter.js
```

Using an external module:

```sh
checkup run . --format checkup-formatter-custom
```