### PR TITLE
Fixes invalid syntax for type output

### DIFF
--- a/packages/core/src/analyzers/handlebars-analyzer.ts
+++ b/packages/core/src/analyzers/handlebars-analyzer.ts
@@ -6,7 +6,7 @@ import AstAnalyzer from './ast-analyzer';
  *
  * @export
  * @class HandlebarsAnalyzer
- * @extends {AstAnalyzer<AST.Template, NodeVisitor, typeof parse, typeof traverse>}
+ * @extends {AstAnalyzer}
  */
 export default class HandlebarsAnalyzer extends AstAnalyzer<
   AST.Template,

--- a/packages/core/src/analyzers/javascript-analyzer.ts
+++ b/packages/core/src/analyzers/javascript-analyzer.ts
@@ -8,7 +8,7 @@ import AstAnalyzer from './ast-analyzer';
  *
  * @export
  * @class JavaScriptAnalyzer
- * @extends {AstAnalyzer<File, TraverseOptions<Node>, typeof parser.parse, typeof traverse>}
+ * @extends {AstAnalyzer}
  */
 export default class JavaScriptAnalyzer extends AstAnalyzer<
   File,

--- a/packages/core/src/analyzers/typescript-analyzer.ts
+++ b/packages/core/src/analyzers/typescript-analyzer.ts
@@ -9,7 +9,7 @@ import AstAnalyzer from './ast-analyzer';
  *
  * @export
  * @class TypeScriptAnalyzer
- * @extends {AstAnalyzer<File, TraverseOptions, typeof recast.parse, typeof traverse>}
+ * @extends {AstAnalyzer}
  */
 export default class TypeScriptAnalyzer extends AstAnalyzer<
   File,


### PR DESCRIPTION
When auto-generating the documentation for `checkupjs.github.io`, the syntax fixed in this PR was causing errors to be thrown when converting from jsdoc to markdown. This PR removes the invalid syntax.