### PR TITLE
Part 1: Ensure results adhere to SARIF specifications

### DIFF
--- a/packages/checkup-plugin-ember/package.json
+++ b/packages/checkup-plugin-ember/package.json
@@ -5,6 +5,9 @@
   "author": "Steve Calvert @scalvert",
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
+    "@babel/parser": "^7.14.2",
+    "@babel/traverse": "^7.14.2",
+    "@babel/types": "7.13.17",
     "@checkup/core": "^1.0.0-beta.10",
     "babel-eslint": "^10.1.0",
     "debug": "^4.3.1",

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { BaseTask, Task, AstTraverser, ErrorKind } from '@checkup/core';
+import { BaseTask, Task, AstTraverser } from '@checkup/core';
 import { File, Node } from '@babel/types';
 import * as parser from '@babel/parser';
 import traverse, { TraverseOptions } from '@babel/traverse';
@@ -27,7 +27,7 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
       return {
         ruleId: this.taskName,
         message: {
-          text: `Ember dependency result for ${dependency.packageName}`,
+          text: `Ember dependency information for ${dependency.packageName}`,
         },
         kind: 'review',
         level: 'note',
@@ -44,6 +44,11 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
             },
           },
         ],
+        properties: {
+          packageName: dependency.packageName,
+          version: dependency.version,
+          type: dependency.type,
+        },
       };
     });
   }

--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -1,8 +1,5 @@
 import { join } from 'path';
-import { BaseTask, Task, AstTraverser } from '@checkup/core';
-import { File, Node } from '@babel/types';
-import * as parser from '@babel/parser';
-import traverse, { TraverseOptions } from '@babel/traverse';
+import { BaseTask, Task, JsonTraverser } from '@checkup/core';
 import { Result } from 'sarif';
 
 type Dependency = {
@@ -54,7 +51,6 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
   }
 
   getDependencies() {
-    let packageJsonContents = `module.exports = ${this.context.pkgSource}`;
     class DependenciesAccumulator {
       dependencies: Set<Dependency>;
 
@@ -97,13 +93,9 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
         };
       }
     }
+
     let dependencyAccumulator = new DependenciesAccumulator();
-    let astTraverser = new AstTraverser<
-      File,
-      TraverseOptions<Node>,
-      typeof parser.parse,
-      typeof traverse
-    >(packageJsonContents, parser.parse, traverse);
+    let astTraverser = new JsonTraverser(this.context.pkgSource);
 
     astTraverser.traverse(dependencyAccumulator.visitors);
 

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -30,7 +30,7 @@ import { Log, Result } from 'sarif';
 
 import { getLog } from '../get-log';
 import TaskListImpl from '../task-list';
-import { getPackageJson } from '../utils/get-package-json';
+import { getPackageJson, getPackageJsonSource } from '../utils/get-package-json';
 import PluginRegistrationProvider from './registration-provider';
 export default class CheckupTaskRunner {
   actions: Action[] = [];
@@ -190,6 +190,7 @@ export default class CheckupTaskRunner {
       parsers: this.registeredParsers,
       config: this.config,
       pkg: getPackageJson(this.options.cwd),
+      pkgSource: getPackageJsonSource(this.options.cwd),
       paths: FilePathArray.from(
         await getFilePathsAsync(this.options.cwd, this.options.paths || ['.'], excludePaths)
       ) as FilePathArray,

--- a/packages/cli/src/utils/get-package-json.ts
+++ b/packages/cli/src/utils/get-package-json.ts
@@ -1,25 +1,29 @@
 import { resolve, join } from 'path';
-import { readJsonSync } from 'fs-extra';
+import { readFileSync } from 'fs-extra';
 import { PackageJson } from 'type-fest';
 
-/**
- * @param basePath
- */
-export function getPackageJson(basePath: string, pathName: string = 'package.json'): PackageJson {
-  let package_ = {};
-  let packageJsonPath = join(resolve(basePath), pathName);
+export function getPackageJsonSource(baseDir: string, pathName: string = 'package.json'): string {
+  let source: string = '';
+  let packageJsonPath = join(resolve(baseDir), pathName);
 
   try {
-    package_ = readJsonSync(packageJsonPath);
+    source = readFileSync(packageJsonPath, { encoding: 'utf-8' });
   } catch (error) {
     if (error.code === 'ENOENT') {
       throw new Error(
         `The ${resolve(
-          basePath
-        )} directory found through the 'path' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`
+          baseDir
+        )} directory found through the 'cwd' option does not contain a package.json file. You must run checkup in a directory with a package.json file.`
       );
     }
   }
 
-  return package_;
+  return source;
+}
+
+/**
+ * @param baseDir
+ */
+export function getPackageJson(baseDir: string, pathName: string = 'package.json'): PackageJson {
+  return JSON.parse(getPackageJsonSource(baseDir, pathName));
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "author": "Steve Calvert <steve.calvert@gmail.com>",
   "bugs": "https://github.com/checkupjs/checkup/issues",
   "dependencies": {
+    "@babel/parser": "^7.14.2",
     "@types/micromatch": "^4.0.1",
     "@types/sarif": "^2.1.3",
     "ajv": "^6.12.6",

--- a/packages/core/src/ast/ast-transformer.ts
+++ b/packages/core/src/ast/ast-transformer.ts
@@ -1,5 +1,5 @@
 import * as recast from 'recast';
-import * as t from '@babel/types';
+import { File } from '@babel/types';
 import traverse, { TraverseOptions } from '@babel/traverse';
 
 import AstTraverser from './ast-traverser';
@@ -17,7 +17,7 @@ type BabelTraverse = typeof traverse;
  *              .generate();
  */
 export default class AstTransformer extends AstTraverser<
-  t.File,
+  File,
   TraverseOptions,
   RecastParse,
   BabelTraverse

--- a/packages/core/src/ast/babel-traverser.ts
+++ b/packages/core/src/ast/babel-traverser.ts
@@ -1,0 +1,15 @@
+import { File, Node } from '@babel/types';
+import * as parser from '@babel/parser';
+import traverse, { TraverseOptions } from '@babel/traverse';
+import AstTraverser from './ast-traverser';
+
+export default class BabelTraverser extends AstTraverser<
+  File,
+  TraverseOptions<Node>,
+  typeof parser.parse,
+  typeof traverse
+> {
+  constructor(source: string) {
+    super(source, parser.parse, traverse);
+  }
+}

--- a/packages/core/src/ast/json-traverser.ts
+++ b/packages/core/src/ast/json-traverser.ts
@@ -1,0 +1,19 @@
+import { File, Node } from '@babel/types';
+import * as parser from '@babel/parser';
+import traverse, { TraverseOptions } from '@babel/traverse';
+import AstTraverser from './ast-traverser';
+
+export default class JsonTraverser extends AstTraverser<
+  File,
+  TraverseOptions<Node>,
+  typeof parser.parse,
+  typeof traverse
+> {
+  constructor(source: string) {
+    // In order to process JSON, we need to convert it to a module,
+    // as babel cannot parse JSON natively.
+    let jsonSource = `module.exports = ${source}`;
+
+    super(jsonSource, parser.parse, traverse);
+  }
+}

--- a/packages/core/src/ast/json-traverser.ts
+++ b/packages/core/src/ast/json-traverser.ts
@@ -1,19 +1,11 @@
-import { File, Node } from '@babel/types';
-import * as parser from '@babel/parser';
-import traverse, { TraverseOptions } from '@babel/traverse';
-import AstTraverser from './ast-traverser';
+import BabelTraverser from './babel-traverser';
 
-export default class JsonTraverser extends AstTraverser<
-  File,
-  TraverseOptions<Node>,
-  typeof parser.parse,
-  typeof traverse
-> {
+export default class JsonTraverser extends BabelTraverser {
   constructor(source: string) {
     // In order to process JSON, we need to convert it to a module,
     // as babel cannot parse JSON natively.
     let jsonSource = `module.exports = ${source}`;
 
-    super(jsonSource, parser.parse, traverse);
+    super(jsonSource);
   }
 }

--- a/packages/core/src/ast/typescript-traverser.ts
+++ b/packages/core/src/ast/typescript-traverser.ts
@@ -1,0 +1,18 @@
+import * as recast from 'recast';
+import { File } from '@babel/types';
+import traverse, { TraverseOptions } from '@babel/traverse';
+
+import AstTraverser from './ast-traverser';
+
+export default class TypeScriptTraverser extends AstTraverser<
+  File,
+  TraverseOptions,
+  typeof recast.parse,
+  typeof traverse
+> {
+  constructor(source: string) {
+    super(source, recast.parse, traverse, {
+      parser: require('recast/parsers/typescript'),
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export { default as CheckupError } from './errors/checkup-error';
 export { default as TaskError } from './errors/task-error';
 
 export { default as AstTraverser } from './ast/ast-traverser';
+export { default as JsonTraverser } from './ast/json-traverser';
 export { default as AstTransformer } from './ast/ast-transformer';
 
 export { getPluginName, normalizePackageName, getShorthandName } from './utils/plugin-name';

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -58,6 +58,7 @@ export interface TaskContext {
   readonly parsers: Map<ParserName, CreateParser<ParserOptions, Parser<ParserReport>>>;
   readonly config: CheckupConfig;
   readonly pkg: PackageJson;
+  readonly pkgSource: string;
   readonly paths: FilePathArray;
 }
 

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -69,6 +69,8 @@ export function getTaskContext({
     parsers: getRegisteredParsers(),
     config: Object.assign({}, DEFAULT_CONFIG, config),
     pkg: pkg,
+    // eslint-disable-next-line unicorn/no-null
+    pkgSource: JSON.stringify(pkg, null, 2),
     paths: paths,
   };
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -7,7 +7,7 @@
     "importHelpers": true,
     "module": "commonjs",
     "strict": true,
-    "target": "es2017",
+    "target": "es2019",
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,10 +8893,30 @@ type-detect@4.0.8, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.11.0, type-fest@^0.20.2, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.0.2:
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.1.tgz#210251e7f57357a1457269e6b34837fed067ac2c"
+  integrity sha512-RPDKc5KrIyKTP7Fk75LruUagqG6b+OTgXlCR2Z0aQDJFeIvL4/mhahSEtHmmVzXu4gmA0srkF/8FCH3WOWxTWA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.2.tgz#d5773e8b557d421fd6ce0d5efa5fd7fc22567c30"
+  integrity sha512-OnADYbKrffDVai5qcpkMxQ7caomHOoEwjkouqnN2QhydAjowFAZcsdecFIRUBdb+ZcruwYE4ythYmF1UBZU5xQ==
+  dependencies:
+    "@babel/types" "^7.14.2"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-compilation-targets@^7.13.13":
   version "7.13.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz#2b2972a0926474853f41e4adbc69338f520600e5"
@@ -93,6 +102,15 @@
     "@babel/helper-get-function-arity" "^7.12.13"
     "@babel/template" "^7.12.13"
     "@babel/types" "^7.12.13"
+
+"@babel/helper-function-name@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz#397688b590760b6ef7725b5f0860c82427ebaac2"
+  integrity sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.12.13"
+    "@babel/template" "^7.12.13"
+    "@babel/types" "^7.14.2"
 
 "@babel/helper-get-function-arity@^7.12.13":
   version "7.12.13"
@@ -222,6 +240,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
+
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
@@ -258,6 +281,11 @@
   version "7.13.16"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.16.tgz#0f18179b0448e6939b1f3f5c4c355a3a9bcdfd37"
   integrity sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==
+
+"@babel/parser@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.2.tgz#0c1680aa44ad4605b16cbdcc5c341a61bde9c746"
+  integrity sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -361,12 +389,34 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.2.tgz#9201a8d912723a831c2679c7ebbf2fe1416d765b"
+  integrity sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.14.2"
+    "@babel/helper-function-name" "^7.14.2"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.14.2"
+    "@babel/types" "^7.14.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@7.13.17", "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.13.16", "@babel/types@^7.13.17", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
   version "7.13.17"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.17.tgz#48010a115c9fba7588b4437dd68c9469012b38b4"
   integrity sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.2.tgz#4208ae003107ef8a057ea8333e56eb64d2f6a2c3"
+  integrity sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":


### PR DESCRIPTION
This PR looks to accomplish a number of things:

1. Updates the `ember-dependencies` task to return a single result per dependency rather than a single result with a `data` property in the `properties` bag
2. Updates the `ember-dependencies` task to include source information, specifically line and column data
3. Adds a number of AST classes (more information to follow)

Following PRs will do the following:

1. Align the `javascript/outdated-dependencies` task to use this same source information for individual dependencies
2. Update the `ember-dependencies` task to include version information to align it with the outdated dependencies (ideally both tasks will pull data from the same source - the ember task will filter on ember info, and the outdated deps will filter only those dependencies that are out of date)
3. Convert these AST classes and the eslint/ember-template-lint parsers into a new directory of `analyzers`. Analyzers will represent available tools that consumers can use to gather data. Some of the built-in analyzers will include:
    - EslintAnalyzer (currently eslint parser)
    - EmberTemplateLintAnalyzer (currently ember-template-lint parser)
    - StyleLintAnalyzer
    - JsonAnalyzer (used to analyze JSON files)
    - JavaScriptAnalyzer (used to analyze JavaScript files)
    - TypeScriptAnalyzer (used to analyze TypeScript files)

The intent of consolidating these types of analyzers together is to give consumers a clear set of ways to statically analyze their projects.
  