### PR TITLE
Part 2: Ensure results adhere to SARIF specifications

### DIFF
--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -2,13 +2,13 @@ import { join } from 'path';
 import { BaseTask, Task, JsonTraverser } from '@checkup/core';
 import { Result } from 'sarif';
 
-type Dependency = {
+interface Dependency {
   packageName: string;
   version: string;
   type: 'dependency' | 'devDependency';
   startLine: number;
   startColumn: number;
-};
+}
 
 export default class EmberDependenciesTask extends BaseTask implements Task {
   taskName = 'ember-dependencies';

--- a/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
@@ -44,7 +44,6 @@ describe('outdated-dependencies-task', () => {
   });
 
   it('returns correct action items if too many dependencies are out of date (and additional actions for minor/major out of date)', async () => {
-    debugger;
     let actions = evaluateActions(results, task.config);
 
     expect(actions).toHaveLength(3);

--- a/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
@@ -44,6 +44,7 @@ describe('outdated-dependencies-task', () => {
   });
 
   it('returns correct action items if too many dependencies are out of date (and additional actions for minor/major out of date)', async () => {
+    debugger;
     let actions = evaluateActions(results, task.config);
 
     expect(actions).toHaveLength(3);

--- a/packages/checkup-plugin-javascript/src/actions/outdated-dependency-actions.ts
+++ b/packages/checkup-plugin-javascript/src/actions/outdated-dependency-actions.ts
@@ -1,12 +1,12 @@
-import { ActionsEvaluator, toPercent, TaskConfig, sumOccurrences } from '@checkup/core';
+import { ActionsEvaluator, toPercent, TaskConfig } from '@checkup/core';
 import { Result } from 'sarif';
 
 export function evaluateActions(taskResults: Result[], taskConfig: TaskConfig) {
-  let totalDependencies = sumOccurrences(taskResults);
+  let totalDependencies = taskResults.length;
 
   let outdatedDependencies = {
-    major: sumOccurrences(taskResults.filter((taskResult) => taskResult.message.text === 'major')),
-    minor: sumOccurrences(taskResults.filter((taskResult) => taskResult.message.text === 'minor')),
+    major: taskResults.filter((taskResult) => taskResult.level === 'error').length,
+    minor: taskResults.filter((taskResult) => taskResult.level === 'warning').length,
   };
 
   let actionsEvaluator = new ActionsEvaluator();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,30 +8893,10 @@ type-detect@4.0.8, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
-  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
-
-type-fest@^0.20.2:
+type-fest@^0.11.0, type-fest@^0.20.2, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.0.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-fest@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.1.tgz#210251e7f57357a1457269e6b34837fed067ac2c"
-  integrity sha512-RPDKc5KrIyKTP7Fk75LruUagqG6b+OTgXlCR2Z0aQDJFeIvL4/mhahSEtHmmVzXu4gmA0srkF/8FCH3WOWxTWA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
Converts `outdated-dependencies` task to more standardized SARIF format. Additionally includes source information for SARIF log.