### PR TITLE
[bugfix] Fixing URI in LOC task

### DIFF
--- a/packages/checkup-plugin-javascript/__tests__/lines-of-code-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/lines-of-code-task-test.ts
@@ -30,54 +30,54 @@ describe('lines-of-code-task', () => {
     ).run();
 
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "kind": "informational",
-          "level": "note",
-          "locations": Array [
-            Object {
-              "physicalLocation": Object {
-                "artifactLocation": Object {
-                  "uri": "/index.hbs",
-                },
-              },
-            },
-          ],
-          "message": Object {
-            "text": "Lines of code count for /index.hbs - total lines: 1",
+Array [
+  Object {
+    "kind": "informational",
+    "level": "note",
+    "locations": Array [
+      Object {
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "uri": "index.hbs",
           },
-          "properties": Object {
-            "extension": "hbs",
-            "filePath": "/index.hbs",
-            "lines": 1,
-          },
-          "ruleId": "lines-of-code",
-          "ruleIndex": 0,
         },
-        Object {
-          "kind": "informational",
-          "level": "note",
-          "locations": Array [
-            Object {
-              "physicalLocation": Object {
-                "artifactLocation": Object {
-                  "uri": "/index.js",
-                },
-              },
-            },
-          ],
-          "message": Object {
-            "text": "Lines of code count for /index.js - total lines: 1",
+      },
+    ],
+    "message": Object {
+      "text": "Lines of code count for index.hbs - total lines: 1",
+    },
+    "properties": Object {
+      "extension": "hbs",
+      "filePath": "index.hbs",
+      "lines": 1,
+    },
+    "ruleId": "lines-of-code",
+    "ruleIndex": 0,
+  },
+  Object {
+    "kind": "informational",
+    "level": "note",
+    "locations": Array [
+      Object {
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "uri": "index.js",
           },
-          "properties": Object {
-            "extension": "js",
-            "filePath": "/index.js",
-            "lines": 1,
-          },
-          "ruleId": "lines-of-code",
-          "ruleIndex": 0,
         },
-      ]
-    `);
+      },
+    ],
+    "message": Object {
+      "text": "Lines of code count for index.js - total lines: 1",
+    },
+    "properties": Object {
+      "extension": "js",
+      "filePath": "index.js",
+      "lines": 1,
+    },
+    "ruleId": "lines-of-code",
+    "ruleIndex": 0,
+  },
+]
+`);
   });
 });

--- a/packages/checkup-plugin-javascript/src/tasks/lines-of-code-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/lines-of-code-task.ts
@@ -1,6 +1,6 @@
 import { extname } from 'path';
 import { promises as fs } from 'fs';
-import { BaseTask, Task } from '@checkup/core';
+import { BaseTask, Task, trimCwd } from '@checkup/core';
 import { Result } from 'sarif';
 const sloc = require('sloc');
 
@@ -72,7 +72,7 @@ export default class LinesOfCodeTask extends BaseTask implements Task {
           let extension = getExtension(filePath);
           let { total } = sloc(contents, extension);
           fileInfos.push({
-            filePath: filePath.replace(this.context.options.cwd, ''),
+            filePath: trimCwd(filePath, this.context.options.cwd),
             extension,
             lines: total,
           });


### PR DESCRIPTION
In the lines of code test, the cwd was not being trimmed properly, leading to filepaths like /foo.js as opposed to foo.js. This doesnt match the patterns of the other tasks, causing scripts that consume these results to not normalize them correctly