### PR TITLE
Fixes errors in lint results causing incorrect data

### DIFF
--- a/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
@@ -218,7 +218,7 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
     let rawData = this.flattenLintResults(results);
 
     rawData.forEach((lintResult: NormalizedLintResult) => {
-      let ruleId = lintResult.lintRuleId ?? '';
+      let ruleId = lintResult.lintRuleId;
       let ruleMetadata = RULE_METADATA[ruleId];
 
       this.addResult(

--- a/packages/core/src/data/lint.ts
+++ b/packages/core/src/data/lint.ts
@@ -29,6 +29,12 @@ export function toLintResults(results: LintResult[], cwd: string): NormalizedLin
           ('ruleId' in lintMessage && lintMessage.ruleId !== undefined) ||
           ('rule' in lintMessage && lintMessage.rule !== undefined)
       )
+      .filter((lintMessage: LintMessage) => {
+        return (
+          !lintMessage.message.includes('Parsing error') &&
+          !getLintRuleId(lintMessage).includes('global')
+        );
+      })
       .map((lintMessage: LintMessage) => {
         return toLintResult(lintMessage, cwd, lintingResults.filePath);
       });

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -95,7 +95,7 @@ export enum OutputFormat {
 
 export interface NormalizedLintResult {
   filePath: string;
-  lintRuleId: string | null;
+  lintRuleId: string;
   message: string;
   line: number;
   column: number;


### PR DESCRIPTION
Any errors that are generated from using the lint analyzers can cause subsequent data loss due to invalid filtering of those errors. This was evident in the octane migration task, where parsing errors or global errors caused this data loss to manifest.

It's important to understand why those errors are occuring in the first place, but our code should be resilient to them propagating into the SARIF logs. This PR resolves this issue.