### PR TITLE
Fixes base-task jsdoc generating invalid syntax for docs (mdx)

### DIFF
--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -97,7 +97,7 @@ export default abstract class BaseTask {
   /**
    * The fully qualified name for this task, in the format
    *
-   * <pluginName>/<taskName>
+   * pluginName/taskName
    */
   get fullyQualifiedTaskName() {
     return `${this._pluginName}/${this.taskName}`;


### PR DESCRIPTION
The syntax currently used for the jsdoc comment causes a syntax error when used via mdx rendering.