### PR TITLE
Adding option to specify a pluginBaseDir directory

### DIFF
--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -28,7 +28,7 @@ describe('cli-test', () => {
 
   afterEach(function () {
     process.chdir(ROOT);
-    project.dispose();
+    // project.dispose();
   });
 
   it('outputs top level help', async () => {
@@ -872,7 +872,6 @@ describe('cli-test', () => {
       actualPluginDir
     );
     newProject.writeSync();
-    newProject.gitInit();
 
     project.addCheckupConfig({
       $schema:
@@ -885,6 +884,7 @@ describe('cli-test', () => {
 
     let result = await run(['run', '.', '--plugin-base-dir', newProject.baseDir]);
     expect(result.exitCode).toEqual(0);
+    expect(result.stdout).toMatch('✔ foo');
   });
 
   function run(args: string[], options: execa.Options = {}) {

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -28,7 +28,7 @@ describe('cli-test', () => {
 
   afterEach(function () {
     process.chdir(ROOT);
-    // project.dispose();
+    project.dispose();
   });
 
   it('outputs top level help', async () => {

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -59,18 +59,19 @@ describe('cli-test', () => {
       "checkup run [paths..] [options]
 
       Options:
-            --help           Show help  [boolean]
-            --version        Show version number  [boolean]
-        -e, --exclude-paths  Paths to exclude from checkup. If paths are provided via command line and via checkup config, command line paths will be used.  [array]
-        -c, --config-path    Use the configuration found at this path, overriding .checkuprc if present.  [default: \\".checkuprc\\"]
-            --config         Use this configuration, overriding .checkuprc if present.
-        -d, --cwd            The path referring to the root directory that Checkup will run in  [default: (default)]
-            --category       Runs specific tasks specified by category. Can be used multiple times.  [array]
-            --group          Runs specific tasks specified by group. Can be used multiple times.  [array]
-        -t, --task           Runs specific tasks specified by the fully qualified task name in the format pluginName/taskName. Can be used multiple times.  [array]
-        -f, --format         The output format, one of summary, json, pretty  [default: \\"summary\\"]
-        -o, --output-file    Specify file to write JSON output to.  [default: \\"\\"]
-        -l, --list-tasks     List all available tasks to run.  [boolean]"
+            --help             Show help  [boolean]
+            --version          Show version number  [boolean]
+        -e, --exclude-paths    Paths to exclude from checkup. If paths are provided via command line and via checkup config, command line paths will be used.  [array]
+        -c, --config-path      Use the configuration found at this path, overriding .checkuprc if present.  [default: \\".checkuprc\\"]
+            --config           Use this configuration, overriding .checkuprc if present.
+        -d, --cwd              The path referring to the root directory that Checkup will run in  [default: (default)]
+            --category         Runs specific tasks specified by category. Can be used multiple times.  [array]
+            --group            Runs specific tasks specified by group. Can be used multiple times.  [array]
+        -t, --task             Runs specific tasks specified by the fully qualified task name in the format pluginName/taskName. Can be used multiple times.  [array]
+        -f, --format           The output format, one of summary, json, pretty  [default: \\"summary\\"]
+        -o, --output-file      Specify file to write JSON output to.  [default: \\"\\"]
+        -l, --list-tasks       List all available tasks to run.  [boolean]
+        -p, --plugin-base-dir  The base directory where Checkup will load the plugins from. Defaults to cwd."
     `);
   });
 
@@ -854,6 +855,36 @@ describe('cli-test', () => {
 
     expect(result.exitCode).toEqual(1);
     expect(result.stderr).toContain('Cannot find the foo task.');
+  });
+
+  it('can load plugins from pluginBaseDir, if provided', async () => {
+    let newProject = new FakeProject('random-app', '0.0.0', () => {});
+    newProject.files['index.js'] = 'module.exports = {};';
+    newProject.files['index.hbs'] = '<div>Random App</div>';
+    newProject.chdir();
+    let actualPluginDir = await newProject.addPlugin(
+      { name: 'fake', defaults: false },
+      { typescript: false }
+    );
+    await newProject.addTask(
+      { name: 'foo', defaults: false },
+      { typescript: false, category: 'best practices', group: 'none' },
+      actualPluginDir
+    );
+    newProject.writeSync();
+    newProject.gitInit();
+
+    project.addCheckupConfig({
+      $schema:
+        'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json',
+      excludePaths: [],
+      plugins: ['checkup-plugin-fake'],
+      tasks: {},
+    });
+    project.chdir();
+
+    let result = await run(['run', '.', '--plugin-base-dir', newProject.baseDir]);
+    expect(result.exitCode).toEqual(0);
   });
 
   function run(args: string[], options: execa.Options = {}) {

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -207,7 +207,7 @@ export default class CheckupTaskRunner {
   }
 
   private async loadFromPlugin(registrationArgs: RegistrationArgs) {
-    let pluginsLocation = this.options.pluginBaseDir || this.options.cwd;
+    let pluginBaseDir = this.options.pluginBaseDir || this.options.cwd;
 
     for (let pluginName of this.config.plugins) {
       this.debug('Loading plugin from %s', pluginName);

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -207,10 +207,12 @@ export default class CheckupTaskRunner {
   }
 
   private async loadFromPlugin(registrationArgs: RegistrationArgs) {
+    let pluginsLocation = this.options.pluginBaseDir || this.options.cwd;
+
     for (let pluginName of this.config.plugins) {
       this.debug('Loading plugin from %s', pluginName);
 
-      let { register } = require(resolve.sync(pluginName, { basedir: this.options.cwd }));
+      let { register } = require(resolve.sync(pluginName, { basedir: pluginsLocation }));
 
       await register(registrationArgs);
     }

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -212,7 +212,7 @@ export default class CheckupTaskRunner {
     for (let pluginName of this.config.plugins) {
       this.debug('Loading plugin from %s', pluginName);
 
-      let { register } = require(resolve.sync(pluginName, { basedir: pluginsLocation }));
+      let { register } = require(resolve.sync(pluginName, { basedir: pluginBaseDir }));
 
       await register(registrationArgs);
     }

--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -90,6 +90,12 @@ checkup <command> [options]`
             description: 'List all available tasks to run.',
             boolean: true,
           },
+
+          'plugin-base-dir': {
+            alias: 'p',
+            description:
+              'The base directory where Checkup will load the plugins from. Defaults to cwd.',
+          },
         });
       },
       handler: async (argv: yargs.Arguments) => {
@@ -104,6 +110,7 @@ checkup <command> [options]`
           categories: argv.category as string[],
           groups: argv.group as string[],
           tasks: argv.task as string[],
+          pluginBaseDir: argv['plugin-base-dir'] as string,
         });
 
         if (!paths || paths.length === 0) {

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -20,6 +20,7 @@ export type RunOptions = {
   listTasks?: boolean;
   paths?: string[];
   tasks?: string[];
+  pluginBaseDir?: string;
 };
 
 export interface RegistrationArgs {


### PR DESCRIPTION
We currently use the cwd prop used as "where do i look for the code to run checkup on" and "where should checkup look for the source code for the plugins". 

This PR adds in a new option to specify a directory for the latter, which is useful for running checkup via node api in a script run in the context of other repos. 