### PR TITLE
backwards incompatibility issue introduced in 1.4.0

### DIFF
--- a/packages/core/src/data/checkup-log-builder.ts
+++ b/packages/core/src/data/checkup-log-builder.ts
@@ -115,7 +115,7 @@ export default class CheckupLogBuilder extends SarifLogBuilder {
           id: error.taskName,
         },
         exception: {
-          message: error.error.message,
+          message: error.error?.message,
           stack: {
             frames: stackFrames,
           },


### PR DESCRIPTION
this fixes #1142 

without fix (running task with v 1.0.1 of @checkup/core): 
```
➜  checkup run . --task a11y-violations-summary
yarn run v1.22.4
$ checkup run . --task a11y-violations-summary

Error Cannot read property 'message' of undefined
✨  Done in 6.54s.
``` 

with fix (running task with v 1.0.1 of @checkup/core): 
```
➜  checkup run . --task a11y-violations-summary
yarn run v1.22.4
$ checkup run . --task a11y-violations-summary

Checkup report generated for sample v0.0.0-productSpec (5925 files analyzed)

This project is 3 years, 4 months old, with 774 active days, 4073 commits and 5915 files.

Checkup ran the following task(s) successfully:
✔ a11y-violations-summary

Results have been saved to the following file:
/Users/jsmith/project/checkup-report-2021-11-29-13_32_54.sarif

checkup v1.4.0
config 2534dc0de3ca2d6dee4d7e783212a993


✨  Done in 5.45s.

``` 

