### PR TITLE
Adds validation task base class and associated component

### DIFF
--- a/packages/checkup-formatter-pretty/__tests__/components/bar-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/components/bar-test.tsx
@@ -7,8 +7,8 @@ import { Bar } from '../../src/components/bar';
 
 const stripAnsi = require('strip-ansi');
 
-describe('Test table component', () => {
-  it('can render task result as expected via table component', async () => {
+describe('bar component', () => {
+  it('can render task result as expected via bar component', async () => {
     const log = readJsonSync(resolve(__dirname, '../__fixtures__/checkup-result.sarif'));
     const logParser = new CheckupLogParser(log);
     const taskResults = logParser.resultsByRule;

--- a/packages/checkup-formatter-pretty/__tests__/components/list-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/components/list-test.tsx
@@ -5,7 +5,7 @@ import { List } from '../../src/components/list';
 
 const stripAnsi = require('strip-ansi');
 
-describe('Test list component', () => {
+describe('list component', () => {
   it('can render task result as expected via list component', async () => {
     const taskResult: RuleResults = {
       rule: {

--- a/packages/checkup-formatter-pretty/__tests__/components/migration-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/components/migration-test.tsx
@@ -169,7 +169,7 @@ function getTaskResult(componentOptions = {}) {
   return merge({}, TASK_RESULT, componentOptions);
 }
 
-describe('Test Migration component', () => {
+describe('Migration component', () => {
   it('can render task result with no sort options', async () => {
     const { stdout } = render(<Migration taskResult={getTaskResult()} />);
 

--- a/packages/checkup-formatter-pretty/__tests__/components/table-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/components/table-test.tsx
@@ -5,7 +5,7 @@ import { Table } from '../../src/components/table';
 
 const stripAnsi = require('strip-ansi');
 
-describe('Test table component', () => {
+describe('table component', () => {
   it('can render task result as expected via table component', async () => {
     const taskResult: RuleResults = {
       rule: {

--- a/packages/checkup-formatter-pretty/__tests__/components/validation-test.tsx
+++ b/packages/checkup-formatter-pretty/__tests__/components/validation-test.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { render } from 'ink-testing-library';
+import { RuleResults } from '@checkup/core';
+import { Validation } from '../../src/components/validation';
+
+const stripAnsi = require('strip-ansi');
+
+const TASK_RESULT: RuleResults = {
+  rule: {
+    id: 'my-fake-validation',
+    shortDescription: {
+      text: 'description',
+    },
+    properties: {
+      taskDisplayName: 'Fake Validation',
+      category: 'foo',
+    },
+  },
+  results: [
+    {
+      message: {
+        text: 'Check the first thing',
+      },
+      ruleId: 'my-fake-validation',
+      kind: 'pass',
+      level: 'none',
+      ruleIndex: 0,
+    },
+    {
+      message: {
+        text: 'Check the second thing',
+      },
+      ruleId: 'my-fake-validation',
+      kind: 'pass',
+      level: 'none',
+      ruleIndex: 0,
+    },
+    {
+      message: {
+        text: 'Check the third thing',
+      },
+      ruleId: 'my-fake-validation',
+      kind: 'fail',
+      level: 'error',
+      ruleIndex: 0,
+    },
+  ],
+};
+
+describe('Validation component', () => {
+  it('can render task result', () => {
+    const { stdout } = render(<Validation taskResult={TASK_RESULT} />);
+
+    expect(stripAnsi(stdout.lastFrame()!)).toMatchInlineSnapshot(`
+"Fake Validation
+===============
+Validation failed
+  ✔ Check the first thing
+  ✔ Check the second thing
+  ✖ Check the third thing"
+`);
+  });
+});

--- a/packages/checkup-formatter-pretty/package.json
+++ b/packages/checkup-formatter-pretty/package.json
@@ -21,6 +21,7 @@
     "ink-table": "^3.0.0",
     "ink-task-list": "^1.1.0",
     "lodash.startcase": "^4.4.0",
+    "log-symbols": "^4.0.0",
     "object-path": "^0.11.7",
     "react": "^17.0.2",
     "strip-ansi": "^6.0.0"

--- a/packages/checkup-formatter-pretty/src/components/validation.tsx
+++ b/packages/checkup-formatter-pretty/src/components/validation.tsx
@@ -14,7 +14,7 @@ export const Validation: React.FC<{ taskResult: RuleResults }> = ({ taskResult }
       <Text>Validation {isValid ? 'passed' : 'failed'}</Text>
       <Box marginLeft={2} flexDirection="column">
         {[...taskResult.results].map((result) => {
-          return <ValidationStepItem result={result} />;
+          return <ValidationStepItem key={result.message.text} result={result} />;
         })}
       </Box>
     </>
@@ -25,7 +25,7 @@ const ValidationStepItem: React.FC<{ result: Result }> = ({ result }) => {
   let { message, kind } = result;
 
   return (
-    <Text key={message.text}>
+    <Text>
       {kind === 'pass' ? success : error} {message.text}
     </Text>
   );

--- a/packages/checkup-formatter-pretty/src/components/validation.tsx
+++ b/packages/checkup-formatter-pretty/src/components/validation.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Box, Text } from 'ink';
+import { RuleResults } from '@checkup/core';
+import { Result } from 'sarif';
+import { success, error } from 'log-symbols';
+import { TaskDisplayName } from '../sub-components/task-display-name';
+
+export const Validation: React.FC<{ taskResult: RuleResults }> = ({ taskResult }) => {
+  let isValid = taskResult.results.every((result) => result.kind === 'pass');
+
+  return (
+    <>
+      <TaskDisplayName taskResult={taskResult} />
+      <Text>Validation {isValid ? 'passed' : 'failed'}</Text>
+      <Box marginLeft={2} flexDirection="column">
+        {[...taskResult.results].map((result) => {
+          return <ValidationStepItem result={result} />;
+        })}
+      </Box>
+    </>
+  );
+};
+
+const ValidationStepItem: React.FC<{ result: Result }> = ({ result }) => {
+  let { message, kind } = result;
+
+  return (
+    <Text key={message.text}>
+      {kind === 'pass' ? success : error} {message.text}
+    </Text>
+  );
+};

--- a/packages/core/__tests__/base-validation-task-test.ts
+++ b/packages/core/__tests__/base-validation-task-test.ts
@@ -1,0 +1,175 @@
+import { getTaskContext } from '@checkup/test-helpers';
+import { Result } from 'sarif';
+import BaseValidationTask from '../src/base-validation-task';
+import { TaskContext } from '../src/types/tasks';
+
+class FakeValidationTask extends BaseValidationTask {
+  taskName = 'my-fake-validation';
+  taskDisplayName = 'Fake Validation';
+  description = 'description';
+  category = 'foo';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule();
+    this.addRuleComponentMetadata();
+
+    this.addValidationSteps();
+  }
+
+  addValidationSteps() {
+    this.addValidationStep('Check the first thing', () => {
+      return {
+        isValid: true,
+      };
+    });
+
+    this.addValidationStep('Check the second thing', () => {
+      return {
+        isValid: true,
+        options: {
+          location: {
+            uri: 'some/path/to/second.js',
+          },
+          properties: {
+            foo: 'bar',
+          },
+        },
+      };
+    });
+
+    this.addValidationStep('Check the third thing', () => {
+      return {
+        isValid: false,
+        options: {
+          location: {
+            uri: 'some/path/to/third.js',
+          },
+          properties: {
+            foo: 'bar',
+          },
+        },
+      };
+    });
+  }
+
+  async run(): Promise<Result[]> {
+    let stepResults = this.validate();
+
+    for (let [messageText, validationResult] of stepResults) {
+      this.addValidationResult(messageText, validationResult.isValid);
+    }
+
+    return this.results;
+  }
+}
+
+describe('BaseValidationTask', () => {
+  it('can add rule component metadata', () => {
+    let context: TaskContext = getTaskContext();
+
+    let fakeTask = new FakeValidationTask('fake validation', context);
+
+    expect(fakeTask.rule).toEqual({
+      id: 'my-fake-validation',
+      shortDescription: {
+        text: 'description',
+      },
+      properties: {
+        taskDisplayName: 'Fake Validation',
+        category: 'foo',
+        component: {
+          name: 'validation',
+        },
+      },
+    });
+  });
+
+  it('can add validation steps to a validation task', () => {
+    let context: TaskContext = getTaskContext();
+
+    let fakeTask = new FakeValidationTask('fake validation', context);
+
+    expect(fakeTask.validationSteps.size).toEqual(3);
+  });
+
+  it('can validate steps and return result', () => {
+    let context: TaskContext = getTaskContext();
+
+    let fakeTask = new FakeValidationTask('fake validation', context);
+
+    let steps = fakeTask.validate();
+
+    expect(steps.size).toEqual(3);
+    expect(steps).toMatchInlineSnapshot(`
+Map {
+  "Check the first thing" => Object {
+    "isValid": true,
+  },
+  "Check the second thing" => Object {
+    "isValid": true,
+    "options": Object {
+      "location": Object {
+        "uri": "some/path/to/second.js",
+      },
+      "properties": Object {
+        "foo": "bar",
+      },
+    },
+  },
+  "Check the third thing" => Object {
+    "isValid": false,
+    "options": Object {
+      "location": Object {
+        "uri": "some/path/to/third.js",
+      },
+      "properties": Object {
+        "foo": "bar",
+      },
+    },
+  },
+}
+`);
+  });
+
+  it('can add validation step results', async () => {
+    let context: TaskContext = getTaskContext();
+
+    let fakeTask = new FakeValidationTask('fake validation', context);
+
+    await fakeTask.run();
+
+    expect(fakeTask.log.runs[0].results).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "kind": "pass",
+    "level": "none",
+    "message": Object {
+      "text": "Check the first thing",
+    },
+    "ruleId": "my-fake-validation",
+    "ruleIndex": 0,
+  },
+  Object {
+    "kind": "pass",
+    "level": "none",
+    "message": Object {
+      "text": "Check the second thing",
+    },
+    "ruleId": "my-fake-validation",
+    "ruleIndex": 0,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "message": Object {
+      "text": "Check the third thing",
+    },
+    "ruleId": "my-fake-validation",
+    "ruleIndex": 0,
+  },
+]
+`);
+  });
+});

--- a/packages/core/src/base-migration-task.ts
+++ b/packages/core/src/base-migration-task.ts
@@ -10,8 +10,15 @@ export type Feature = {
   helpUri: string;
 };
 
+/**
+ * Creates a new instance of a BaseMigrationTask.
+ *
+ * @param migrationName The short name of the migration. Used to format result messages.
+ * @param pluginName The name of the plugin this task is included in.
+ * @param context The runtime task context passed to the Task.
+ */
 export default abstract class BaseMigrationTask extends BaseTask {
-  features: Map<FeatureId, Feature>;
+  protected features: Map<FeatureId, Feature>;
 
   /**
    * A list of feature names that represent this migration.
@@ -43,7 +50,7 @@ export default abstract class BaseMigrationTask extends BaseTask {
   /**
    * Adds componennt data to the rule metadata.
    */
-  addRuleComponentMetadata() {
+  protected addRuleComponentMetadata() {
     this.addRule({
       properties: {
         component: {
@@ -56,6 +63,7 @@ export default abstract class BaseMigrationTask extends BaseTask {
       },
     });
   }
+
   /**
    * Adds a feature definition to the Checkup rule metadata. Used for correctly associating features and results.
    *
@@ -65,7 +73,7 @@ export default abstract class BaseMigrationTask extends BaseTask {
    * @param feature.message - The user-friendly message
    * @param feature.helpUri - A URL to provide help documentation about the feature
    */
-  addFeature(featureId: FeatureId, feature: Feature) {
+  protected addFeature(featureId: FeatureId, feature: Feature) {
     this.features.set(featureId, feature);
 
     this.addRuleProperties({
@@ -85,7 +93,7 @@ export default abstract class BaseMigrationTask extends BaseTask {
    * @param options.location Specifies a location where the result occurred
    * @param options.properties A property bag named properties, which stores additional values on the result
    */
-  addFeatureResult(feature: Feature, options?: TaskResultOptions) {
+  protected addFeatureResult(feature: Feature, options?: TaskResultOptions) {
     this.addResult(
       `${this.migrationName} | ${feature.featureName} : ${feature.message}. More info: ${feature.helpUri}`,
       'review',

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -40,7 +40,7 @@ export default abstract class BaseTask {
   _logBuilder: CheckupLogBuilder;
 
   /**
-   * Creates a new instance of a Task.
+   * Creates a new instance of a BaseTask.
    *
    * @param pluginName The name of the plugin this task is included in.
    * @param context The runtime task context passed to the Task.

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -1,6 +1,6 @@
 import * as debug from 'debug';
 
-import { Location, PropertyBag, Result } from 'sarif';
+import { Location, PropertyBag, ReportingDescriptor, Result } from 'sarif';
 import { SetRequired } from 'type-fest';
 
 import {
@@ -28,6 +28,7 @@ export default abstract class BaseTask {
   abstract taskDisplayName: string;
   abstract description: string;
   abstract category: string;
+  rule?: ReportingDescriptor;
   group?: string;
   context: TaskContext;
   debug: debug.Debugger;
@@ -55,7 +56,17 @@ export default abstract class BaseTask {
   }
 
   /**
-   * An object containing optional configuration for this Task. Tasks can be
+   * Gets a reference to the SARIF log.
+   *
+   * @readonly
+   * @memberof BaseTask
+   */
+  get log() {
+    return this._logBuilder.log;
+  }
+
+  /**
+   * Gets an object containing optional configuration for this Task. Tasks can be
    * configured in the .checkuprc file.
    */
   get config() {
@@ -207,7 +218,7 @@ export default abstract class BaseTask {
       },
     };
 
-    taskRule = merge({}, ruleProps, additionalRuleProps);
+    this.rule = taskRule = merge({}, ruleProps, additionalRuleProps);
 
     this._logBuilder.addRule(taskRule);
 

--- a/packages/core/src/base-validation-task.ts
+++ b/packages/core/src/base-validation-task.ts
@@ -1,13 +1,13 @@
 import BaseTask from './base-task';
-import { TaskContext, TaskResultLocation, TaskResultOptions } from './types/tasks';
+import { TaskContext, TaskResultOptions } from './types/tasks';
 
 type ValidationResult = {
   isValid: boolean;
-  location?: TaskResultLocation;
+  options?: TaskResultOptions;
 };
 
 export default abstract class BaseValidationTask extends BaseTask {
-  private validationSteps: Map<string, () => ValidationResult>;
+  validationSteps: Map<string, () => ValidationResult>;
 
   /**
    * Creates a new instance of a validation Task.
@@ -49,7 +49,7 @@ export default abstract class BaseValidationTask extends BaseTask {
    *
    * @returns A map of messages and ValidationResult objects
    */
-  protected validate() {
+  validate() {
     let results = new Map<string, ValidationResult>();
 
     for (let [messageText, validate] of this.validationSteps) {

--- a/packages/core/src/base-validation-task.ts
+++ b/packages/core/src/base-validation-task.ts
@@ -1,0 +1,77 @@
+import BaseTask from './base-task';
+import { TaskContext, TaskResultLocation, TaskResultOptions } from './types/tasks';
+
+type ValidationResult = {
+  isValid: boolean;
+  location?: TaskResultLocation;
+};
+
+export default abstract class BaseValidationTask extends BaseTask {
+  private validationSteps: Map<string, () => ValidationResult>;
+
+  /**
+   * Creates a new instance of a validation Task.
+   *
+   * @param pluginName The name of the plugin this task is included in.
+   * @param context The runtime task context passed to the Task.
+   */
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.validationSteps = new Map();
+  }
+
+  /**
+   * Adds componennt data to the rule metadata.
+   */
+  protected addRuleComponentMetadata() {
+    this.addRule({
+      properties: {
+        component: {
+          name: 'validation',
+        },
+      },
+    });
+  }
+
+  /**
+   * Adds a validation step to be run during this class' validate method.
+   *
+   * @param messageText A non-empty string containing a plain text message
+   * @param validate A function to run that returns a {ValidationResult} indicating whether the validation was successful.
+   */
+  protected addValidationStep(messageText: string, validate: () => ValidationResult) {
+    this.validationSteps.set(messageText, validate);
+  }
+
+  /**
+   * Validates each step added by addValidationStep.
+   *
+   * @returns A map of messages and ValidationResult objects
+   */
+  protected validate() {
+    let results = new Map<string, ValidationResult>();
+
+    for (let [messageText, validate] of this.validationSteps) {
+      results.set(messageText, validate());
+    }
+
+    return results;
+  }
+
+  /**
+   * Adds a validation-specific result object to the Checkup output.  '
+   *
+   * @param messageText A non-empty string containing a plain text message
+   * @param isValid - A boolean indicating whether the validation step is valid.
+   * @param options Additional options to pass to the result
+   * @param options.location Specifies a location where the result occurred
+   * @param options.properties A property bag named properties, which stores additional values on the result   */
+  protected addValidationResult(
+    messageText: string,
+    isValid: boolean,
+    options?: TaskResultOptions
+  ) {
+    this.addResult(messageText, isValid ? 'pass' : 'fail', isValid ? 'none' : 'error', options);
+  }
+}

--- a/packages/core/src/base-validation-task.ts
+++ b/packages/core/src/base-validation-task.ts
@@ -1,7 +1,7 @@
 import BaseTask from './base-task';
 import { TaskContext, TaskResultOptions } from './types/tasks';
 
-type ValidationResult = {
+export type ValidationResult = {
   isValid: boolean;
   options?: TaskResultOptions;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { default as BaseTask } from './base-task';
 export { default as BaseMigrationTask } from './base-migration-task';
+export { default as BaseValidationTask } from './base-validation-task';
 
 export { getRegisteredActions, registerActions } from './actions/registered-actions';
 export { default as ActionsEvaluator } from './actions/actions-evaluator';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { default as BaseTask } from './base-task';
-export { default as BaseMigrationTask } from './base-migration-task';
-export { default as BaseValidationTask } from './base-validation-task';
+export { default as BaseMigrationTask, Feature, FeatureId } from './base-migration-task';
+export { default as BaseValidationTask, ValidationResult } from './base-validation-task';
 
 export { getRegisteredActions, registerActions } from './actions/registered-actions';
 export { default as ActionsEvaluator } from './actions/actions-evaluator';


### PR DESCRIPTION
This PR supersedes #855, which started the implementation of the validation task base class, but stalled due to its coupling with the addition of a validate command (which was decided against).

This adds the following:

1. A new `BaseValidationTask` class with associated APIs that make it easy to add validation-based tasks
2. A new `validation` component in the pretty formatter to output the validation steps.

The APIs allow you to add a validation step, which is defined using the following signature:

```ts
type ValidationResult = {
  isValid: boolean;
  options?: TaskResultOptions;
};

addValidationStep(messageText: string, validate: () => ValidationResult);
```

A `validate` function consists of a function that returns whether the computation performed within it was valid or not. It's also possible to pass additional information back, which could pertain to AST-based location information, or arbitrary data via a property bag. This data is then passed through to the `addValidationResult` method, which adds results to the SARIF log with the correct `kind` and `level` properties set.

Example:

```ts
class FakeValidationTask extends BaseValidationTask {
  taskName = 'my-fake-validation';
  taskDisplayName = 'Fake Validation';
  description = 'description';
  category = 'foo';

  constructor(pluginName: string, context: TaskContext) {
    super(pluginName, context);

    this.addRule();
    this.addRuleComponentMetadata();

    this.addValidationSteps();
  }

  addValidationSteps() {
    this.addValidationStep('Check the first thing', () => {
      return {
        isValid: true,
      };
    });

    this.addValidationStep('Check the second thing', () => {
      return {
        isValid: true,
        options: {
          location: {
            uri: 'some/path/to/second.js',
          },
          properties: {
            foo: 'bar',
          },
        },
      };
    });

    this.addValidationStep('Check the third thing', () => {
      return {
        isValid: false,
        options: {
          location: {
            uri: 'some/path/to/third.js',
          },
          properties: {
            foo: 'bar',
          },
        },
      };
    });
  }

  async run(): Promise<Result[]> {
    let stepResults = this.validate();

    for (let [messageText, validationResult] of stepResults) {
      this.addValidationResult(messageText, validationResult.isValid);
    }

    return this.results;
  }
}
```

And the sample pretty formatter output:

```sh-session
Fake Validation
===============
Validation failed
  ✔ Check the first thing
  ✔ Check the second thing
  ✖ Check the third thing
```