### PR TITLE
Extracting rule metadata from addResult

### DIFF
--- a/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-dependencies-task.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { BaseTask, Task, DependencyAnalyzer } from '@checkup/core';
+import { BaseTask, Task, TaskContext, DependencyAnalyzer } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class EmberDependenciesTask extends BaseTask implements Task {
@@ -8,6 +8,25 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
   description = 'Finds Ember-specific dependencies and their versions in an Ember.js project';
   category = 'dependencies';
   group = 'ember';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'table',
+          options: {
+            rows: {
+              Dependency: 'properties.packageName',
+              Installed: 'properties.packageVersion',
+              Latest: 'properties.latestVersion',
+            },
+          },
+        },
+      },
+    });
+  }
 
   async run(): Promise<Result[]> {
     let analyzer = new DependencyAnalyzer(this.context.options.cwd);
@@ -33,20 +52,6 @@ export default class EmberDependenciesTask extends BaseTask implements Task {
               packageVersion: dependency.packageVersion,
               latestVersion: dependency.latestVersion,
               type: dependency.type,
-            },
-            rule: {
-              properties: {
-                component: {
-                  name: 'table',
-                  options: {
-                    rows: {
-                      Dependency: 'properties.packageName',
-                      Installed: 'properties.packageVersion',
-                      Latest: 'properties.latestVersion',
-                    },
-                  },
-                },
-              },
             },
           }
         );

--- a/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-in-repo-addons-engines-task.ts
@@ -1,4 +1,4 @@
-import { Task, BaseTask, TaskError } from '@checkup/core';
+import { Task, BaseTask, TaskError, TaskContext } from '@checkup/core';
 
 import { PackageJson } from 'type-fest';
 import { readJson } from 'fs-extra';
@@ -11,6 +11,30 @@ export default class EmberInRepoAddonsEnginesTask extends BaseTask implements Ta
   description = 'Finds all in-repo engines and addons in an Ember.js project';
   category = 'metrics';
   group = 'ember';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: {
+              Engine: {
+                groupBy: 'properties.type',
+                value: 'engine',
+              },
+              Addon: {
+                groupBy: 'properties.type',
+                value: 'addon',
+              },
+            },
+          },
+        },
+      },
+    });
+  }
 
   async run(): Promise<Result[]> {
     let packageJsonPaths: string[] = this.context.paths.filterByGlob('**/*package.json');
@@ -29,25 +53,6 @@ export default class EmberInRepoAddonsEnginesTask extends BaseTask implements Ta
           },
           properties: {
             type,
-          },
-          rule: {
-            properties: {
-              component: {
-                name: 'list',
-                options: {
-                  items: {
-                    Engine: {
-                      groupBy: 'properties.type',
-                      value: 'engine',
-                    },
-                    Addon: {
-                      groupBy: 'properties.type',
-                      value: 'addon',
-                    },
-                  },
-                },
-              },
-            },
           },
         });
       }

--- a/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
@@ -177,6 +177,15 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
   constructor(pluginName: string, context: TaskContext) {
     super(pluginName, context);
 
+    this.addRule({
+      properties: {
+        component: {
+          name: 'migration',
+        },
+        features: Object.values(RULE_METADATA).map((ruleMetadata) => ruleMetadata.feature),
+      },
+    });
+
     this.eslintAnalyzer = new ESLintAnalyzer(OCTANE_ES_LINT_CONFIG, this.config);
     this.emberTemplateLintAnalyzer = new EmberTemplateLintAnalyzer(
       OCTANE_TEMPLATE_LINT_CONFIG,
@@ -229,14 +238,6 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
               name: 'ember-octane-migration',
               displayName: 'Ember Octane Migration',
               feature: ruleMetadata.feature,
-            },
-          },
-          rule: {
-            properties: {
-              component: {
-                name: 'migration',
-              },
-              features: Object.values(RULE_METADATA).map((ruleMetadata) => ruleMetadata.feature),
             },
           },
         }

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
@@ -1,5 +1,12 @@
 import { promises } from 'fs';
-import { Task, BaseTask, NormalizedLintResult, trimCwd, HandlebarsAnalyzer } from '@checkup/core';
+import {
+  Task,
+  BaseTask,
+  NormalizedLintResult,
+  trimCwd,
+  HandlebarsAnalyzer,
+  TaskContext,
+} from '@checkup/core';
 import { Result } from 'sarif';
 
 const TEMPLATE_LINT_DISABLE = 'template-lint-disable';
@@ -11,6 +18,26 @@ export default class EmberTemplateLintDisableTask extends BaseTask implements Ta
   category = 'linting';
   group = 'disabled-lint-rules';
 
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: {
+              'Disabled rules': {
+                groupBy: 'level',
+                value: 'note',
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
   async run(): Promise<Result[]> {
     let hbsPaths = this.context.paths.filterByGlob('**/*.hbs');
     let templateLintDisables = await getTemplateLintDisables(hbsPaths, this.context.options.cwd);
@@ -21,21 +48,6 @@ export default class EmberTemplateLintDisableTask extends BaseTask implements Ta
           uri: disable.filePath,
           startColumn: disable.column,
           startLine: disable.line,
-        },
-        rule: {
-          properties: {
-            component: {
-              name: 'list',
-              options: {
-                items: {
-                  'Disabled rules': {
-                    groupBy: 'level',
-                    value: 'note',
-                  },
-                },
-              },
-            },
-          },
         },
       });
     });

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
@@ -21,6 +21,26 @@ export default class TemplateLintSummaryTask extends BaseTask implements Task {
   constructor(pluginName: string, context: TaskContext) {
     super(pluginName, context);
 
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: {
+              Errors: {
+                groupBy: 'level',
+                value: 'error',
+              },
+              Warnings: {
+                groupBy: 'level',
+                value: 'warning',
+              },
+            },
+          },
+        },
+      },
+    });
+
     let resolvedTemplateLintConfigFile = join(
       resolve(this.context.options.cwd),
       '.template-lintrc.js'
@@ -49,25 +69,6 @@ export default class TemplateLintSummaryTask extends BaseTask implements Task {
           startLine: result.line,
           endLine: result.endLine,
           endColumn: result.endColumn,
-        },
-        rule: {
-          properties: {
-            component: {
-              name: 'list',
-              options: {
-                items: {
-                  Errors: {
-                    groupBy: 'level',
-                    value: 'error',
-                  },
-                  Warnings: {
-                    groupBy: 'level',
-                    value: 'warning',
-                  },
-                },
-              },
-            },
-          },
         },
       });
     });

--- a/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-test-types-task.ts
@@ -41,6 +41,30 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
   constructor(pluginName: string, context: TaskContext) {
     super(pluginName, context);
 
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: {
+              Application: {
+                groupBy: 'properties.testType',
+                value: 'application',
+              },
+              Rendering: {
+                groupBy: 'properties.testType',
+                value: 'rendering',
+              },
+              Unit: {
+                groupBy: 'properties.testType',
+                value: 'unit',
+              },
+            },
+          },
+        },
+      },
+    });
+
     this.eslintAnalyzer = new ESLintAnalyzer(EMBER_TEST_TYPES);
 
     this.testFiles = this.context.paths.filterByGlob('**/*test.js');
@@ -73,29 +97,6 @@ export default class EmberTestTypesTask extends BaseTask implements Task {
         properties: {
           testType,
           testMethod: method,
-        },
-        rule: {
-          properties: {
-            component: {
-              name: 'list',
-              options: {
-                items: {
-                  Application: {
-                    groupBy: 'properties.testType',
-                    value: 'application',
-                  },
-                  Rendering: {
-                    groupBy: 'properties.testType',
-                    value: 'rendering',
-                  },
-                  Unit: {
-                    groupBy: 'properties.testType',
-                    value: 'unit',
-                  },
-                },
-              },
-            },
-          },
         },
       });
     });

--- a/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-types-task.ts
@@ -1,4 +1,4 @@
-import { Task, BaseTask, trimCwd } from '@checkup/core';
+import { Task, BaseTask, trimCwd, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 const SEARCH_PATTERNS = [
@@ -21,6 +21,27 @@ export default class EmberTypesTask extends BaseTask implements Task {
   category = 'metrics';
   group = 'ember';
 
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: SEARCH_PATTERNS.reduce((total, pattern) => {
+              total[pattern.type] = {
+                groupBy: 'properties.type',
+                value: pattern.type,
+              };
+              return total;
+            }, {} as Record<string, any>),
+          },
+        },
+      },
+    });
+  }
+
   async run(): Promise<Result[]> {
     SEARCH_PATTERNS.map((pattern) => {
       let files = this.context.paths.filterByGlob(pattern.pattern);
@@ -37,22 +58,6 @@ export default class EmberTypesTask extends BaseTask implements Task {
             },
             properties: {
               type: pattern.type,
-            },
-            rule: {
-              properties: {
-                component: {
-                  name: 'list',
-                  options: {
-                    items: SEARCH_PATTERNS.reduce((total, pattern) => {
-                      total[pattern.type] = {
-                        groupBy: 'properties.type',
-                        value: pattern.type,
-                      };
-                      return total;
-                    }, {} as Record<string, any>),
-                  },
-                },
-              },
             },
           }
         );

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -1,5 +1,12 @@
 import * as fs from 'fs';
-import { Task, BaseTask, trimCwd, NormalizedLintResult, AstAnalyzer } from '@checkup/core';
+import {
+  Task,
+  BaseTask,
+  trimCwd,
+  NormalizedLintResult,
+  AstAnalyzer,
+  TaskContext,
+} from '@checkup/core';
 import * as t from '@babel/types';
 import { parse, visit } from 'recast';
 import { Visitor } from 'ast-types';
@@ -14,6 +21,26 @@ export default class EslintDisableTask extends BaseTask implements Task {
   category = 'linting';
   group = 'disabled-lint-rules';
 
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: {
+              'Disabled rules': {
+                groupBy: 'level',
+                value: 'note',
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
   async run(): Promise<Result[]> {
     let jsPaths = this.context.paths.filterByGlob('**/*.js');
     let eslintDisables: NormalizedLintResult[] = await getEslintDisables(
@@ -27,23 +54,6 @@ export default class EslintDisableTask extends BaseTask implements Task {
           uri: disable.filePath,
           startColumn: disable.column,
           startLine: disable.line,
-        },
-        rule: {
-          properties: {
-            taskDisplayName: this.taskDisplayName,
-            category: this.category,
-            component: {
-              name: 'list',
-              options: {
-                items: {
-                  'Disabled rules': {
-                    groupBy: 'level',
-                    value: 'note',
-                  },
-                },
-              },
-            },
-          },
         },
       });
     });

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -40,6 +40,26 @@ export default class EslintSummaryTask extends BaseTask implements Task {
   constructor(pluginName: string, context: TaskContext) {
     super(pluginName, context);
 
+    this.addRule({
+      properties: {
+        component: {
+          name: 'list',
+          options: {
+            items: {
+              Errors: {
+                groupBy: 'level',
+                value: 'error',
+              },
+              Warnings: {
+                groupBy: 'level',
+                value: 'warning',
+              },
+            },
+          },
+        },
+      },
+    });
+
     let eslintConfig: ESLintOptions = this.readEslintConfig(
       this.context.paths,
       this.context.options.cwd,
@@ -60,25 +80,6 @@ export default class EslintSummaryTask extends BaseTask implements Task {
           startLine: result.line,
           endColumn: result.endColumn,
           endLine: result.endLine,
-        },
-        rule: {
-          properties: {
-            component: {
-              name: 'list',
-              options: {
-                items: {
-                  Errors: {
-                    groupBy: 'level',
-                    value: 'error',
-                  },
-                  Warnings: {
-                    groupBy: 'level',
-                    value: 'warning',
-                  },
-                },
-              },
-            },
-          },
         },
       });
     });

--- a/packages/checkup-plugin-javascript/src/tasks/lines-of-code-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/lines-of-code-task.ts
@@ -19,7 +19,7 @@ export default class LinesOfCodeTask extends BaseTask implements Task {
   constructor(pluginName: string, context: TaskContext) {
     super(pluginName, context);
 
-    this.addRuleProperties({
+    this.addRule({
       properties: {
         component: {
           name: 'table',

--- a/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/outdated-dependencies-task.ts
@@ -1,12 +1,31 @@
 import { join } from 'path';
 import { Result } from 'sarif';
-import { BaseTask, Task, DependencyAnalyzer } from '@checkup/core';
+import { BaseTask, Task, DependencyAnalyzer, TaskContext } from '@checkup/core';
 
 export default class OutdatedDependenciesTask extends BaseTask implements Task {
   taskName = 'outdated-dependencies';
   taskDisplayName = 'Outdated Dependencies';
   description = 'Gets a summary of all outdated dependencies in a project';
   category = 'dependencies';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'table',
+          options: {
+            rows: {
+              Dependency: 'properties.packageName',
+              Installed: 'properties.packageVersion',
+              Latest: 'properties.latestVersion',
+            },
+          },
+        },
+      },
+    });
+  }
 
   async run(): Promise<Result[]> {
     let analyzer = new DependencyAnalyzer(this.context.options.cwd);
@@ -34,20 +53,6 @@ export default class OutdatedDependenciesTask extends BaseTask implements Task {
               packageVersion: dependency.packageVersion,
               latestVersion: dependency.latestVersion,
               type: dependency.type,
-            },
-            rule: {
-              properties: {
-                component: {
-                  name: 'table',
-                  options: {
-                    rows: {
-                      Dependency: 'properties.packageName',
-                      Installed: 'properties.packageVersion',
-                      Latest: 'properties.latestVersion',
-                    },
-                  },
-                },
-              },
             },
           }
         );

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -30,7 +30,7 @@ describe('cli-test', () => {
 
   afterEach(function () {
     process.chdir(ROOT);
-    project.dispose();
+    // project.dispose();
   });
 
   it('outputs top level help', async () => {
@@ -250,11 +250,6 @@ describe('cli-test', () => {
   });
 
   it('should run a single task if the tasks option is specified with a single task', async () => {
-    project.symlinkPackage(
-      join(__dirname, '..', '..', 'checkup-formatter-pretty'),
-      join(project.baseDir, 'node_modules', 'checkup-formatter-pretty')
-    );
-
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -269,16 +264,12 @@ describe('cli-test', () => {
       plugins: ['checkup-plugin-fake'],
     });
 
-    let result = await run(['run', '.', '--task', 'fake/file-count', '--format', 'summary']);
+    let result = await run(['run', '.', '--task', 'fake/file-count']);
 
     expect(stripAnsi(result.stdout)).toContain('✔ file-count');
   });
 
   it('should run multiple tasks if the tasks option is specified with multiple tasks', async () => {
-    project.symlinkPackage(
-      join(__dirname, '..', '..', 'checkup-formatter-pretty'),
-      join(project.baseDir, 'node_modules', 'checkup-formatter-pretty')
-    );
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -314,11 +305,6 @@ describe('cli-test', () => {
   });
 
   it('should run only one task if the category option is specified', async () => {
-    project.symlinkPackage(
-      join(__dirname, '..', '..', 'checkup-formatter-pretty'),
-      join(project.baseDir, 'node_modules', 'checkup-formatter-pretty')
-    );
-
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -338,18 +324,13 @@ describe('cli-test', () => {
       plugins: ['checkup-plugin-fake'],
     });
 
-    let result = await run(['run', '.', '--category', 'files', '--format', 'summary']);
+    let result = await run(['run', '.', '--category', 'files']);
 
     expect(stripAnsi(result.stdout)).toContain('✔ file-count');
     expect(stripAnsi(result.stdout)).not.toContain('✔ foo');
   });
 
   it('should run multiple tasks if the category option is specified with multiple categories', async () => {
-    project.symlinkPackage(
-      join(__dirname, '..', '..', 'checkup-formatter-pretty'),
-      join(project.baseDir, 'node_modules', 'checkup-formatter-pretty')
-    );
-
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -385,10 +366,6 @@ describe('cli-test', () => {
   });
 
   it('should run only one task if the group option is specified', async () => {
-    project.symlinkPackage(
-      join(__dirname, '..', '..', 'checkup-formatter-pretty'),
-      join(project.baseDir, 'node_modules', 'checkup-formatter-pretty')
-    );
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -408,17 +385,12 @@ describe('cli-test', () => {
       plugins: ['checkup-plugin-fake'],
     });
 
-    let result = await run(['run', '.', '--group', 'group1', '--format', 'summary']);
+    let result = await run(['run', '.', '--group', 'group1']);
 
     expect(stripAnsi(result.stdout)).toContain('✔ file-count');
   });
 
   it('should run multiple tasks if the group option is specified with multiple groups', async () => {
-    project.symlinkPackage(
-      join(__dirname, '..', '..', 'checkup-formatter-pretty'),
-      join(project.baseDir, 'node_modules', 'checkup-formatter-pretty')
-    );
-
     let pluginDir = await project.addPlugin(
       { name: 'fake', defaults: false },
       { typescript: false }
@@ -469,7 +441,7 @@ describe('cli-test', () => {
       tasks: { 'fake/file-count': 'off' },
     });
 
-    let result = await run(['run', '.', '--task', 'fake/file-count', '--format', 'summary']);
+    let result = await run(['run', '.', '--task', 'fake/file-count']);
 
     expect(stripAnsi(result.stdout)).toContain('✔ file-count');
   });
@@ -509,10 +481,10 @@ describe('cli-test', () => {
     });
 
     project.writeSync();
-    let result = await run(['run', '**/*.hbs', '**baz/**', '--format', 'summary']);
+    let result = await run(['run', '**/*.hbs', '**baz/**']);
     let filtered = result.stdout;
 
-    result = await run(['run', '.', '--format', 'summary']);
+    result = await run(['run', '.']);
 
     let unfiltered = result.stdout;
 
@@ -524,13 +496,13 @@ describe('cli-test', () => {
     project.addCheckupConfig({ excludePaths: ['**/*.hbs'] });
     project.writeSync();
 
-    let result = await run(['run', '.', '--format', 'summary']);
+    let result = await run(['run', '.']);
     let filtered = result.stdout;
 
     project.addCheckupConfig({ excludePaths: [] });
     project.writeSync();
 
-    result = await run(['run', '.', '--format', 'summary']);
+    result = await run(['run', '.']);
     let unfiltered = result.stdout;
 
     expect(filtered).toContain('4 files analyzed');
@@ -550,7 +522,7 @@ describe('cli-test', () => {
 
     let hbsJsFiltered = result.stdout;
 
-    result = await run(['run', '.', '--exclude-paths', '**/*.hbs', '--format', 'summary']);
+    result = await run(['run', '.', '--exclude-paths', '**/*.hbs']);
 
     let hbsFiltered = result.stdout;
 
@@ -562,13 +534,13 @@ describe('cli-test', () => {
     project.addCheckupConfig({ excludePaths: ['**/*.js'] });
     project.writeSync();
 
-    let result = await run(['run', '.', '--exclude-paths', '**/*.hbs', '--format', 'summary']);
+    let result = await run(['run', '.', '--exclude-paths', '**/*.hbs']);
 
     let hbsFiltered = result.stdout;
 
     expect(hbsFiltered).toContain('4 files analyzed');
 
-    result = await run(['run', '.', '--format', 'summary']);
+    result = await run(['run', '.']);
 
     let hbsJsFiltered = result.stdout;
     expect(hbsJsFiltered).toContain('5 files analyzed');

--- a/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-task-test.ts.snap
@@ -10,6 +10,11 @@ module.exports = class MyFooTask extends BaseTask {
   category = 'foo';
   group = 'bar';
 
+  constructor(pluginName, context) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run() {
     this.addResult(
@@ -76,7 +81,7 @@ module.exports = {
 `;
 
 exports[`task generator generates correct files with TypeScript for defaults 1`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
@@ -84,6 +89,12 @@ export default class MyFooTask extends BaseTask implements Task {
   taskDisplayName = 'My Foo';
   description = '';
   category = '';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(
@@ -148,7 +159,7 @@ export function register(args: RegistrationArgs) {
 `;
 
 exports[`task generator generates correct files with TypeScript for defaults in custom path 1`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
@@ -156,6 +167,12 @@ export default class MyFooTask extends BaseTask implements Task {
   taskDisplayName = 'My Foo';
   description = '';
   category = '';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(
@@ -220,7 +237,7 @@ export function register(args: RegistrationArgs) {
 `;
 
 exports[`task generator generates correct files with category 1`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
@@ -229,6 +246,12 @@ export default class MyFooTask extends BaseTask implements Task {
   description = 'Some description';
   category = 'foo';
   group = 'bar';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(
@@ -293,7 +316,7 @@ export function register(args: RegistrationArgs) {
 `;
 
 exports[`task generator generates correct files with group 1`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
@@ -302,6 +325,12 @@ export default class MyFooTask extends BaseTask implements Task {
   description = 'Some description';
   category = 'foo';
   group = 'bar';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(
@@ -366,7 +395,7 @@ export function register(args: RegistrationArgs) {
 `;
 
 exports[`task generator generates correct files with typescript 1`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
@@ -375,6 +404,12 @@ export default class MyFooTask extends BaseTask implements Task {
   description = 'Some description';
   category = 'foo';
   group = 'bar';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(
@@ -439,7 +474,7 @@ export function register(args: RegistrationArgs) {
 `;
 
 exports[`task generator generates multiple correct files with TypeScript for defaults 1`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyFooTask extends BaseTask implements Task {
@@ -447,6 +482,12 @@ export default class MyFooTask extends BaseTask implements Task {
   taskDisplayName = 'My Foo';
   description = '';
   category = '';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(
@@ -498,7 +539,7 @@ describe('my-foo-task', () => {
 `;
 
 exports[`task generator generates multiple correct files with TypeScript for defaults 3`] = `
-"import { BaseTask, Task } from '@checkup/core';
+"import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class MyBarTask extends BaseTask implements Task {
@@ -506,6 +547,12 @@ export default class MyBarTask extends BaseTask implements Task {
   taskDisplayName = 'My Bar';
   description = '';
   category = '';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(

--- a/packages/cli/src/api/checkup-task-runner.ts
+++ b/packages/cli/src/api/checkup-task-runner.ts
@@ -98,6 +98,7 @@ export default class CheckupTaskRunner {
     this.tasks = new TaskListImpl();
     this.taskResults = [];
     this.taskErrors = [];
+    this.executedTasks = [];
     this.options = options;
     this.pkg = getPackageJson(this.options.cwd);
     this.pkgSource = getPackageJsonSource(this.options.cwd);
@@ -121,6 +122,7 @@ export default class CheckupTaskRunner {
       actions: this.actions,
       errors: this.taskErrors,
       timings: this.tasks.timings,
+      executedTasks: this.executedTasks,
     });
 
     return this.logBuilder.log;

--- a/packages/cli/src/formatters/summary.ts
+++ b/packages/cli/src/formatters/summary.ts
@@ -13,12 +13,12 @@ export default class SummaryFormatter extends BaseFormatter<BufferedWriter> impl
   }
 
   format(logParser: CheckupLogParser) {
-    let { rules, metaData, log, actions } = logParser;
+    let { metaData, log, actions, executedTasks } = logParser;
 
     this.renderMetadata(metaData);
     this.writer.log('Checkup ran the following task(s) successfully:');
 
-    rules
+    executedTasks
       .map((rule) => rule.id)
       .sort()
       .forEach((taskName) => {

--- a/packages/cli/templates/src/task/src/tasks/task.js.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.js.ejs
@@ -9,6 +9,11 @@ module.exports = class <%- taskClass %> extends BaseTask {
   group = '<%- group %>';
   <%_ } _%>
 
+  constructor(pluginName, context) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run() {
     this.addResult(

--- a/packages/cli/templates/src/task/src/tasks/task.ts.ejs
+++ b/packages/cli/templates/src/task/src/tasks/task.ts.ejs
@@ -1,4 +1,4 @@
-import { BaseTask, Task } from '@checkup/core';
+import { BaseTask, Task, TaskContext } from '@checkup/core';
 import { Result } from 'sarif';
 
 export default class <%- taskClass %> extends BaseTask implements Task {
@@ -9,6 +9,12 @@ export default class <%- taskClass %> extends BaseTask implements Task {
   <%_ if (group) { _%>
   group = '<%- group %>';
   <%_ } _%>
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 
   async run(): Promise<Result[]> {
     this.addResult(

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -8,6 +8,12 @@ class FakeTask extends BaseTask {
   taskDisplayName = 'Fake';
   description = 'description';
   category = 'foo';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+  }
 }
 
 describe('BaseTask', () => {
@@ -202,54 +208,6 @@ describe('BaseTask', () => {
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
-    });
-
-    it('can add a result with overridden rule metadata', () => {
-      let context: TaskContext = getTaskContext();
-
-      let fakeTask = new FakeTask('fake', context);
-
-      fakeTask.addResult('The is a fake message', 'informational', 'note', {
-        rule: {
-          id: 'my-fake-sub',
-          properties: {
-            category: 'foo',
-            component: 'table',
-            taskDisplayName: 'Fake',
-          },
-        },
-      });
-
-      let run = fakeTask.context.logBuilder.currentRunBuilder.run;
-
-      expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "id": "my-fake-sub",
-            "properties": Object {
-              "category": "foo",
-              "component": "table",
-              "taskDisplayName": "Fake",
-            },
-            "shortDescription": Object {
-              "text": "description",
-            },
-          },
-        ]
-      `);
-      expect(run.results).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kind": "informational",
-            "level": "note",
-            "message": Object {
-              "text": "The is a fake message",
-            },
-            "ruleId": "my-fake-sub",
-            "ruleIndex": 0,
-          },
-        ]
-      `);
     });
   });
 

--- a/packages/core/__tests__/data/checkup-log-builder-test.ts
+++ b/packages/core/__tests__/data/checkup-log-builder-test.ts
@@ -35,6 +35,7 @@ describe('checkup-log-builder-test', () => {
       actions: [],
       errors: [],
       timings: {},
+      executedTasks: [],
     });
 
     // arguments are non-deterministic, so we nuke them

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -1,6 +1,6 @@
 import * as debug from 'debug';
 
-import { Location, Result } from 'sarif';
+import { Location, PropertyBag, Result } from 'sarif';
 import { SetRequired } from 'type-fest';
 
 import {
@@ -181,7 +181,7 @@ export default abstract class BaseTask {
     return toLintResults(results, this.context.options.cwd);
   }
 
-  public addRule(rule?: TaskRule) {
+  public addRule(additionalRuleProps?: TaskRule) {
     let taskRule;
     let ruleProps = {
       id: this.taskName,
@@ -194,10 +194,22 @@ export default abstract class BaseTask {
       },
     };
 
-    taskRule = merge({}, ruleProps, rule);
+    taskRule = merge({}, ruleProps, additionalRuleProps);
 
     this._logBuilder.addRule(taskRule);
 
     return taskRule.id;
+  }
+
+  public addRuleProperties(properties: PropertyBag) {
+    let rule = this._logBuilder.getRule(this.taskName);
+
+    if (!rule) {
+      throw new Error(
+        'You must call `addRule` in your Task implemenation prior to calling `addResult`'
+      );
+    }
+
+    merge(rule.properties, properties);
   }
 }

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -118,16 +118,20 @@ export default abstract class BaseTask {
     level: TaskResultLevel,
     options?: TaskResultOptions
   ): RequiredResult {
-    let ruleId = this._addRule(options?.rule);
-
     let result: RequiredResult = {
       message: {
         text: messageText,
       },
-      ruleId,
+      ruleId: this.taskName,
       kind,
       level,
     };
+
+    if (!this._logBuilder.hasRule(this.taskName)) {
+      throw new Error(
+        'You must call `addRule` in your Task implemenation prior to calling `addResult`'
+      );
+    }
 
     if (options?.properties) {
       result.properties = options.properties;
@@ -177,7 +181,7 @@ export default abstract class BaseTask {
     return toLintResults(results, this.context.options.cwd);
   }
 
-  private _addRule(rule?: TaskRule) {
+  public addRule(rule?: TaskRule) {
     let taskRule;
     let ruleProps = {
       id: this.taskName,

--- a/packages/core/src/data/checkup-log-builder.ts
+++ b/packages/core/src/data/checkup-log-builder.ts
@@ -7,7 +7,7 @@ import { FilePathArray } from '../utils/file-path-array';
 import extractStack from '../utils/extract-stack';
 import { AnnotationArgs, CheckupLogBuilderArgs } from '../types/checkup-log';
 import { CheckupConfig } from '../types/config';
-import { TaskAction, TaskListError } from '../types/tasks';
+import { Task, TaskAction, TaskListError } from '../types/tasks';
 import SarifLogBuilder from './sarif-log-builder';
 import { trimAllCwd } from './path';
 
@@ -24,6 +24,7 @@ export default class CheckupLogBuilder extends SarifLogBuilder {
   actions: TaskAction[] = [];
   errors: TaskListError[] = [];
   timings: Record<string, number> = {};
+  executedTasks: Task[] = [];
 
   startTime: string;
 
@@ -46,6 +47,7 @@ export default class CheckupLogBuilder extends SarifLogBuilder {
       actions: this.actions,
       errors: this.errors,
       timings: this.timings,
+      executedTasks: this.executedTasks,
     } = annotations);
 
     this.addInvocation({
@@ -57,6 +59,7 @@ export default class CheckupLogBuilder extends SarifLogBuilder {
 
     await this.addCheckupMetadata();
 
+    this.addTaskExecutionNotifications();
     this.addExecptionNotifications();
     this.addActionNotifications();
   }
@@ -88,6 +91,15 @@ export default class CheckupLogBuilder extends SarifLogBuilder {
         timings: this.timings,
       },
     };
+  }
+
+  addTaskExecutionNotifications() {
+    this.executedTasks.forEach((task) => {
+      this.addNotification({
+        id: task.taskName,
+        name: 'Execution successful',
+      });
+    });
   }
 
   addExecptionNotifications(): void {

--- a/packages/core/src/data/checkup-log-parser.ts
+++ b/packages/core/src/data/checkup-log-parser.ts
@@ -56,6 +56,10 @@ export default class CheckupLogParser {
     return this.metaData.timings;
   }
 
+  get executedTasks() {
+    return this.run.tool.driver.notifications ?? [];
+  }
+
   get actions() {
     return (
       this.invocation.toolExecutionNotifications?.filter(

--- a/packages/core/src/data/sarif-log-builder.ts
+++ b/packages/core/src/data/sarif-log-builder.ts
@@ -49,6 +49,10 @@ export default class SarifLogBuilder {
     return ruleIndex;
   }
 
+  hasRule(ruleId: string) {
+    return this.rules.some((rule) => rule.id === ruleId);
+  }
+
   addResult<TResult extends RequiredResult>(
     result: TResult,
     ruleMetadata?: Omit<ReportingDescriptor, 'id'>

--- a/packages/core/src/data/sarif-log-builder.ts
+++ b/packages/core/src/data/sarif-log-builder.ts
@@ -49,8 +49,16 @@ export default class SarifLogBuilder {
     return ruleIndex;
   }
 
+  getRule(ruleId: string) {
+    let rules = this.currentRunBuilder.run.tool.driver.rules;
+
+    if (rules) {
+      return rules.find((rule) => rule.id === ruleId);
+    }
+  }
+
   hasRule(ruleId: string) {
-    return this.rules.some((rule) => rule.id === ruleId);
+    return !!this.getRule(ruleId);
   }
 
   addResult<TResult extends RequiredResult>(

--- a/packages/core/src/data/sarif-log-builder.ts
+++ b/packages/core/src/data/sarif-log-builder.ts
@@ -92,6 +92,16 @@ export default class SarifLogBuilder {
     this.currentRunBuilder.run.invocations?.push(invocation);
   }
 
+  addNotification(notification: ReportingDescriptor) {
+    let notifications = this.currentRunBuilder.run.tool.driver.notifications;
+
+    if (!notifications) {
+      this.currentRunBuilder.run.tool.driver.notifications = notifications = [];
+    }
+
+    notifications.push(notification);
+  }
+
   addToolExecutionNotification(notification: Notification) {
     let notifications = this.currentRunBuilder.currentInvocation.toolExecutionNotifications;
 

--- a/packages/core/src/types/checkup-log.ts
+++ b/packages/core/src/types/checkup-log.ts
@@ -1,7 +1,7 @@
 import { PackageJson, SetRequired } from 'type-fest';
 import { Run, Result, ReportingDescriptor } from 'sarif';
 import { RunOptions } from '../types/cli';
-import { TaskListError, TaskAction } from '../types/tasks';
+import { TaskListError, TaskAction, Task } from '../types/tasks';
 import { CheckupConfig } from '../types/config';
 import { FilePathArray } from '../utils/file-path-array';
 
@@ -21,6 +21,7 @@ export type RuleResults = {
 
 export interface AnnotationArgs {
   config: CheckupConfig;
+  executedTasks: Task[];
   actions: TaskAction[];
   errors: TaskListError[];
   timings: Record<string, number>;

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -37,7 +37,6 @@ export type TaskRule = SetOptional<ReportingDescriptor, 'id'>;
 export type TaskResultOptions = {
   location?: TaskResultLocation;
   properties?: TaskResultProperties;
-  rule?: TaskRule;
 };
 
 export interface Task {

--- a/packages/test-helpers/src/get-task-context.ts
+++ b/packages/test-helpers/src/get-task-context.ts
@@ -80,6 +80,7 @@ export function getTaskContext({
   taskContext.logBuilder.actions = [];
   taskContext.logBuilder.errors = [];
   taskContext.logBuilder.timings = {};
+  taskContext.logBuilder.executedTasks = [];
 
   return taskContext;
 }


### PR DESCRIPTION
The `addResult` API is a cleaner addition to the `Task` class, and helps for adding valid SARIF to the resulting log. One awkward part of that API was it being overloaded to _also_ add the rule metadata. The awkwardness centered around a few things:

- it felt like a side-effect to invoke `addRule` inside `addResult`
- if no results were found for a task, the rule metadata would never be populated
- calling `addResult` multiple times, which is pretty common, would result in `addRule` being also called multiple times unnecessarily. While there was logic in `addRule` to ensure a new rule wasn't added every time it was called if one already existed, this still felt like unnecessary execution
- it made it hard for users to understand the relationship between the rule metadata and a result. There really wasn't any relationship other than the rule metadata represented static information added to the log about the `Task`, not the result.

Based on the above, it felt more correct to extract the `addRule` method out of `addResult` and require each Task to individually invoke it to set things up correctly in the SARIF log. While it seems somewhat redundant to require all Tasks to call this boilerplate, it gives Task authors an opportunity to add additional metadata to the rule, if they desire.
