### PR TITLE
Fixing bug in config code

### DIFF
--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -4,7 +4,7 @@ import {
   CheckupConfig,
   FilePathArray,
   getRegisteredActions,
-  getConfigPathFromOptions,
+  getConfigPath,
   getFilePathsAsync,
   readConfig,
   RunOptions,
@@ -166,7 +166,7 @@ export default class CheckupTaskRunner {
 
   private async loadConfig() {
     try {
-      let configPath = await getConfigPathFromOptions(this.options.configPath, this.options.cwd);
+      let configPath = await getConfigPath(this.options.configPath, this.options.cwd);
       this.config = this.options.config || readConfig(configPath);
     } catch (error) {
       if (error instanceof CheckupError) {

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -2,11 +2,11 @@ import fetch from 'node-fetch';
 import { readJsonSync, writeJsonSync, writeFileSync } from 'fs-extra';
 import { createTmpDir } from '@checkup/test-helpers';
 import {
-  getConfigPath,
+  resolveConfigPath,
   readConfig,
   writeConfig,
   parseConfigTuple,
-  getConfigPathFromOptions,
+  getConfigPath,
   CONFIG_SCHEMA_URL,
   DEFAULT_CONFIG,
 } from '../src/config';
@@ -31,7 +31,7 @@ describe('config', () => {
     });
 
     it('throws if config format is invalid', () => {
-      let configPath = getConfigPath(tmp);
+      let configPath = resolveConfigPath(tmp);
       writeJsonSync(configPath, {
         plugins: [],
         task: {},
@@ -43,7 +43,7 @@ describe('config', () => {
     });
 
     it('throws if JSON is invalid', () => {
-      let configPath = getConfigPath(tmp);
+      let configPath = resolveConfigPath(tmp);
       writeFileSync(
         configPath,
         `{
@@ -60,7 +60,7 @@ describe('config', () => {
     });
 
     it('throws if invalid paths are passed in via config', () => {
-      let configPath = getConfigPath(tmp);
+      let configPath = resolveConfigPath(tmp);
       writeJsonSync(configPath, {
         plugins: [],
         tasks: {},
@@ -80,12 +80,19 @@ describe('config', () => {
     });
 
     it('can load a config from an HTTP endpoint', async () => {
-      let configPath = await getConfigPathFromOptions(
+      let configPath = await getConfigPath(
         'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/__tests__/__fixtures__/.checkuprc.json'
       );
       let config = readConfig(configPath!);
 
       expect(config).toEqual(REMOTE_CONFIG);
+    });
+
+    it('returns default config path if it is not defined', async () => {
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      let configPath = await getConfigPath(undefined);
+
+      expect(configPath).toBe(`${process.cwd()}/.checkuprc`);
     });
 
     it('throws if config with invalid task config string value set invalid string', () => {

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -89,10 +89,9 @@ describe('config', () => {
     });
 
     it('returns default config path if it is not defined', async () => {
-      // eslint-disable-next-line unicorn/no-useless-undefined
-      let configPath = await getConfigPath(undefined);
+      let configPath = await getConfigPath(undefined, tmp);
 
-      expect(configPath).toBe(`${process.cwd()}/.checkuprc`);
+      expect(configPath).toBe(`${tmp}/.checkuprc`);
     });
 
     it('throws if config with invalid task config string value set invalid string', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -26,16 +26,12 @@ export const DEFAULT_CONFIG: CheckupConfig = {
   tasks: {},
 };
 
-export function getConfigPath(cwd: string = '', configPath: string = '.checkuprc') {
+export function resolveConfigPath(cwd: string = '', configPath: string = '.checkuprc') {
   return join(resolve(cwd), configPath);
 }
 
-export async function getConfigPathFromOptions(configPath: string | undefined, cwd: string = '') {
-  if (!configPath) {
-    return '';
-  }
-
-  if (configPath.startsWith('http')) {
+export async function getConfigPath(configPath: string | undefined, cwd: string = '') {
+  if (configPath && configPath.startsWith('http')) {
     const contents = await downloadFile(configPath);
     const filePath = tmp.fileSync();
 
@@ -43,7 +39,7 @@ export async function getConfigPathFromOptions(configPath: string | undefined, c
 
     return filePath.name;
   } else {
-    return getConfigPath(cwd, configPath);
+    return resolveConfigPath(cwd, configPath);
   }
 }
 
@@ -88,7 +84,7 @@ export function mergeConfig(config: Partial<CheckupConfig>) {
 }
 
 export function writeConfig(dir: string, config: Partial<CheckupConfig> = {}) {
-  let path = getConfigPath(dir);
+  let path = resolveConfigPath(dir);
 
   if (existsSync(path)) {
     throw new CheckupError(ErrorKind.ConfigFileExists, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,8 +12,8 @@ export {
 export {
   readConfig,
   writeConfig,
+  resolveConfigPath,
   getConfigPath,
-  getConfigPathFromOptions,
   mergeConfig,
   parseConfigTuple,
   DEFAULT_CONFIG,


### PR DESCRIPTION
There was a bug introduced in the previous change to support inline configs that broke checkup finding a config at root/.checkuprc by default. This fixes that, and cleans up some of the naming to be more straightforward