### PR TITLE
Fixing JavaScriptAnalyzer to handle esm. Adding tests

### DIFF
--- a/packages/core/__tests__/analyzers/javascript-analyzer-test.ts
+++ b/packages/core/__tests__/analyzers/javascript-analyzer-test.ts
@@ -1,0 +1,27 @@
+import JavaScriptAnalyzer from '../../src/analyzers/javascript-analyzer';
+
+describe('javascript-analyzer', () => {
+  it('can parse cjs modules', () => {
+    let source = `
+    const foo = require('foo');
+
+    foo();
+    `;
+
+    expect(() => {
+      new JavaScriptAnalyzer(source);
+    }).not.toThrow();
+  });
+
+  it('can parse esm modules', () => {
+    let source = `
+    import foo from './foo';
+
+    foo();
+    `;
+
+    expect(() => {
+      new JavaScriptAnalyzer(source);
+    }).not.toThrow();
+  });
+});

--- a/packages/core/__tests__/analyzers/json-analyzer-test.ts
+++ b/packages/core/__tests__/analyzers/json-analyzer-test.ts
@@ -1,0 +1,15 @@
+import JsonAnalyzer from '../../src/analyzers/json-analyzer';
+
+describe('json-analyzer', () => {
+  it('throws when given invalid JSON string', () => {
+    expect(() => {
+      new JsonAnalyzer('not valid');
+    }).toThrow();
+  });
+
+  it('can traverse JSON', () => {
+    expect(() => {
+      new JsonAnalyzer(JSON.stringify(['an', 'array'], null, 2));
+    }).not.toThrow();
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "@types/sarif": "^2.1.3",
     "@types/stylelint": "^9.10.1",
     "ajv": "^6.12.6",
+    "ast-types": "^0.14.2",
     "chalk": "^4.0.0",
     "ci-info": "^3.1.1",
     "clean-stack": "^3.0.1",

--- a/packages/core/src/analyzers/dependency-analyzer.ts
+++ b/packages/core/src/analyzers/dependency-analyzer.ts
@@ -1,4 +1,5 @@
 import * as npmCheck from 'npm-check';
+import { Visitor } from 'ast-types';
 import { getPackageJsonSource } from '../utils/get-package-json';
 import { Dependency, DependencyInfo } from '../types/dependency';
 import JsonAnalyzer from './json-analyzer';
@@ -70,10 +71,11 @@ export default class DependencyAnalyzer {
         this.dependencies = new Set();
       }
 
-      get visitors() {
+      get visitors(): Visitor<any> {
         let self = this;
+
         return {
-          ObjectProperty(path: any) {
+          visitObjectProperty: function (path: any) {
             let node: any = path.node;
             if (node.key.value === 'dependencies' && node.value.properties) {
               for (let property of node.value.properties) {
@@ -101,6 +103,8 @@ export default class DependencyAnalyzer {
                 });
               }
             }
+
+            this.traverse(path);
           },
         };
       }

--- a/packages/core/src/analyzers/javascript-analyzer.ts
+++ b/packages/core/src/analyzers/javascript-analyzer.ts
@@ -1,6 +1,6 @@
-import { File, Node } from '@babel/types';
-import * as parser from '@babel/parser';
-import traverse, { TraverseOptions } from '@babel/traverse';
+import * as t from '@babel/types';
+import { parse, visit } from 'recast';
+import { Visitor } from 'ast-types';
 import AstAnalyzer from './ast-analyzer';
 
 /**
@@ -11,12 +11,14 @@ import AstAnalyzer from './ast-analyzer';
  * @extends {AstAnalyzer}
  */
 export default class JavaScriptAnalyzer extends AstAnalyzer<
-  File,
-  TraverseOptions<Node>,
-  typeof parser.parse,
-  typeof traverse
+  t.File,
+  Visitor<any>,
+  typeof parse,
+  typeof visit
 > {
   constructor(source: string) {
-    super(source, parser.parse, traverse);
+    super(source, parse, visit, {
+      parser: require('recast/parsers/babel'),
+    });
   }
 }

--- a/packages/core/src/analyzers/json-analyzer.ts
+++ b/packages/core/src/analyzers/json-analyzer.ts
@@ -9,6 +9,12 @@ import JavaScriptAnalyzer from './javascript-analyzer';
  */
 export default class JsonAnalyzer extends JavaScriptAnalyzer {
   constructor(source: string) {
+    try {
+      JSON.parse(source);
+    } catch {
+      throw new Error('The JsonAnalyzer `source` parameter should be a valid JSON string');
+    }
+
     // In order to process JSON, we need to convert it to a module,
     // as babel cannot parse JSON natively.
     let jsonSource = `module.exports = ${source}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,7 +2421,7 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.14.2:
+ast-types@0.14.2, ast-types@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
   integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==


### PR DESCRIPTION
The current implementation of the `JavaScriptAnalyzer` didn't correctly handle esm, and would throw when import/export statements were used. This fix ensures esm is handled correctly, and additionally adds tests for other related analyzers.