### PR TITLE
[enhancement] Adding non-fatal errors to tasks

### DIFF
--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -108,9 +108,8 @@ describe('eslint-disable-task', () => {
     await task.run();
 
     expect(task.nonFatalErrors).toHaveLength(1);
-    expect(task.nonFatalErrors![0]).toMatchInlineSnapshot(
-      // eslint-disable-next-line jest/no-interpolation-in-snapshots
-      `[SyntaxError: Error occurred at ${project.root}/foo/error-file.js. Unexpected token (9:18)]`
+    expect(task.nonFatalErrors[0].message).toEqual(
+      `Error occurred at ${project.root}/foo/error-file.js. Unexpected token (9:18)`
     );
   });
 });

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -79,4 +79,38 @@ describe('eslint-disable-task', () => {
       }
     `);
   });
+
+  it('captures a non-fatal error for nonparsable files', async () => {
+    project.files['error-file.js'] = `
+      let config;
+
+      try {
+        const metaName = '{{MODULE_PREFIX}}/config/environment';
+        const rawConfig = document.querySelector('meta[name="' + metaName + '"]').getAttribute('content');
+        config = JSON.parse(unescape(rawConfig));
+      } catch(err) {
+        config = {{CONFIG_CONTENTS}};
+      }
+
+      export default config;
+    `;
+
+    project.writeSync();
+
+    const task = new EslintDisableTask(
+      pluginName,
+      getTaskContext({
+        paths: project.filePaths,
+        options: { cwd: project.baseDir },
+      })
+    );
+
+    await task.run();
+
+    expect(task.nonFatalErrors).toHaveLength(1);
+    expect(task.nonFatalErrors![0]).toMatchInlineSnapshot(
+      // eslint-disable-next-line jest/no-interpolation-in-snapshots
+      `[SyntaxError: Error occurred at ${project.root}/foo/error-file.js. Unexpected token (9:18)]`
+    );
+  });
 });

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -116,8 +116,10 @@ export default class EslintDisableTask extends BaseTask implements Task {
             analyzer.analyze(accumulator.visitors);
             data.push(...accumulator.data);
           } catch (error) {
-            (error as Error).message = `Error occurred at ${filePath}. ${(error as Error).message}`;
-            this.addNonFatalError(error as Error);
+            if (error instanceof Error) {
+              error.message = `Error occurred at ${filePath}. ${error.message}`;
+            }
+            this.addNonFatalError(error);
           }
         });
       })

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -187,7 +187,7 @@ export default class TaskListImpl implements RegisterableTaskList {
       result = await this._runTask(task);
       this.addErrors(task.fullyQualifiedTaskName, task.nonFatalErrors);
     } catch (error) {
-      this.addError(task.fullyQualifiedTaskName, error);
+      this.addErrors(task.fullyQualifiedTaskName, error);
     }
 
     this.debug('%s run done', task.fullyQualifiedTaskName);
@@ -211,7 +211,7 @@ export default class TaskListImpl implements RegisterableTaskList {
         result = await this._runTask(task);
         this.addErrors(task.fullyQualifiedTaskName, task.nonFatalErrors);
       } catch (error) {
-        this.addError(task.fullyQualifiedTaskName, error);
+        this.addErrors(task.fullyQualifiedTaskName, error);
       }
 
       this.debug('%s run done', task.fullyQualifiedTaskName);
@@ -281,13 +281,11 @@ export default class TaskListImpl implements RegisterableTaskList {
     return values;
   }
 
-  private addError(taskName: TaskName, error: Error) {
-    this._errors.push({ taskName, error });
-  }
+  private addErrors(taskName: TaskName, errors: Error | Error[]) {
+    const errorsArr = Array.isArray(errors) ? errors : [errors];
 
-  private addErrors(taskName: TaskName, errors: Error[]) {
     this._errors.push(
-      ...errors.map((error) => {
+      ...errorsArr.map((error) => {
         return {
           error,
           taskName,

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -185,6 +185,7 @@ export default class TaskListImpl implements RegisterableTaskList {
 
     try {
       result = await this._runTask(task);
+      this.addErrors(task.fullyQualifiedTaskName, task.nonFatalErrors);
     } catch (error) {
       this.addError(task.fullyQualifiedTaskName, error);
     }
@@ -208,6 +209,7 @@ export default class TaskListImpl implements RegisterableTaskList {
 
       try {
         result = await this._runTask(task);
+        this.addErrors(task.fullyQualifiedTaskName, task.nonFatalErrors);
       } catch (error) {
         this.addError(task.fullyQualifiedTaskName, error);
       }
@@ -219,7 +221,7 @@ export default class TaskListImpl implements RegisterableTaskList {
     return [(results.flat().filter(Boolean) as Result[]).sort(taskResultComparator), this._errors];
   }
 
-  private async _runTask(task: Task) {
+  private async _runTask(task: Task): Promise<Result[]> {
     let t = process.hrtime();
     let result = await task.run();
     t = process.hrtime(t);
@@ -281,5 +283,16 @@ export default class TaskListImpl implements RegisterableTaskList {
 
   private addError(taskName: TaskName, error: Error) {
     this._errors.push({ taskName, error });
+  }
+
+  private addErrors(taskName: TaskName, errors: Error[]) {
+    this._errors.push(
+      ...errors.map((error) => {
+        return {
+          error,
+          taskName,
+        };
+      })
+    );
   }
 }

--- a/packages/cli/src/task-list.ts
+++ b/packages/cli/src/task-list.ts
@@ -282,10 +282,10 @@ export default class TaskListImpl implements RegisterableTaskList {
   }
 
   private addErrors(taskName: TaskName, errors: Error | Error[]) {
-    const errorsArr = Array.isArray(errors) ? errors : [errors];
+    errors = Array.isArray(errors) ? errors : [errors];
 
     this._errors.push(
-      ...errorsArr.map((error) => {
+      ...errors.map((error) => {
         return {
           error,
           taskName,

--- a/packages/core/src/analyzers/ast-analyzer.ts
+++ b/packages/core/src/analyzers/ast-analyzer.ts
@@ -29,15 +29,7 @@ export default class AstAnalyzer<
   }
 
   private _parse(source: string): TAst {
-    let ast: TAst;
-
-    try {
-      ast = this.parser(source, this.parserOptions);
-    } catch (error) {
-      throw new Error(error);
-    }
-
-    return ast;
+    return this.parser(source, this.parserOptions);
   }
 
   analyze(visitors: TVisitors) {

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -33,6 +33,7 @@ export default abstract class BaseTask {
   context: TaskContext;
   debug: debug.Debugger;
   results: Result[];
+  nonFatalErrors: Error[];
 
   _pluginName: string;
   _config!: TaskConfig;
@@ -49,6 +50,7 @@ export default abstract class BaseTask {
   constructor(pluginName: string, context: TaskContext) {
     this.context = context;
     this.results = [];
+    this.nonFatalErrors = [];
     this._pluginName = getShorthandName(pluginName);
     this._logBuilder = context.logBuilder;
 
@@ -240,5 +242,14 @@ export default abstract class BaseTask {
     }
 
     merge(rule.properties, properties);
+  }
+
+  /**
+   * Adds non-fatal error encountered while running a task to the SARIF log.
+   *
+   * @param error - A non-fatal {Error} thrown while the task was run
+   */
+  public addNonFatalError(error: Error) {
+    this.nonFatalErrors.push(error);
   }
 }

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -45,6 +45,7 @@ export interface Task {
   description: string;
   config: TaskConfig;
   results: Result[];
+  nonFatalErrors: Error[];
   category: string;
   group?: string;
 


### PR DESCRIPTION
## Rationale: 
Previously, when a single file could not be parsed correctly, the entire eslint-disable task would fail. We want to notify our consumers when a file can not be parsed, or when any error occurs when analyzing a single file, but we dont necessarily want that to cause the whole task to fail. It is now up to the author of a task whether they just want to throw an error when a failure is caught, or just add a nonFatalError, which are all collected at the end and pushed to the `toolExecutionNotifications`.

## Implementation: 

Added new public function `addNonFatalError` to base-task, and collected the nonFatalErrors in task-list with the other (fatal) errors. This approach pushes the responsibility of handling failures in the analyzers onto the task authors, giving them full control of how they want to handle what happens when a file cant be analyzed (for some tasks, I imagine failure to read/parse a file to be fatal, and for the desired behavior to be a task erroring out completely). With this change, made required changes to eslint-disable task (the only task using the AstAnalyzer right now).