### PR TITLE
Adding ruleId into eslint and ember-template-lint disable tasks

### DIFF
--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-disable-task.ts
@@ -49,6 +49,9 @@ export default class EmberTemplateLintDisableTask extends BaseTask implements Ta
           startColumn: disable.column,
           startLine: disable.line,
         },
+        properties: {
+          ruleId: disable.lintRuleId,
+        },
       });
     });
 

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -55,6 +55,9 @@ export default class EslintDisableTask extends BaseTask implements Task {
           startColumn: disable.column,
           startLine: disable.line,
         },
+        properties: {
+          ruleId: disable.lintRuleId,
+        },
       });
     });
 


### PR DESCRIPTION
Similar to #1124, this adds the underlying lint rule's `ruleId` to the disabled tasks.