### PR TITLE
Add export to @checkup/cli for writeResultFile

### DIFF
--- a/packages/cli/src/checkup.ts
+++ b/packages/cli/src/checkup.ts
@@ -6,7 +6,7 @@ import CheckupTaskRunner from './api/checkup-task-runner';
 import Generator from './api/generator';
 import { getFormatter } from './formatters/get-formatter';
 import { reportAvailableTasks } from './formatters/available-tasks';
-import { writeResultFile } from './formatters/file-writer';
+import { writeResultsToFile } from './formatters/file-writer';
 
 interface CheckupArguments {
   [x: string]: unknown;
@@ -159,7 +159,7 @@ checkup <command> [options]`
 
           if (output) {
             if (options.outputFile) {
-              let resultFilePath = writeResultFile(log, options.cwd, options.outputFile);
+              let resultFilePath = writeResultsToFile(log, options.cwd, options.outputFile);
 
               console.log();
               console.log('Results have been saved to the following file:');

--- a/packages/cli/src/formatters/file-writer.ts
+++ b/packages/cli/src/formatters/file-writer.ts
@@ -7,6 +7,16 @@ const stripAnsi = require('strip-ansi');
 
 export const DEFAULT_OUTPUT_FILENAME = `checkup-report-${todayFormat()}`;
 
+/**
+ * A utility function to write results to an output file. If no `outputFile` is given,
+ * it uses a default output file name in the format "checkup-report-YYYY-MM-DD-HH_mm_ss".
+ * If result is a string the extension is .txt, otherwise .sarif is used.
+ *
+ * @param {(Log | string)} result - The result to be output, either a SARIF log or a string.
+ * @param {string} cwd - The current working directory to write to.
+ * @param {string} [outputFile=DEFAULT_OUTPUT_FILENAME] - The output filename format.
+ * @return {*}  {string}
+ */
 export function writeResultsToFile(
   result: Log | string,
   cwd: string,

--- a/packages/cli/src/formatters/file-writer.ts
+++ b/packages/cli/src/formatters/file-writer.ts
@@ -7,7 +7,7 @@ const stripAnsi = require('strip-ansi');
 
 export const DEFAULT_OUTPUT_FILENAME = `checkup-report-${todayFormat()}`;
 
-export function writeResultFile(
+export function writeResultsToFile(
   result: Log | string,
   cwd: string,
   outputFile: string = DEFAULT_OUTPUT_FILENAME

--- a/packages/cli/src/formatters/json.ts
+++ b/packages/cli/src/formatters/json.ts
@@ -1,7 +1,7 @@
 import { CheckupLogParser, ConsoleWriter, Formatter, FormatterOptions } from '@checkup/core';
 import { yellow } from 'chalk';
 import { Log } from 'sarif';
-import { writeResultFile } from './file-writer';
+import { writeResultsToFile } from './file-writer';
 
 export default class JsonFormatter implements Formatter {
   options: FormatterOptions;
@@ -18,7 +18,7 @@ export default class JsonFormatter implements Formatter {
   }
 
   writeResultsToFile(log: Log) {
-    let resultFilePath = writeResultFile(log, this.options.cwd, this.options.outputFile);
+    let resultFilePath = writeResultsToFile(log, this.options.cwd, this.options.outputFile);
 
     this.writer.blankLine();
     this.writer.log('Results have been saved to the following file:');

--- a/packages/cli/src/formatters/summary.ts
+++ b/packages/cli/src/formatters/summary.ts
@@ -2,7 +2,7 @@ import { BufferedWriter, CheckupLogParser, Formatter, FormatterOptions } from '@
 import { success } from 'log-symbols';
 import { yellow } from 'chalk';
 import { Log } from 'sarif';
-import { writeResultFile } from './file-writer';
+import { writeResultsToFile } from './file-writer';
 import BaseFormatter from './base-formatter';
 
 export default class SummaryFormatter extends BaseFormatter<BufferedWriter> implements Formatter {
@@ -34,7 +34,7 @@ export default class SummaryFormatter extends BaseFormatter<BufferedWriter> impl
   }
 
   writeResultsToFile(log: Log) {
-    let resultsFilePath = writeResultFile(log, this.options.cwd, this.options.outputFile);
+    let resultsFilePath = writeResultsToFile(log, this.options.cwd, this.options.outputFile);
 
     this.writer.blankLine();
     this.writer.log('Results have been saved to the following file:');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,3 @@
 export { default as CheckupTaskRunner } from './api/checkup-task-runner';
 export { getFormatter } from './formatters/get-formatter';
-export { writeResultFile } from './formatters/file-writer';
+export { writeResultsToFile } from './formatters/file-writer';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,3 @@
 export { default as CheckupTaskRunner } from './api/checkup-task-runner';
 export { getFormatter } from './formatters/get-formatter';
+export { writeResultFile } from './formatters/file-writer';

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -1,3 +1,4 @@
+import { Log } from 'sarif';
 import CheckupLogParser from '../data/checkup-log-parser';
 import {
   Task,
@@ -45,6 +46,7 @@ export interface RegisterableTaskList {
 
 export interface Formatter {
   format(logParser: CheckupLogParser): string;
+  writeResultsToFile?(log: Log): void;
 }
 
 export interface FormatterCtor {

--- a/packages/core/src/types/cli.ts
+++ b/packages/core/src/types/cli.ts
@@ -1,4 +1,3 @@
-import { Log } from 'sarif';
 import CheckupLogParser from '../data/checkup-log-parser';
 import {
   Task,
@@ -46,7 +45,6 @@ export interface RegisterableTaskList {
 
 export interface Formatter {
   format(logParser: CheckupLogParser): string;
-  writeResultsToFile?(log: Log): void;
 }
 
 export interface FormatterCtor {


### PR DESCRIPTION
This exports the writeResultFile from cli, and adds writeResultsToFile as an optional function on the Formatter interface, to expose it for formatters that populate it