### PR TITLE
Adding support to pass in a config inline to checkup

### DIFF
--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -62,7 +62,8 @@ describe('cli-test', () => {
             --help           Show help  [boolean]
             --version        Show version number  [boolean]
         -e, --exclude-paths  Paths to exclude from checkup. If paths are provided via command line and via checkup config, command line paths will be used.  [array]
-        -c, --config         Use this configuration, overriding .checkuprc if present.
+        -c, --config-path    Use the configuration found at this path, overriding .checkuprc if present.
+            --config         Use this configuration, overriding .checkuprc if present.
         -d, --cwd            The path referring to the root directory that Checkup will run in  [default: (default)]
             --category       Runs specific tasks specified by category. Can be used multiple times.  [array]
             --group          Runs specific tasks specified by group. Can be used multiple times.  [array]
@@ -709,7 +710,7 @@ describe('cli-test', () => {
     let result = await run([
       'run',
       '.',
-      '--config',
+      '--config-path',
       join(anotherProject.baseDir, '.checkuprc'),
       '--format',
       'pretty',

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -62,7 +62,7 @@ describe('cli-test', () => {
             --help           Show help  [boolean]
             --version        Show version number  [boolean]
         -e, --exclude-paths  Paths to exclude from checkup. If paths are provided via command line and via checkup config, command line paths will be used.  [array]
-        -c, --config-path    Use the configuration found at this path, overriding .checkuprc if present.
+        -c, --config-path    Use the configuration found at this path, overriding .checkuprc if present.  [default: \\".checkuprc\\"]
             --config         Use this configuration, overriding .checkuprc if present.
         -d, --cwd            The path referring to the root directory that Checkup will run in  [default: (default)]
             --category       Runs specific tasks specified by category. Can be used multiple times.  [array]

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -170,8 +170,9 @@ export default class CheckupTaskRunner {
 
     try {
       configPath =
-        (await getConfigPathFromOptions(this.options.config)) || getConfigPath(this.options.cwd);
-      this.config = readConfig(configPath);
+        (await getConfigPathFromOptions(this.options.configPath)) ||
+        getConfigPath(this.options.cwd);
+      this.config = this.options.config || readConfig(configPath);
     } catch (error) {
       if (error instanceof CheckupError) {
         throw error;

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -5,7 +5,6 @@ import {
   FilePathArray,
   getRegisteredActions,
   getConfigPathFromOptions,
-  getConfigPath,
   getFilePathsAsync,
   readConfig,
   RunOptions,
@@ -166,12 +165,8 @@ export default class CheckupTaskRunner {
   }
 
   private async loadConfig() {
-    let configPath;
-
     try {
-      configPath =
-        (await getConfigPathFromOptions(this.options.configPath)) ||
-        getConfigPath(this.options.cwd);
+      let configPath = await getConfigPathFromOptions(this.options.configPath, this.options.cwd);
       this.config = this.options.config || readConfig(configPath);
     } catch (error) {
       if (error instanceof CheckupError) {

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -36,6 +36,7 @@ checkup <command> [options]`
             alias: 'c',
             description:
               'Use the configuration found at this path, overriding .checkuprc if present.',
+            default: '.checkuprc',
           },
 
           config: {

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -1,6 +1,6 @@
 import * as yargs from 'yargs';
 import * as ora from 'ora';
-import { OutputFormat, ConsoleWriter } from '@checkup/core';
+import { OutputFormat, ConsoleWriter, CheckupConfig } from '@checkup/core';
 
 import CheckupTaskRunner from './api/checkup-task-runner';
 import Generator from './api/generator';
@@ -32,8 +32,13 @@ checkup <command> [options]`
             array: true,
           },
 
-          config: {
+          'config-path': {
             alias: 'c',
+            description:
+              'Use the configuration found at this path, overriding .checkuprc if present.',
+          },
+
+          config: {
             description: 'Use this configuration, overriding .checkuprc if present.',
           },
 
@@ -92,7 +97,8 @@ checkup <command> [options]`
         let taskRunner = new CheckupTaskRunner({
           paths: paths as string[],
           excludePaths: argv.excludePaths as string[],
-          config: argv.config as string,
+          config: argv.config as CheckupConfig,
+          configPath: argv.configPath as string,
           cwd: argv.cwd as string,
           categories: argv.category as string[],
           groups: argv.group as string[],

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -26,13 +26,13 @@ export const DEFAULT_CONFIG: CheckupConfig = {
   tasks: {},
 };
 
-export function getConfigPath(path: string = '') {
-  return join(resolve(path), '.checkuprc');
+export function getConfigPath(cwd: string = '', configPath: string = '.checkuprc') {
+  return join(resolve(cwd), configPath);
 }
 
-export async function getConfigPathFromOptions(configPath: string | undefined) {
+export async function getConfigPathFromOptions(configPath: string | undefined, cwd: string = '') {
   if (!configPath) {
-    return;
+    return '';
   }
 
   if (configPath.startsWith('http')) {
@@ -43,7 +43,7 @@ export async function getConfigPathFromOptions(configPath: string | undefined) {
 
     return filePath.name;
   } else {
-    configPath;
+    return getConfigPath(cwd, configPath);
   }
 }
 
@@ -59,7 +59,7 @@ export function readConfig(configPath: string) {
   debug(`Reading config from ${configPath}`);
 
   try {
-    config = readJsonSync(resolve(configPath || getConfigPath()));
+    config = readJsonSync(resolve(configPath));
   } catch (error) {
     if (error instanceof SyntaxError) {
       let hint = error.message.replace(/.*:\s(.*)/, '$1');

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -8,10 +8,12 @@ import {
   OutputFormat,
 } from './tasks';
 import { ParserName, CreateParser, ParserOptions, Parser, ParserReport } from './parsers';
+import { CheckupConfig } from './config';
 
 export type RunOptions = {
   cwd: string;
-  config?: string;
+  config?: CheckupConfig;
+  configPath?: string;
   categories?: string[];
   excludePaths?: string[];
   groups?: string[];


### PR DESCRIPTION
Renamed `config` param to `config-path`; `config` param now accepts an inline config.