### PR TITLE
Making paths an optional param in RunOptions, defaulting to `.`

### DIFF
--- a/packages/cli/__tests__/checkup-task-runner-test.ts
+++ b/packages/cli/__tests__/checkup-task-runner-test.ts
@@ -53,19 +53,16 @@ describe('checkup-task-runner', () => {
 
   it('can instantiate with options', () => {
     let taskRunner = new CheckupTaskRunner({
-      paths: [],
       cwd: '.',
     });
 
     expect(taskRunner.options).toEqual({
-      paths: [],
       cwd: '.',
     });
   });
 
   it('can return a default SARIF file when no plugins are loaded', async () => {
     let taskRunner = new CheckupTaskRunner({
-      paths: [],
       cwd: project.baseDir,
     });
 
@@ -74,7 +71,6 @@ describe('checkup-task-runner', () => {
 
   it('can execute configured tasks', async () => {
     let taskRunner = new CheckupTaskRunner({
-      paths: ['.'],
       cwd: project.baseDir,
     });
 

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -195,7 +195,7 @@ export default class CheckupTaskRunner {
       config: this.config,
       pkg: getPackageJson(this.options.cwd),
       paths: FilePathArray.from(
-        await getFilePathsAsync(this.options.cwd, this.options.paths, excludePaths)
+        await getFilePathsAsync(this.options.cwd, this.options.paths || ['.'], excludePaths)
       ) as FilePathArray,
     });
 

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -90,7 +90,7 @@ checkup <command> [options]`
         let paths = argv._.slice(1);
 
         let taskRunner = new CheckupTaskRunner({
-          paths: paths || ['.'],
+          paths: paths as string[],
           excludePaths: argv.excludePaths as string[],
           config: argv.config as string,
           cwd: argv.cwd as string,

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -90,7 +90,7 @@ checkup <command> [options]`
         let paths = argv._.slice(1);
 
         let taskRunner = new CheckupTaskRunner({
-          paths: paths || '.',
+          paths: paths || ['.'],
           excludePaths: argv.excludePaths as string[],
           config: argv.config as string,
           cwd: argv.cwd as string,

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -90,7 +90,7 @@ checkup <command> [options]`
         let paths = argv._.slice(1);
 
         let taskRunner = new CheckupTaskRunner({
-          paths,
+          paths: paths || '.',
           excludePaths: argv.excludePaths as string[],
           config: argv.config as string,
           cwd: argv.cwd as string,

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -9,7 +9,7 @@ export type RunOptions = {
   excludePaths?: string[];
   groups?: string[];
   listTasks?: boolean;
-  paths: string[];
+  paths?: string[];
   tasks?: string[];
 };
 


### PR DESCRIPTION
Giving paths a default value in RunOptions, used by CheckupTaskRunner