### PR TITLE
Allows for loading plugins from arbitrary directories using `--plugin-base-dir`

### DIFF
--- a/packages/cli/__tests__/__utils__/fake-project.ts
+++ b/packages/cli/__tests__/__utils__/fake-project.ts
@@ -7,15 +7,20 @@ import type { Answers } from 'inquirer';
 import { generatePlugin, generateTask } from './generator-utils';
 
 export class FakeProject extends CheckupProject {
-  async addPlugin(options: helpers.Dictionary<any> = {}, prompts: Answers = {}) {
-    let pluginDir = await generatePlugin(options, prompts, join(this.baseDir, 'node_modules'));
+  symlinkCorePackage(baseDir: string = this.baseDir) {
     let source = join(__dirname, '../../..', 'core');
-    let target = join(pluginDir, 'node_modules', '@checkup', 'core');
+    let target = join(baseDir, 'node_modules', '@checkup', 'core');
 
     // we create a self-referential link to the core package within the generated plugin. This
     // allows us to generate plugins, and test the APIs for the latest version of core that is
     // referenced via the plugins' node_modules.
     this.symlinkPackage(source, target);
+  }
+
+  async addPlugin(options: helpers.Dictionary<any> = {}, prompts: Answers = {}) {
+    let pluginDir = await generatePlugin(options, prompts, join(this.baseDir, 'node_modules'));
+
+    this.symlinkCorePackage(pluginDir);
 
     return pluginDir;
   }


### PR DESCRIPTION
Previously it was possible to load plugins from another directory that contained a `node_modules` directory. This would not allow you to load plugins from an arbitrary nested directory that didn't contain a `node_modules`. This change widens this functionality to allow for this use case.