### PR TITLE
Skip unused dependency check to avoid depcheck open file spike

### DIFF
--- a/packages/core/src/analyzers/dependency-analyzer.ts
+++ b/packages/core/src/analyzers/dependency-analyzer.ts
@@ -58,7 +58,7 @@ export default class DependencyAnalyzer {
   }
 
   async loadOutdatedDependencies(): Promise<NpmCheckDependency[]> {
-    let result = await npmCheck({ cwd: this.baseDir });
+    let result = await npmCheck({ cwd: this.baseDir, skipUnused: true });
 
     return result.get('packages');
   }


### PR DESCRIPTION
From `npm-check` docs:

> #### `-s, --skip-unused`
>
> By default `npm-check` will let you know if any of your modules are not being used by looking at `require` statements in your code.
>
> This option will skip that check. 

Checkup doesn't use this info when calculating out-of-date dependencies, and it causes a big spike in open files due to how `depcheck` works internally.

This PR is a small change to avoid that.