### PR TITLE
Adding support for declarative sorting in Migration component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -121,12 +121,18 @@
       }
     },
     {
-      "files": ["packages/**/__tests__/**/*.ts", "packages/test-helpers/**/*.ts"],
+      "files": [
+        "packages/**/__tests__/**/*.ts",
+        "packages/**/__tests__/**/*.tsx",
+        "packages/test-helpers/**/*.ts"
+      ],
       "env": {
         "jest": true
       },
       "rules": {
-        "node/no-extraneous-import": "off"
+        "node/no-extraneous-import": "off",
+        "node/no-unpublished-import": "off",
+        "node/no-unpublished-require": "off"
       }
     }
   ],

--- a/packages/checkup-formatter-pretty/__tests__/components/migration-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/components/migration-test.tsx
@@ -2,126 +2,445 @@ import * as React from 'react';
 import { render } from 'ink-testing-library';
 import { RuleResults } from '@checkup/core';
 import { Migration } from '../../src/components/migration';
+import { getSorter } from '../../src/get-sorter';
 
+const merge = require('lodash.merge');
 const stripAnsi = require('strip-ansi');
 
-describe('Test Migration component', () => {
-  it('can render task result as expected via migration component', async () => {
-    const taskResult: RuleResults = {
-      rule: {
-        id: 'ember-octane-migration-status',
-        shortDescription: {
-          text:
-            'Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project',
-        },
-        properties: {
-          taskDisplayName: 'Ember Octane Migration Status',
-          category: 'migrations',
-          component: {
-            name: 'migration',
-          },
-          features: [
-            'Native Classes',
-            'Native Classes',
-            'Native Classes',
-            'Native Classes',
-            'Glimmer Components',
-            'Native Classes',
-            'Native Classes',
-            'Glimmer Components',
-            'Native Classes',
-            'Tagless Components',
-            'Glimmer Components',
-            'Tracked Properties',
-            'Angle Bracket Syntax',
-            'Named Arguments',
-            'Own Properties',
-            'Modifiers',
-          ],
+const TASK_RESULT: RuleResults = {
+  rule: {
+    id: 'ember-octane-migration-status',
+    shortDescription: {
+      text:
+        'Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project',
+    },
+    properties: {
+      taskDisplayName: 'Ember Octane Migration Status',
+      category: 'migrations',
+      component: {
+        name: 'migration',
+      },
+      features: [
+        'Native Classes',
+        'Glimmer Components',
+        'Native Classes',
+        'Tagless Components',
+        'Tracked Properties',
+        'Angle Bracket Syntax',
+        'Named Arguments',
+        'Own Properties',
+        'Modifiers',
+      ],
+    },
+  },
+  results: [
+    {
+      message: {
+        text:
+          'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
+      },
+      ruleId: 'ember-octane-migration-status',
+      kind: 'review',
+      level: 'warning',
+      properties: {
+        migration: {
+          name: 'ember-octane-migration',
+          displayName: 'Ember Octane Migration',
+          feature: 'Native Classes',
         },
       },
-      results: [
+      locations: [
         {
-          message: {
-            text:
-              'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
-          },
-          ruleId: 'ember-octane-migration-status',
-          kind: 'review',
-          level: 'warning',
-          properties: {
-            migration: {
-              name: 'ember-octane-migration',
-              displayName: 'Ember Octane Migration',
-              feature: 'Native Classes',
+          physicalLocation: {
+            artifactLocation: {
+              uri: 'app/adapters/application.js',
+            },
+            region: {
+              startLine: 5,
+              startColumn: 16,
+              endLine: 56,
+              endColumn: 3,
             },
           },
-          locations: [
-            {
-              physicalLocation: {
-                artifactLocation: {
-                  uri: 'app/adapters/application.js',
-                },
-                region: {
-                  startLine: 5,
-                  startColumn: 16,
-                  endLine: 56,
-                  endColumn: 3,
-                },
-              },
-            },
-          ],
-          ruleIndex: 0,
-        },
-        {
-          message: {
-            text:
-              'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
-          },
-          ruleId: 'ember-octane-migration-status',
-          kind: 'review',
-          level: 'warning',
-          properties: {
-            migration: {
-              name: 'ember-octane-migration',
-              displayName: 'Ember Octane Migration',
-              feature: 'Native Classes',
-            },
-          },
-          locations: [
-            {
-              physicalLocation: {
-                artifactLocation: {
-                  uri: 'app/app.js',
-                },
-                region: {
-                  startLine: 12,
-                  startColumn: 13,
-                  endLine: 45,
-                  endColumn: 3,
-                },
-              },
-            },
-          ],
-          ruleIndex: 0,
         },
       ],
-    };
+      ruleIndex: 0,
+    },
+    {
+      message: {
+        text:
+          'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
+      },
+      ruleId: 'ember-octane-migration-status',
+      kind: 'review',
+      level: 'warning',
+      properties: {
+        migration: {
+          name: 'ember-octane-migration',
+          displayName: 'Ember Octane Migration',
+          feature: 'Native Classes',
+        },
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: 'app/app.js',
+            },
+            region: {
+              startLine: 12,
+              startColumn: 13,
+              endLine: 45,
+              endColumn: 3,
+            },
+          },
+        },
+      ],
+      ruleIndex: 0,
+    },
+    {
+      message: {
+        text:
+          'Octane | Glimmer Components : Use native DOM APIs over jQuery. More info: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-jquery.md',
+      },
+      ruleId: 'ember-octane-migration-status',
+      kind: 'review',
+      level: 'warning',
+      properties: {
+        migration: {
+          name: 'ember-octane-migration',
+          displayName: 'Ember Octane Migration',
+          feature: 'Glimmer Components',
+        },
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: 'app/app.js',
+            },
+            region: {
+              startLine: 12,
+              startColumn: 13,
+              endLine: 45,
+              endColumn: 3,
+            },
+          },
+        },
+      ],
+      ruleIndex: 0,
+    },
+    {
+      message: {
+        text:
+          'Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name',
+      },
+      ruleId: 'ember-octane-migration-status',
+      kind: 'review',
+      level: 'warning',
+      properties: {
+        migration: {
+          name: 'ember-octane-migration',
+          displayName: 'Ember Octane Migration',
+          feature: 'Tagless Components',
+        },
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: 'app/app.js',
+            },
+            region: {
+              startLine: 12,
+              startColumn: 13,
+              endLine: 45,
+              endColumn: 3,
+            },
+          },
+        },
+      ],
+      ruleIndex: 0,
+    },
+  ],
+};
 
-    const { stdout } = render(<Migration taskResult={taskResult} />);
+function getTaskResult(componentOptions = {}) {
+  return merge({}, TASK_RESULT, componentOptions);
+}
+
+describe('Test Migration component', () => {
+  it('can render task result with no sort options', async () => {
+    const { stdout } = render(<Migration taskResult={getTaskResult()} />);
 
     expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
 "Ember Octane Migration Status
 =============================
-Outstanding features to be migrated: 2
+Outstanding features to be migrated: 4
   Native Classes 2
-  Glimmer Components 0
-  Tagless Components 0
+  Glimmer Components 1
+  Tagless Components 1
   Tracked Properties 0
   Angle Bracket Syntax 0
   Named Arguments 0
   Own Properties 0
   Modifiers 0"
 `);
+  });
+
+  it('can render task result sorted by key, default to asc', async () => {
+    const { stdout } = render(
+      <Migration
+        taskResult={getTaskResult({
+          rule: {
+            properties: {
+              component: {
+                options: {
+                  sortBy: 'key',
+                },
+              },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
+"Ember Octane Migration Status
+=============================
+Outstanding features to be migrated: 4
+  Angle Bracket Syntax 0
+  Glimmer Components 1
+  Modifiers 0
+  Named Arguments 0
+  Native Classes 2
+  Own Properties 0
+  Tagless Components 1
+  Tracked Properties 0"
+`);
+  });
+
+  it('can render task result sorted by key, asc', async () => {
+    const { stdout } = render(
+      <Migration
+        taskResult={getTaskResult({
+          rule: {
+            properties: {
+              component: {
+                options: {
+                  sortBy: 'key',
+                  sortDirection: 'asc',
+                },
+              },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
+"Ember Octane Migration Status
+=============================
+Outstanding features to be migrated: 4
+  Angle Bracket Syntax 0
+  Glimmer Components 1
+  Modifiers 0
+  Named Arguments 0
+  Native Classes 2
+  Own Properties 0
+  Tagless Components 1
+  Tracked Properties 0"
+`);
+  });
+
+  it('can render task result sorted by key, desc', async () => {
+    const { stdout } = render(
+      <Migration
+        taskResult={getTaskResult({
+          rule: {
+            properties: {
+              component: {
+                options: {
+                  sortBy: 'key',
+                  sortDirection: 'desc',
+                },
+              },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
+"Ember Octane Migration Status
+=============================
+Outstanding features to be migrated: 4
+  Tracked Properties 0
+  Tagless Components 1
+  Own Properties 0
+  Native Classes 2
+  Named Arguments 0
+  Modifiers 0
+  Glimmer Components 1
+  Angle Bracket Syntax 0"
+`);
+  });
+
+  it('can render task result sorted by value, asc', async () => {
+    const { stdout } = render(
+      <Migration
+        taskResult={getTaskResult({
+          rule: {
+            properties: {
+              component: {
+                options: {
+                  sortBy: 'value',
+                  sortDirection: 'asc',
+                },
+              },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
+"Ember Octane Migration Status
+=============================
+Outstanding features to be migrated: 4
+  Tracked Properties 0
+  Angle Bracket Syntax 0
+  Named Arguments 0
+  Own Properties 0
+  Modifiers 0
+  Glimmer Components 1
+  Tagless Components 1
+  Native Classes 2"
+`);
+  });
+
+  it('can render task result sorted by value, desc', async () => {
+    const { stdout } = render(
+      <Migration
+        taskResult={getTaskResult({
+          rule: {
+            properties: {
+              component: {
+                options: {
+                  sortBy: 'value',
+                  sortDirection: 'desc',
+                },
+              },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
+"Ember Octane Migration Status
+=============================
+Outstanding features to be migrated: 4
+  Native Classes 2
+  Tagless Components 1
+  Glimmer Components 1
+  Modifiers 0
+  Own Properties 0
+  Named Arguments 0
+  Angle Bracket Syntax 0
+  Tracked Properties 0"
+`);
+  });
+});
+
+describe('sorters', () => {
+  it('can sort keys by alpha', () => {
+    let sort = getSorter('key');
+
+    expect(
+      sort(
+        new Map([
+          ['DDD', 4],
+          ['BBB', 2],
+          ['AAA', 1],
+          ['CCC', 3],
+        ])
+      )
+    ).toEqual(
+      new Map([
+        ['AAA', 1],
+        ['BBB', 2],
+        ['CCC', 3],
+        ['DDD', 4],
+      ])
+    );
+  });
+
+  it('can sort keys by alpha, desc', () => {
+    let sort = getSorter('key');
+
+    expect(
+      sort(
+        new Map([
+          ['DDD', 4],
+          ['BBB', 2],
+          ['AAA', 1],
+          ['CCC', 3],
+        ]),
+        'desc'
+      )
+    ).toEqual(
+      new Map([
+        ['DDD', 4],
+        ['CCC', 3],
+        ['BBB', 2],
+        ['AAA', 1],
+      ])
+    );
+  });
+
+  it('can sort values', () => {
+    let sort = getSorter('value');
+
+    expect(
+      sort(
+        new Map([
+          ['DDD', 4],
+          ['BBB', 2],
+          ['AAA', 1],
+          ['CCC', 3],
+        ])
+      )
+    ).toEqual(
+      new Map([
+        ['AAA', 1],
+        ['BBB', 2],
+        ['CCC', 3],
+        ['DDD', 4],
+      ])
+    );
+  });
+
+  it('can sort values, desc', () => {
+    let sort = getSorter('value');
+
+    expect(
+      sort(
+        new Map([
+          ['DDD', 4],
+          ['BBB', 2],
+          ['AAA', 1],
+          ['CCC', 3],
+        ]),
+        'desc'
+      )
+    ).toEqual(
+      new Map([
+        ['DDD', 4],
+        ['CCC', 3],
+        ['BBB', 2],
+        ['AAA', 1],
+      ])
+    );
   });
 });

--- a/packages/checkup-formatter-pretty/package.json
+++ b/packages/checkup-formatter-pretty/package.json
@@ -31,7 +31,8 @@
     "@types/object-path": "^0.11.1",
     "@types/react": "^17.0.15",
     "@types/resolve": "^1.20.0",
-    "ink-testing-library": "^2.1.0"
+    "ink-testing-library": "^2.1.0",
+    "lodash.merge": "^4.6.2"
   },
   "engines": {
     "node": ">= 12.22.*"

--- a/packages/checkup-formatter-pretty/src/components/migration.tsx
+++ b/packages/checkup-formatter-pretty/src/components/migration.tsx
@@ -3,6 +3,13 @@ import { Box, Text } from 'ink';
 import { RuleResults } from '@checkup/core';
 import { Result } from 'sarif';
 import { TaskDisplayName } from '../sub-components/task-display-name';
+import { getOptions } from '../get-options';
+import { getSorter, SortBy, SortDirection } from '../get-sorter';
+
+type MigrationOptions = {
+  sortBy: SortBy;
+  sortDirection: SortDirection;
+};
 
 export const Migration: React.FC<{ taskResult: RuleResults }> = ({ taskResult }) => {
   let featureStatus = buildMigrationData(taskResult);
@@ -27,17 +34,16 @@ export const Migration: React.FC<{ taskResult: RuleResults }> = ({ taskResult })
 
 function buildMigrationData(taskResult: RuleResults) {
   const features = taskResult.rule.properties?.features || [];
+  const { rule, results } = taskResult;
+  const options = getOptions<MigrationOptions>(rule);
 
-  const aggregatedFeatureResults = taskResult.results.reduce(
-    (features: Map<string, number>, result: Result) => {
-      let feature = result.properties?.migration.feature;
+  let aggregatedFeatureResults = results.reduce((features: Map<string, number>, result: Result) => {
+    let feature = result.properties?.migration.feature;
 
-      features.set(feature, (features.get(feature) ?? 0) + 1);
+    features.set(feature, (features.get(feature) ?? 0) + 1);
 
-      return features;
-    },
-    new Map<string, number>()
-  );
+    return features;
+  }, new Map<string, number>());
 
   // Any feature that doesn't have results associated with it should indicate that
   // it's complete, or has no outstanding work.
@@ -45,6 +51,12 @@ function buildMigrationData(taskResult: RuleResults) {
     if (!aggregatedFeatureResults.get(feature)) {
       aggregatedFeatureResults.set(feature, 0);
     }
+  }
+
+  if (options.sortBy) {
+    let sort = getSorter(options.sortBy);
+
+    aggregatedFeatureResults = sort(aggregatedFeatureResults, options.sortDirection);
   }
 
   return aggregatedFeatureResults;

--- a/packages/checkup-formatter-pretty/src/get-sorter.ts
+++ b/packages/checkup-formatter-pretty/src/get-sorter.ts
@@ -1,0 +1,28 @@
+export type SortBy = 'key' | 'value';
+export type SortDirection = 'asc' | 'desc';
+
+export function getSorter(sortBy: SortBy = 'key') {
+  if (sortBy === 'key') {
+    // sorts aphabetically by key, ascending by default (normal alphabtical order)
+    return (subject: Map<string, number>, sortDirection: SortDirection = 'asc') => {
+      let sorted = [...subject.keys()].sort();
+
+      if (sortDirection === 'desc') {
+        sorted.reverse();
+      }
+
+      return new Map<string, number>(sorted.map((key) => [key, subject.get(key)!]));
+    };
+  }
+
+  // Sorts by the numerical value, descending by default
+  return (subject: Map<string, number>, sortDirection: SortDirection = 'desc') => {
+    let sorted = [...subject.entries()].sort((a, b) => a[1] - b[1]);
+
+    if (sortDirection === 'desc') {
+      sorted.reverse();
+    }
+
+    return new Map<string, number>(sorted);
+  };
+}

--- a/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
@@ -181,8 +181,14 @@ export default class EmberOctaneMigrationStatusTask extends BaseTask implements 
       properties: {
         component: {
           name: 'migration',
+          options: {
+            sortBy: 'value',
+            sortDirection: 'desc',
+          },
         },
-        features: Object.values(RULE_METADATA).map((ruleMetadata) => ruleMetadata.feature),
+        features: [
+          ...new Set(Object.values(RULE_METADATA).map((ruleMetadata) => ruleMetadata.feature)),
+        ],
       },
     });
 


### PR DESCRIPTION
Allows for migration Tasks to declaratively define the order of their rendered output for the pretty formatter.

Specifically, this now allows:

- sort by key, asc
- sort by key, desc
- sort by value, asc
- sort by value, desc

To define this in a component, you need to pass an additional `options` configuration into the rule metadata, for example:

```
this.addRule({
  properties: {
    component: {
      name: 'migration',
      options: {
        sortBy: 'value',
        sortDirection: 'desc',
      },
    },
    features: [...features],
  },
});
```