### PR TITLE
Adds valid-esm-package-task

### DIFF
--- a/packages/checkup-plugin-javascript/__tests__/valid-esm-package-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/valid-esm-package-task-test.ts
@@ -1,0 +1,72 @@
+import { CheckupProject, getTaskContext } from '@checkup/test-helpers';
+import { getPluginName } from '@checkup/core';
+import ValidEsmPackageTask from '../src/tasks/valid-esm-package-task';
+
+describe('valid-esm-package-task', () => {
+  let project: CheckupProject;
+  let pluginName = getPluginName(__dirname);
+
+  beforeEach(() => {
+    project = new CheckupProject('checkup-app', '0.0.0');
+
+    project.writeSync();
+    project.gitInit();
+  });
+
+  afterEach(() => {
+    project.dispose();
+  });
+
+  it('valid esm package passes validation', async () => {
+    project.write({
+      'index.js': `function foo() { console.log('foo'); }`,
+    });
+    project.updatePackageJson({
+      name: 'fake-package',
+      type: 'module',
+      exports: './index.js',
+      description: '',
+      version: '0.1.0',
+      engines: {
+        node: '>=13.2.0',
+      },
+      dependencies: {},
+      devDependencies: {},
+    });
+
+    const results = await new ValidEsmPackageTask(
+      pluginName,
+      getTaskContext({
+        options: { cwd: project.baseDir },
+        pkg: project.pkg,
+      })
+    ).run();
+
+    expect(results.filter((result) => result.kind === 'pass')).toHaveLength(5);
+  });
+
+  it('invalid esm package fails validation', async () => {
+    project.write({
+      'index.js': `"use strict";
+  function foo() { console.log('foo'); }`,
+    });
+    project.updatePackageJson({
+      name: 'fake-package',
+      main: './index.js',
+      description: '',
+      version: '0.1.0',
+      dependencies: {},
+      devDependencies: {},
+    });
+
+    const results = await new ValidEsmPackageTask(
+      pluginName,
+      getTaskContext({
+        options: { cwd: project.baseDir },
+        pkg: project.pkg,
+      })
+    ).run();
+
+    expect(results.filter((result) => result.kind === 'fail')).toHaveLength(5);
+  });
+});

--- a/packages/checkup-plugin-javascript/package.json
+++ b/packages/checkup-plugin-javascript/package.json
@@ -27,12 +27,14 @@
     "ember-template-recast": "^5.0.3",
     "npm-check": "^5.9.2",
     "recast": "^0.20.5",
+    "semver": "^7.3.5",
     "sloc": "^0.2.1",
     "tslib": "^2"
   },
   "devDependencies": {
     "@checkup/plugin": "^1.3.0",
     "@checkup/test-helpers": "^1.3.0",
+    "@types/semver": "^7.3.9",
     "fixturify-project": "^2.1.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/checkup-plugin-javascript/src/index.ts
+++ b/packages/checkup-plugin-javascript/src/index.ts
@@ -4,6 +4,7 @@ import EslintDisableTask from './tasks/eslint-disable-task';
 import EslintSummaryTask from './tasks/eslint-summary-task';
 import OutdatedDependencyTask from './tasks/outdated-dependencies-task';
 import LinesOfCodeTask from './tasks/lines-of-code-task';
+import ValidEsmPackageTask from './tasks/valid-esm-package-task';
 import { evaluateActions as evaluateESLintDisables } from './actions/eslint-disable-actions';
 import { evaluateActions as evaluateESLintSummary } from './actions/eslint-summary-actions';
 import { evaluateActions as evaluateOutdatedDependencies } from './actions/outdated-dependency-actions';
@@ -19,4 +20,5 @@ export function register(args: RegistrationArgs) {
   args.register.task(new EslintDisableTask(pluginName, args.context));
   args.register.task(new OutdatedDependencyTask(pluginName, args.context));
   args.register.task(new LinesOfCodeTask(pluginName, args.context));
+  args.register.task(new ValidEsmPackageTask(pluginName, args.context));
 }

--- a/packages/checkup-plugin-javascript/src/tasks/valid-esm-package-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/valid-esm-package-task.ts
@@ -1,0 +1,113 @@
+import {
+  BaseValidationTask,
+  ESLintAnalyzer,
+  ESLintOptions,
+  Task,
+  TaskContext,
+} from '@checkup/core';
+import { satisfies } from 'semver';
+import { Result } from 'sarif';
+
+const ESLINT_CONFIG: ESLintOptions = {
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      legacyDecorators: true,
+    },
+  },
+  rules: {
+    strict: ['error', 'never'],
+  },
+  useEslintrc: false,
+  allowInlineConfig: false,
+  ignore: false,
+};
+
+export default class ValidEsmPackageTask extends BaseValidationTask implements Task {
+  taskName = 'valid-esm-package';
+  taskDisplayName = 'Valid ESM Package';
+  description = 'Validates whether a project is a valid ESM package';
+  category = 'validation';
+
+  constructor(pluginName: string, context: TaskContext) {
+    super(pluginName, context);
+
+    this.addRule({
+      properties: {
+        component: {
+          name: 'validation',
+        },
+      },
+    });
+
+    this.addValidationSteps();
+  }
+
+  private addValidationSteps() {
+    let pkg = this.context.pkg;
+
+    this.addValidationStep('Contains "type" property set to "module" in package.json', () => {
+      return {
+        isValid: !!(pkg.type && pkg.type === 'module'),
+      };
+    });
+
+    this.addValidationStep('Does not contain a "main" property in package.json', () => {
+      return {
+        isValid: !('main' in pkg),
+      };
+    });
+
+    this.addValidationStep(
+      'Contains an "exports" property set to a valid value in package.json',
+      () => {
+        let exports = pkg.exports;
+        return {
+          isValid: !!(
+            exports &&
+            (typeof exports === 'string' ||
+              (Array.isArray(exports) && exports.every((value) => typeof value === 'string')) ||
+              (typeof exports === 'object' && exports !== null))
+          ),
+        };
+      }
+    );
+
+    this.addValidationStep(
+      'Requires at least Node 13 in the "engines" property of package.json',
+      () => {
+        // Node 13.2.0 was the first Node version that shipped with ESM without the --experimental-module flag.
+        return {
+          isValid: !!(
+            pkg.engines &&
+            pkg.engines['node'] &&
+            satisfies('13.2.0', pkg.engines['node'])
+          ),
+        };
+      }
+    );
+
+    this.addValidationStep('Should not have "use strict" in any JavaScript files', async () => {
+      let analyzer = new ESLintAnalyzer(ESLINT_CONFIG);
+
+      let { results } = await analyzer.analyze(this.context.paths.filterByGlob('**/*.js'));
+      let hasErrors = results.some((result) => result.messages.length > 0);
+
+      return {
+        isValid: !hasErrors,
+      };
+    });
+  }
+
+  async run(): Promise<Result[]> {
+    let validationResults = await this.validate();
+
+    for (let [messageText, validationResult] of validationResults) {
+      this.addValidationResult(messageText, validationResult.isValid);
+    }
+
+    return this.results;
+  }
+}

--- a/packages/core/__tests__/base-validation-task-test.ts
+++ b/packages/core/__tests__/base-validation-task-test.ts
@@ -55,7 +55,7 @@ class FakeValidationTask extends BaseValidationTask {
   }
 
   async run(): Promise<Result[]> {
-    let stepResults = this.validate();
+    let stepResults = await this.validate();
 
     for (let [messageText, validationResult] of stepResults) {
       this.addValidationResult(messageText, validationResult.isValid);
@@ -94,12 +94,12 @@ describe('BaseValidationTask', () => {
     expect(fakeTask.validationSteps.size).toEqual(3);
   });
 
-  it('can validate steps and return result', () => {
+  it('can validate steps and return result', async () => {
     let context: TaskContext = getTaskContext();
 
     let fakeTask = new FakeValidationTask('fake validation', context);
 
-    let steps = fakeTask.validate();
+    let steps = await fakeTask.validate();
 
     expect(steps.size).toEqual(3);
     expect(steps).toMatchInlineSnapshot(`

--- a/packages/core/src/base-validation-task.ts
+++ b/packages/core/src/base-validation-task.ts
@@ -7,7 +7,7 @@ export type ValidationResult = {
 };
 
 export default abstract class BaseValidationTask extends BaseTask {
-  validationSteps: Map<string, () => ValidationResult>;
+  validationSteps: Map<string, () => ValidationResult | Promise<ValidationResult>>;
 
   /**
    * Creates a new instance of a validation Task.
@@ -40,7 +40,10 @@ export default abstract class BaseValidationTask extends BaseTask {
    * @param messageText A non-empty string containing a plain text message
    * @param validate A function to run that returns a {ValidationResult} indicating whether the validation was successful.
    */
-  protected addValidationStep(messageText: string, validate: () => ValidationResult) {
+  protected addValidationStep(
+    messageText: string,
+    validate: () => ValidationResult | Promise<ValidationResult>
+  ) {
     this.validationSteps.set(messageText, validate);
   }
 
@@ -49,11 +52,11 @@ export default abstract class BaseValidationTask extends BaseTask {
    *
    * @returns A map of messages and ValidationResult objects
    */
-  validate() {
+  async validate() {
     let results = new Map<string, ValidationResult>();
 
     for (let [messageText, validate] of this.validationSteps) {
-      results.set(messageText, validate());
+      results.set(messageText, await validate());
     }
 
     return results;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@types/sloc@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@types/sloc/-/sloc-0.2.0.tgz#bf1518cfc5ce325d6e92655fed42863a6399456c"


### PR DESCRIPTION
Adds a new validation task for validating ESM packages.

Validation output:

```sh-session
Checkup ran the following task(s) successfully:

Valid ESM Package
=================
Validation passed
  ✔ Contains "type" property set to "module" in package.json
  ✔ Does not contain a "main" property in package.json
  ✔ Contains an "exports" property set to a valid value in package.json
  ✔ Requires at least Node 13.2.0 in the "engines" property of package.json
  ✔ Should not have "use strict" in any JavaScript files
```

Uses heuristic from https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c to determine if a package is a valid ESM package.