### PR TITLE
Fixes Pretty formatter outputing empty results for all tasks

### DIFF
--- a/packages/checkup-formatter-pretty/__tests__/pretty-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/pretty-test.tsx
@@ -279,7 +279,7 @@ config 257cda6f6d50eeef891fc6ec8d808bdb
 `);
   });
 
-  it('can render a messgae when there is no result found', () => {
+  it('can render a messgae when there is no result found for executed results', () => {
     const log = readJsonSync(resolve(__dirname, './__fixtures__/checkup-no-result-found.sarif'));
     const logParser = new CheckupLogParser(log);
 
@@ -306,27 +306,6 @@ Ember Types
   Routes 0
   Services 0
   Templates 0
-
-
-Template Lint Summary
-=====================
-  Errors 0
-  Warnings 0
-
-
-Number of eslint-disable Usages
-===============================
-  Disabled Rules 0
-
-
-Outdated Dependencies
-=====================
-No results found.
-
-
-Ember Dependencies
-==================
-No results found.
 
 
 checkup v1.0.0-beta.11

--- a/packages/checkup-formatter-pretty/src/pretty-formatter.tsx
+++ b/packages/checkup-formatter-pretty/src/pretty-formatter.tsx
@@ -13,7 +13,7 @@ const PrettyFormatter: React.FC<{ logParser: CheckupLogParser }> = ({ logParser 
   return (
     <Box flexDirection={'column'} marginTop={1} marginBottom={1}>
       <MetaData metaData={metaData} />
-      <TaskResults taskResults={taskResults} rules={rules} />
+      <TaskResults taskResults={taskResults} rules={rules} logParser={logParser} />
       <RenderTiming timings={logParser.timings} />
       <CLIInfo metaData={metaData} />
     </Box>
@@ -48,7 +48,8 @@ const MetaData: React.FC<{ metaData: CheckupMetadata }> = ({ metaData }) => {
 const TaskResults: React.FC<{
   taskResults: Map<TaskName, RuleResults> | undefined;
   rules: ReportingDescriptor[];
-}> = ({ taskResults, rules }) => {
+  logParser: CheckupLogParser;
+}> = ({ taskResults, rules, logParser }) => {
   let r: { Component: React.FC<any>; taskResult: RuleResults }[] = [];
 
   if (taskResults!.size > 0) {
@@ -62,11 +63,13 @@ const TaskResults: React.FC<{
       });
     });
 
+    // For any executed task, we want to set its values to empty for output, to indicate the task ran with no results.
     for (let rule of rules) {
       if (
         !r.some((item) => {
           return rule.id === item.taskResult.rule.id;
-        })
+        }) &&
+        logParser.executedTasks.some((ruleDescriptor) => ruleDescriptor.id === rule.id)
       ) {
         let taskProps = rule.properties;
         let componentName = taskProps!.component.name;


### PR DESCRIPTION
Due to changes to the way we build rule metadata, there are now differences in the way we want to output results. 

Formerly the pretty formatter would try to indicate when no results were present, which helped verify to the user that the task ran with no results. Since the change to _always_ allow rule metadata, and the addition of tracking executed tasks separately, we needed to additionally filter when outputting the 'no results' info to only do so for executed tasks.