### PR TITLE
Resolves type errors when building fresh master

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -18,7 +18,8 @@
       "checkup-plugin-ember": ["./packages/checkup-plugin-ember/lib/index.d.ts"],
       "checkup-plugin-javascript": ["./packages/checkup-plugin-javascript/lib/index.d.ts"],
       "*": ["./types/*"]
-    }
+    },
+    "typeRoots": ["node_modules/@types"]
   },
   "exclude": ["**/node_modules/**"]
 }


### PR DESCRIPTION
Building a fresh master resulted in a number of TS compilation errors.

```shell
$ yarn build
yarn run v1.22.4
$ tsc --build
node_modules/@types/eslint/helpers.d.ts:1:6 - error TS2300: Duplicate identifier 'Prepend'.

1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends ((
       ~~~~~~~

  ../node_modules/@types/eslint/helpers.d.ts:1:6
    1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends (..._: infer Result) => any
           ~~~~~~~
    'Prepend' was also declared here.

../node_modules/@types/eslint/helpers.d.ts:1:6 - error TS2300: Duplicate identifier 'Prepend'.

1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends (..._: infer Result) => any
       ~~~~~~~

  node_modules/@types/eslint/helpers.d.ts:1:6
    1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends ((
           ~~~~~~~
    'Prepend' was also declared here.

packages/plugin/src/generate-docs.ts:4:69 - error TS2307: Cannot find module '@checkup/core' or its corresponding type declarations.

4 import { getPluginName, getShorthandName, TypeScriptAnalyzer } from '@checkup/core';
                                                                      ~~~~~~~~~~~~~~~

packages/plugin/src/generate-docs.ts:50:30 - error TS7031: Binding element 'node' implicitly has an 'any' type.

50       AssignmentExpression({ node }) {
                                ~~~~

node_modules/@types/eslint/helpers.d.ts:1:6 - error TS2300: Duplicate identifier 'Prepend'.

1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends ((
       ~~~~~~~

  ../node_modules/@types/eslint/helpers.d.ts:1:6
    1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends (..._: infer Result) => any
           ~~~~~~~
    'Prepend' was also declared here.

../node_modules/@types/eslint/helpers.d.ts:1:6 - error TS2300: Duplicate identifier 'Prepend'.

1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends (..._: infer Result) => any
       ~~~~~~~

  node_modules/@types/eslint/helpers.d.ts:1:6
    1 type Prepend<Tuple extends any[], Addend> = ((_: Addend, ..._1: Tuple) => any) extends ((
           ~~~~~~~
    'Prepend' was also declared here.


Found 6 errors.
```

Adding `"typeRoots": ["node_modules/@types"]` to the tsconfig.json fixes this.