### PR TITLE
fix: Fixes lint result filtering to exclude exact match on global

### DIFF
--- a/packages/core/src/data/lint.ts
+++ b/packages/core/src/data/lint.ts
@@ -31,8 +31,7 @@ export function toLintResults(results: LintResult[], cwd: string): NormalizedLin
       )
       .filter((lintMessage: LintMessage) => {
         return (
-          !lintMessage.message.includes('Parsing error') &&
-          !getLintRuleId(lintMessage).includes('global')
+          !lintMessage.message.includes('Parsing error') && getLintRuleId(lintMessage) === 'global'
         );
       })
       .map((lintMessage: LintMessage) => {


### PR DESCRIPTION
[This fix](https://github.com/checkupjs/checkup/pull/1110) had the unfortunate side-effect of filtering out lint rules whose name _included_ global (as expected from the code!), but we wanted a more exact match on these rules, as this precluded any rule who _wanted_ to include global in the name.