### PR TITLE
Adds dependabot auto-merge configuration

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.AUTO_MERGE }}

--- a/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
@@ -48,37 +48,28 @@ describe('outdated-dependencies-task', () => {
   it('returns correct action items if too many dependencies are out of date (and additional actions for minor/major out of date)', async () => {
     let actions = evaluateActions(results, task.config);
 
-    expect(actions).toHaveLength(3);
+    expect(actions).toHaveLength(2);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "defaultThreshold": 0.05,
-          "details": "1 major versions outdated",
-          "input": 0.5,
-          "items": Array [],
-          "name": "reduce-outdated-major-dependencies",
-          "summary": "Update outdated major versions",
-          "taskName": "outdated-dependencies",
-        },
-        Object {
-          "defaultThreshold": 0.05,
-          "details": "1 minor versions outdated",
-          "input": 0.5,
-          "items": Array [],
-          "name": "reduce-outdated-minor-dependencies",
-          "summary": "Update outdated minor versions",
-          "taskName": "outdated-dependencies",
-        },
-        Object {
-          "defaultThreshold": 0.2,
-          "details": "100% of versions outdated",
-          "input": 1,
-          "items": Array [],
-          "name": "reduce-outdated-dependencies",
-          "summary": "Update outdated versions",
-          "taskName": "outdated-dependencies",
-        },
-      ]
-    `);
+Array [
+  Object {
+    "defaultThreshold": 0.05,
+    "details": "2 major versions outdated",
+    "input": 1,
+    "items": Array [],
+    "name": "reduce-outdated-major-dependencies",
+    "summary": "Update outdated major versions",
+    "taskName": "outdated-dependencies",
+  },
+  Object {
+    "defaultThreshold": 0.2,
+    "details": "100% of versions outdated",
+    "input": 1,
+    "items": Array [],
+    "name": "reduce-outdated-dependencies",
+    "summary": "Update outdated versions",
+    "taskName": "outdated-dependencies",
+  },
+]
+`);
   });
 });


### PR DESCRIPTION
This PR adds dependabot [auto-merge](https://github.com/marketplace/actions/dependabot-auto-merge) to the repository.

Please ensure you have creacted a GitHub token called `AUTO_MERGE` as per the instructions [here](https://github.com/marketplace/actions/dependabot-auto-merge#token-scope).

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖