### PR TITLE
Fixes actions generator for JavaScript

### DIFF
--- a/packages/checkup-plugin-javascript/docs/tasks/lines-of-code-task.md
+++ b/packages/checkup-plugin-javascript/docs/tasks/lines-of-code-task.md
@@ -1,0 +1,15 @@
+<!--TASK_NAME_START-->
+# javascript/lines-of-code
+<!--TASK_NAME_END-->
+
+<!--TASK_DESCRIPTION_START-->
+Counts lines of code within a project
+<!--TASK_DESCRIPTION_END-->
+
+<!--RUN_START-->
+## To run this task
+
+```bash
+checkup run --task javascript/lines-of-code
+```
+<!--RUN_END-->

--- a/packages/cli/__tests__/generators/__snapshots__/generate-actions-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-actions-test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`actions generator generates correct files with JavaScript 1`] = `
-"import { ActionsEvaluator } from '@checkup/core';
+"const { ActionsEvaluator } = require('@checkup/core');
 
-export function evaluateActions(taskResult, taskConfig) {
+module.exports = function evaluateActions(taskResult, taskConfig) {
   let actionsEvaluator = new ActionsEvaluator();
 
   return actionsEvaluator.evaluate(taskConfig);

--- a/packages/cli/templates/src/actions/src/actions/actions.js.ejs
+++ b/packages/cli/templates/src/actions/src/actions/actions.js.ejs
@@ -1,6 +1,6 @@
-import { ActionsEvaluator } from '@checkup/core';
+const { ActionsEvaluator } = require('@checkup/core');
 
-export function evaluateActions(taskResult, taskConfig) {
+module.exports = function evaluateActions(taskResult, taskConfig) {
   let actionsEvaluator = new ActionsEvaluator();
 
   return actionsEvaluator.evaluate(taskConfig);


### PR DESCRIPTION
The actions generator for JS was outputting es6 module syntax, which would require the plugins to have a transpile step (which they don't have). This fix ensures they're inline with other JS output for generated code (plugins, tasks).