### PR TITLE
Update jest to use printBasicPrototype for snapshotFormat

### DIFF
--- a/packages/checkup-formatter-pretty/jest.config.js
+++ b/packages/checkup-formatter-pretty/jest.config.js
@@ -15,5 +15,8 @@ module.exports = {
     },
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   testPathIgnorePatterns: ['/__utils__/', '__fixtures__'],
 };

--- a/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-octane-migration-status-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/__tests__/__snapshots__/ember-octane-migration-status-task-test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ember-octane-migration-status-task detects octane migration status for non-octane addon and outputs to json 1`] = `
-Array [
-  Object {
+[
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 25,
             "endLine": 2,
             "startColumn": 16,
@@ -20,11 +20,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Use Glimmer components over classic Ember Components. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -32,16 +32,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -50,11 +50,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -62,16 +62,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -80,11 +80,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Tagless Components",
         "name": "Octane",
       },
@@ -92,16 +92,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 27,
             "endLine": 9,
             "startColumn": 11,
@@ -110,11 +110,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Do not use \\"classic\\" Ember component lifecycle hooks.. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-lifecycle",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -122,16 +122,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 44,
             "endLine": 10,
             "startColumn": 24,
@@ -140,11 +140,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native ES5 getters instead of \`get\` / \`getProperties\` on Ember objects. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__get-and-set",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -152,16 +152,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 12,
             "endLine": 19,
             "startColumn": 11,
@@ -170,11 +170,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Do not use the actions hash and {{action}} modifier and helper. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#actions__actions",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -182,16 +182,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 25,
             "endLine": 2,
             "startColumn": 16,
@@ -200,11 +200,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Use Glimmer components over classic Ember Components. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -212,16 +212,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -230,11 +230,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -242,16 +242,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -260,11 +260,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Tagless Components",
         "name": "Octane",
       },
@@ -272,16 +272,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 27,
             "endLine": 9,
             "startColumn": 11,
@@ -290,11 +290,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Do not use \\"classic\\" Ember component lifecycle hooks.. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-lifecycle",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -302,16 +302,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 44,
             "endLine": 10,
             "startColumn": 24,
@@ -320,11 +320,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native ES5 getters instead of \`get\` / \`getProperties\` on Ember objects. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__get-and-set",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -332,16 +332,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 12,
             "endLine": 19,
             "startColumn": 11,
@@ -350,11 +350,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Do not use the actions hash and {{action}} modifier and helper. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#actions__actions",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -362,16 +362,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/routes/my-route.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 5,
             "startColumn": 24,
@@ -380,11 +380,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -392,16 +392,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/services/my-service.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 10,
             "startColumn": 24,
@@ -410,11 +410,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -422,16 +422,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/services/my-service.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 40,
             "endLine": 8,
             "startColumn": 25,
@@ -440,11 +440,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native ES5 getters instead of \`get\` / \`getProperties\` on Ember objects. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__get-and-set",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -452,16 +452,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 38,
             "endLine": 2,
             "startColumn": 10,
@@ -470,11 +470,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -482,16 +482,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 44,
             "endLine": 3,
             "startColumn": 10,
@@ -500,11 +500,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -512,16 +512,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 36,
             "endLine": 2,
             "startColumn": 33,
@@ -530,11 +530,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -542,16 +542,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 42,
             "endLine": 3,
             "startColumn": 39,
@@ -560,11 +560,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -572,16 +572,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/my-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 37,
             "endLine": 2,
             "startColumn": 18,
@@ -590,11 +590,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Modifiers : Do not use \`action\`. Instead, use the \`on\` modifier and \`fn\` helper. More info: https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Modifiers",
         "name": "Octane",
       },
@@ -602,16 +602,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/my-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 22,
             "endLine": 3,
             "startColumn": 10,
@@ -620,11 +620,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -632,16 +632,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/my-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 20,
             "endLine": 3,
             "startColumn": 12,
@@ -650,11 +650,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -662,16 +662,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/other-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 22,
             "endLine": 2,
             "startColumn": 10,
@@ -680,11 +680,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -692,16 +692,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "addon/templates/other-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 20,
             "endLine": 2,
             "startColumn": 12,
@@ -710,11 +710,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -726,17 +726,17 @@ Array [
 `;
 
 exports[`ember-octane-migration-status-task detects octane migration status for non-octane app and outputs to json 1`] = `
-Array [
-  Object {
+[
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 25,
             "endLine": 2,
             "startColumn": 16,
@@ -745,11 +745,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Use Glimmer components over classic Ember Components. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -757,16 +757,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -775,11 +775,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -787,16 +787,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -805,11 +805,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Tagless Components",
         "name": "Octane",
       },
@@ -817,16 +817,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 27,
             "endLine": 9,
             "startColumn": 11,
@@ -835,11 +835,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Do not use \\"classic\\" Ember component lifecycle hooks.. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-lifecycle",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -847,16 +847,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 44,
             "endLine": 10,
             "startColumn": 24,
@@ -865,11 +865,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native ES5 getters instead of \`get\` / \`getProperties\` on Ember objects. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__get-and-set",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -877,16 +877,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/my-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 12,
             "endLine": 19,
             "startColumn": 11,
@@ -895,11 +895,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Do not use the actions hash and {{action}} modifier and helper. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#actions__actions",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -907,16 +907,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 25,
             "endLine": 2,
             "startColumn": 16,
@@ -925,11 +925,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Use Glimmer components over classic Ember Components. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -937,16 +937,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -955,11 +955,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -967,16 +967,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 20,
             "startColumn": 24,
@@ -985,11 +985,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Tagless Components",
         "name": "Octane",
       },
@@ -997,16 +997,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 27,
             "endLine": 9,
             "startColumn": 11,
@@ -1015,11 +1015,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Glimmer Components : Do not use \\"classic\\" Ember component lifecycle hooks.. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-lifecycle",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Glimmer Components",
         "name": "Octane",
       },
@@ -1027,16 +1027,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 44,
             "endLine": 10,
             "startColumn": 24,
@@ -1045,11 +1045,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native ES5 getters instead of \`get\` / \`getProperties\` on Ember objects. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__get-and-set",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -1057,16 +1057,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/components/other-component.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 12,
             "endLine": 19,
             "startColumn": 11,
@@ -1075,11 +1075,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Do not use the actions hash and {{action}} modifier and helper. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#actions__actions",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -1087,16 +1087,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/routes/my-route.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 5,
             "startColumn": 24,
@@ -1105,11 +1105,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -1117,16 +1117,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/services/my-service.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 11,
             "endLine": 10,
             "startColumn": 24,
@@ -1135,11 +1135,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -1147,16 +1147,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/services/my-service.js",
           },
-          "region": Object {
+          "region": {
             "endColumn": 40,
             "endLine": 8,
             "startColumn": 25,
@@ -1165,11 +1165,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Native Classes : Use native ES5 getters instead of \`get\` / \`getProperties\` on Ember objects. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__get-and-set",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Native Classes",
         "name": "Octane",
       },
@@ -1177,16 +1177,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 38,
             "endLine": 2,
             "startColumn": 10,
@@ -1195,11 +1195,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -1207,16 +1207,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 44,
             "endLine": 3,
             "startColumn": 10,
@@ -1225,11 +1225,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -1237,16 +1237,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 36,
             "endLine": 2,
             "startColumn": 33,
@@ -1255,11 +1255,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -1267,16 +1267,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/application.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 42,
             "endLine": 3,
             "startColumn": 39,
@@ -1285,11 +1285,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -1297,16 +1297,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/my-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 37,
             "endLine": 2,
             "startColumn": 18,
@@ -1315,11 +1315,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Modifiers : Do not use \`action\`. Instead, use the \`on\` modifier and \`fn\` helper. More info: https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Modifiers",
         "name": "Octane",
       },
@@ -1327,16 +1327,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/my-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 22,
             "endLine": 3,
             "startColumn": 10,
@@ -1345,11 +1345,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -1357,16 +1357,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/my-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 20,
             "endLine": 3,
             "startColumn": 12,
@@ -1375,11 +1375,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -1387,16 +1387,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/other-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 22,
             "endLine": 2,
             "startColumn": 10,
@@ -1405,11 +1405,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Angle Bracket Syntax : Use angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__angle-brackets",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Angle Bracket Syntax",
         "name": "Octane",
       },
@@ -1417,16 +1417,16 @@ Array [
     "ruleId": "ember-octane-migration-status",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "review",
     "level": "warning",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "app/templates/other-component.hbs",
           },
-          "region": Object {
+          "region": {
             "endColumn": 20,
             "endLine": 2,
             "startColumn": 12,
@@ -1435,11 +1435,11 @@ Array [
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Octane | Own Properties : Use \`this\` when referring to properties owned by the component. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__template-this",
     },
-    "properties": Object {
-      "migration": Object {
+    "properties": {
+      "migration": {
         "featureName": "Own Properties",
         "name": "Octane",
       },
@@ -1450,6 +1450,6 @@ Array [
 ]
 `;
 
-exports[`ember-octane-migration-status-task detects octane migration status for octane addon and outputs to json 1`] = `Array []`;
+exports[`ember-octane-migration-status-task detects octane migration status for octane addon and outputs to json 1`] = `[]`;
 
-exports[`ember-octane-migration-status-task detects octane migration status for octane app and outputs to json 1`] = `Array []`;
+exports[`ember-octane-migration-status-task detects octane migration status for octane app and outputs to json 1`] = `[]`;

--- a/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-template-lint-disable-task-test.ts
@@ -55,19 +55,19 @@ describe('ember-template-lint-disable-task', () => {
 
     expect(actions).toHaveLength(1);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "defaultThreshold": 2,
-          "details": "3 usages of template-lint-disable",
-          "input": 3,
-          "items": Array [
-            "Total template-lint-disable usages: 3",
-          ],
-          "name": "reduce-template-lint-disable-usages",
-          "summary": "Reduce number of template-lint-disable usages",
-          "taskName": "ember-template-lint-disable",
-        },
-      ]
-    `);
+[
+  {
+    "defaultThreshold": 2,
+    "details": "3 usages of template-lint-disable",
+    "input": 3,
+    "items": [
+      "Total template-lint-disable usages: 3",
+    ],
+    "name": "reduce-template-lint-disable-usages",
+    "summary": "Reduce number of template-lint-disable usages",
+    "taskName": "ember-template-lint-disable",
+  },
+]
+`);
   });
 });

--- a/packages/checkup-plugin-ember/__tests__/ember-template-lint-summary-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-template-lint-summary-task-test.ts
@@ -97,30 +97,30 @@ describe('ember-emplate-lint-summary-task', () => {
 
     expect(actions).toHaveLength(2);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "defaultThreshold": 20,
-          "details": "3 total errors",
-          "input": 3,
-          "items": Array [
-            "Total template-lint errors: 3",
-          ],
-          "name": "reduce-template-lint-errors",
-          "summary": "Reduce number of template-lint errors",
-          "taskName": "ember-template-lint-summary",
-        },
-        Object {
-          "defaultThreshold": 20,
-          "details": "1 total warnings",
-          "input": 1,
-          "items": Array [
-            "Total template-lint warnings: 1",
-          ],
-          "name": "reduce-template-lint-warnings",
-          "summary": "Reduce number of template-lin warnings",
-          "taskName": "ember-template-lint-summary",
-        },
-      ]
-    `);
+[
+  {
+    "defaultThreshold": 20,
+    "details": "3 total errors",
+    "input": 3,
+    "items": [
+      "Total template-lint errors: 3",
+    ],
+    "name": "reduce-template-lint-errors",
+    "summary": "Reduce number of template-lint errors",
+    "taskName": "ember-template-lint-summary",
+  },
+  {
+    "defaultThreshold": 20,
+    "details": "1 total warnings",
+    "input": 1,
+    "items": [
+      "Total template-lint warnings: 1",
+    ],
+    "name": "reduce-template-lint-warnings",
+    "summary": "Reduce number of template-lin warnings",
+    "taskName": "ember-template-lint-summary",
+  },
+]
+`);
   });
 });

--- a/packages/checkup-plugin-ember/__tests__/ember-test-types-task-test.ts
+++ b/packages/checkup-plugin-ember/__tests__/ember-test-types-task-test.ts
@@ -157,19 +157,19 @@ describe('ember-test-types-task', () => {
 
     expect(actions).toHaveLength(1);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "defaultThreshold": 0.01,
-          "details": "67% of tests are skipped",
-          "input": 0.6666666666666666,
-          "items": Array [
-            "Total skipped tests: 8",
-          ],
-          "name": "reduce-skipped-tests",
-          "summary": "Reduce number of skipped tests",
-          "taskName": "ember-test-types",
-        },
-      ]
-    `);
+[
+  {
+    "defaultThreshold": 0.01,
+    "details": "67% of tests are skipped",
+    "input": 0.6666666666666666,
+    "items": [
+      "Total skipped tests: 8",
+    ],
+    "name": "reduce-skipped-tests",
+    "summary": "Reduce number of skipped tests",
+    "taskName": "ember-test-types",
+  },
+]
+`);
   });
 });

--- a/packages/checkup-plugin-ember/jest.config.js
+++ b/packages/checkup-plugin-ember/jest.config.js
@@ -15,5 +15,8 @@ module.exports = {
     },
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   testPathIgnorePatterns: ['/__utils__/', '__fixtures__'],
 };

--- a/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-disable-task-test.ts
@@ -66,18 +66,18 @@ describe('eslint-disable-task', () => {
 
     expect(actions).toHaveLength(1);
     expect(actions![0]).toMatchInlineSnapshot(`
-      Object {
-        "defaultThreshold": 2,
-        "details": "2 usages of eslint-disable",
-        "input": 2,
-        "items": Array [
-          "Total eslint-disable usages: 2",
-        ],
-        "name": "reduce-eslint-disable-usages",
-        "summary": "Reduce number of eslint-disable usages",
-        "taskName": "eslint-disable",
-      }
-    `);
+{
+  "defaultThreshold": 2,
+  "details": "2 usages of eslint-disable",
+  "input": 2,
+  "items": [
+    "Total eslint-disable usages: 2",
+  ],
+  "name": "reduce-eslint-disable-usages",
+  "summary": "Reduce number of eslint-disable usages",
+  "taskName": "eslint-disable",
+}
+`);
   });
 
   it('captures a non-fatal error for nonparsable files', async () => {

--- a/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/eslint-summary-task-test.ts
@@ -99,31 +99,31 @@ describe('eslint-summary-task', () => {
 
     expect(actions).toHaveLength(2);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "defaultThreshold": 20,
-          "details": "1 total errors",
-          "input": 1,
-          "items": Array [
-            "Total eslint errors: 1",
-          ],
-          "name": "reduce-eslint-errors",
-          "summary": "Reduce number of eslint errors",
-          "taskName": "eslint-summary",
-        },
-        Object {
-          "defaultThreshold": 20,
-          "details": "1 total warnings",
-          "input": 1,
-          "items": Array [
-            "Total eslint warnings: 1",
-          ],
-          "name": "reduce-eslint-warnings",
-          "summary": "Reduce number of eslint warnings",
-          "taskName": "eslint-summary",
-        },
-      ]
-    `);
+[
+  {
+    "defaultThreshold": 20,
+    "details": "1 total errors",
+    "input": 1,
+    "items": [
+      "Total eslint errors: 1",
+    ],
+    "name": "reduce-eslint-errors",
+    "summary": "Reduce number of eslint errors",
+    "taskName": "eslint-summary",
+  },
+  {
+    "defaultThreshold": 20,
+    "details": "1 total warnings",
+    "input": 1,
+    "items": [
+      "Total eslint warnings: 1",
+    ],
+    "name": "reduce-eslint-warnings",
+    "summary": "Reduce number of eslint warnings",
+    "taskName": "eslint-summary",
+  },
+]
+`);
   });
 
   describe('readEslintConfig', () => {

--- a/packages/checkup-plugin-javascript/__tests__/lines-of-code-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/lines-of-code-task-test.ts
@@ -30,23 +30,23 @@ describe('lines-of-code-task', () => {
     ).run();
 
     expect(result).toMatchInlineSnapshot(`
-Array [
-  Object {
+[
+  {
     "kind": "informational",
     "level": "note",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "index.hbs",
           },
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Lines of code count for index.hbs - total lines: 1",
     },
-    "properties": Object {
+    "properties": {
       "extension": "hbs",
       "filePath": "index.hbs",
       "lines": 1,
@@ -54,22 +54,22 @@ Array [
     "ruleId": "lines-of-code",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "informational",
     "level": "note",
-    "locations": Array [
-      Object {
-        "physicalLocation": Object {
-          "artifactLocation": Object {
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
             "uri": "index.js",
           },
         },
       },
     ],
-    "message": Object {
+    "message": {
       "text": "Lines of code count for index.js - total lines: 1",
     },
-    "properties": Object {
+    "properties": {
       "extension": "js",
       "filePath": "index.js",
       "lines": 1,

--- a/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
+++ b/packages/checkup-plugin-javascript/__tests__/outdated-dependencies-task-test.ts
@@ -50,21 +50,21 @@ describe('outdated-dependencies-task', () => {
 
     expect(actions).toHaveLength(2);
     expect(actions).toMatchInlineSnapshot(`
-Array [
-  Object {
+[
+  {
     "defaultThreshold": 0.05,
     "details": "2 major versions outdated",
     "input": 1,
-    "items": Array [],
+    "items": [],
     "name": "reduce-outdated-major-dependencies",
     "summary": "Update outdated major versions",
     "taskName": "outdated-dependencies",
   },
-  Object {
+  {
     "defaultThreshold": 0.2,
     "details": "100% of versions outdated",
     "input": 1,
-    "items": Array [],
+    "items": [],
     "name": "reduce-outdated-dependencies",
     "summary": "Update outdated versions",
     "taskName": "outdated-dependencies",

--- a/packages/checkup-plugin-javascript/jest.config.js
+++ b/packages/checkup-plugin-javascript/jest.config.js
@@ -15,5 +15,8 @@ module.exports = {
     },
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   testPathIgnorePatterns: ['/__utils__/', '__fixtures__'],
 };

--- a/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
+++ b/packages/cli/__tests__/generators/__snapshots__/generate-plugin-test.ts.snap
@@ -136,19 +136,19 @@ export function register(args: RegistrationArgs) {
 exports[`plugin generator generates plugin into existing directory with defaults 9`] = `""`;
 
 exports[`plugin generator generates plugin into existing directory with defaults 10`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin into existing directory with defaults 11`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin into existing directory with defaults 12`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
@@ -269,19 +269,19 @@ module.exports = {
 exports[`plugin generator generates plugin with JavaScript defaults 8`] = `""`;
 
 exports[`plugin generator generates plugin with JavaScript defaults 9`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with JavaScript defaults 10`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with JavaScript defaults 11`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
@@ -422,19 +422,19 @@ export function register(args: RegistrationArgs) {
 exports[`plugin generator generates plugin with custom options 9`] = `""`;
 
 exports[`plugin generator generates plugin with custom options 10`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with custom options 11`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with custom options 12`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
@@ -575,19 +575,19 @@ export function register(args: RegistrationArgs) {
 exports[`plugin generator generates plugin with defaults 9`] = `""`;
 
 exports[`plugin generator generates plugin with defaults 10`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with defaults 11`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with defaults 12`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
@@ -728,19 +728,19 @@ export function register(args: RegistrationArgs) {
 exports[`plugin generator generates plugin with defaults in custom path 9`] = `""`;
 
 exports[`plugin generator generates plugin with defaults in custom path 10`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with defaults in custom path 11`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with defaults in custom path 12`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
@@ -881,19 +881,19 @@ export function register(args: RegistrationArgs) {
 exports[`plugin generator generates plugin with unmodified name with defaults 9`] = `""`;
 
 exports[`plugin generator generates plugin with unmodified name with defaults 10`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with unmodified name with defaults 11`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;
 
 exports[`plugin generator generates plugin with unmodified name with defaults 12`] = `
-Array [
+[
   ".gitkeep",
 ]
 `;

--- a/packages/cli/__tests__/task-list-test.ts
+++ b/packages/cli/__tests__/task-list-test.ts
@@ -290,20 +290,20 @@ describe('TaskList', () => {
     let [result, errors] = await taskList.runTask('insights-task-high');
 
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "bar",
-            "group": "group1",
-            "taskDisplayName": "Insights Task High",
-          },
-          "ruleId": "insights-task-high",
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "bar",
+      "group": "group1",
+      "taskDisplayName": "Insights Task High",
+    },
+    "ruleId": "insights-task-high",
+  },
+]
+`);
     expect(errors).toHaveLength(0);
   });
 
@@ -352,31 +352,31 @@ describe('TaskList', () => {
     let [results, errors] = await taskList.runTasks();
 
     expect(results).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "foo",
-            "group": "group2",
-            "taskDisplayName": "Insights Task Low",
-          },
-          "ruleId": "insights-task-low",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "bar",
-            "group": "group1",
-            "taskDisplayName": "Insights Task High",
-          },
-          "ruleId": "insights-task-high",
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "foo",
+      "group": "group2",
+      "taskDisplayName": "Insights Task Low",
+    },
+    "ruleId": "insights-task-low",
+  },
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "bar",
+      "group": "group1",
+      "taskDisplayName": "Insights Task High",
+    },
+    "ruleId": "insights-task-high",
+  },
+]
+`);
     expect(errors).toHaveLength(0);
   });
 
@@ -393,75 +393,75 @@ describe('TaskList', () => {
     let [results, errors] = await taskList.runTasks();
 
     expect(results).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "foo",
-            "group": "group2",
-            "taskDisplayName": "Insights Task Low",
-          },
-          "ruleId": "insights-task-low",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "bar",
-            "group": "group1",
-            "taskDisplayName": "Insights Task High",
-          },
-          "ruleId": "insights-task-high",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "foo",
-            "group": undefined,
-            "taskDisplayName": "Migration Task High",
-          },
-          "ruleId": "migration-task-high",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "baz",
-            "group": undefined,
-            "taskDisplayName": "Recommendations Task High",
-          },
-          "ruleId": "recommendations-task-high",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "baz",
-            "group": undefined,
-            "taskDisplayName": "Migration Task Low",
-          },
-          "ruleId": "migration-task-low",
-        },
-        Object {
-          "message": Object {
-            "text": "hi",
-          },
-          "properties": Object {
-            "category": "bar",
-            "group": undefined,
-            "taskDisplayName": "Recommendations Task Low",
-          },
-          "ruleId": "recommendations-task-low",
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "foo",
+      "group": "group2",
+      "taskDisplayName": "Insights Task Low",
+    },
+    "ruleId": "insights-task-low",
+  },
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "bar",
+      "group": "group1",
+      "taskDisplayName": "Insights Task High",
+    },
+    "ruleId": "insights-task-high",
+  },
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "foo",
+      "group": undefined,
+      "taskDisplayName": "Migration Task High",
+    },
+    "ruleId": "migration-task-high",
+  },
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "baz",
+      "group": undefined,
+      "taskDisplayName": "Recommendations Task High",
+    },
+    "ruleId": "recommendations-task-high",
+  },
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "baz",
+      "group": undefined,
+      "taskDisplayName": "Migration Task Low",
+    },
+    "ruleId": "migration-task-low",
+  },
+  {
+    "message": {
+      "text": "hi",
+    },
+    "properties": {
+      "category": "bar",
+      "group": undefined,
+      "taskDisplayName": "Recommendations Task Low",
+    },
+    "ruleId": "recommendations-task-low",
+  },
+]
+`);
     expect(errors).toHaveLength(0);
   });
 

--- a/packages/cli/__tests__/task-result-comparator-test.ts
+++ b/packages/cli/__tests__/task-result-comparator-test.ts
@@ -13,75 +13,75 @@ describe('taskResultComparator', () => {
     ];
 
     expect(results.sort(taskResultComparator)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "metrics",
-            "group": "",
-            "taskDisplayName": "baz",
-            "taskName": "baz",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "best practices",
-            "group": "",
-            "taskDisplayName": "bag",
-            "taskName": "bag",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "dependencies",
-            "group": "",
-            "taskDisplayName": "bad",
-            "taskName": "bad",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "linting",
-            "group": "",
-            "taskDisplayName": "foo",
-            "taskName": "foo",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "testing",
-            "group": "",
-            "taskDisplayName": "bar",
-            "taskName": "bar",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "migrations",
-            "group": "",
-            "taskDisplayName": "fod",
-            "taskName": "fod",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "metrics",
+      "group": "",
+      "taskDisplayName": "baz",
+      "taskName": "baz",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "best practices",
+      "group": "",
+      "taskDisplayName": "bag",
+      "taskName": "bag",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "dependencies",
+      "group": "",
+      "taskDisplayName": "bad",
+      "taskName": "bad",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "linting",
+      "group": "",
+      "taskDisplayName": "foo",
+      "taskName": "foo",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "testing",
+      "group": "",
+      "taskDisplayName": "bar",
+      "taskName": "bar",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "migrations",
+      "group": "",
+      "taskDisplayName": "fod",
+      "taskName": "fod",
+    },
+  },
+]
+`);
   });
 
   it('should sort task results with custom category by category with no group', () => {
@@ -96,86 +96,86 @@ describe('taskResultComparator', () => {
     ];
 
     expect(results.sort(taskResultComparator)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "metrics",
-            "group": "",
-            "taskDisplayName": "baz",
-            "taskName": "baz",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "best practices",
-            "group": "",
-            "taskDisplayName": "bag",
-            "taskName": "bag",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "dependencies",
-            "group": "",
-            "taskDisplayName": "bad",
-            "taskName": "bad",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "linting",
-            "group": "",
-            "taskDisplayName": "foo",
-            "taskName": "foo",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "testing",
-            "group": "",
-            "taskDisplayName": "fod",
-            "taskName": "fod",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "custom category2",
-            "group": "",
-            "taskDisplayName": "bar",
-            "taskName": "bar",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "custom category",
-            "group": "",
-            "taskDisplayName": "bar",
-            "taskName": "bar",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "metrics",
+      "group": "",
+      "taskDisplayName": "baz",
+      "taskName": "baz",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "best practices",
+      "group": "",
+      "taskDisplayName": "bag",
+      "taskName": "bag",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "dependencies",
+      "group": "",
+      "taskDisplayName": "bad",
+      "taskName": "bad",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "linting",
+      "group": "",
+      "taskDisplayName": "foo",
+      "taskName": "foo",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "testing",
+      "group": "",
+      "taskDisplayName": "fod",
+      "taskName": "fod",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "custom category2",
+      "group": "",
+      "taskDisplayName": "bar",
+      "taskName": "bar",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "custom category",
+      "group": "",
+      "taskDisplayName": "bar",
+      "taskName": "bar",
+    },
+  },
+]
+`);
   });
 
   it('should sort task results by category with group', () => {
@@ -189,75 +189,75 @@ describe('taskResultComparator', () => {
     ];
 
     expect(results.sort(taskResultComparator)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "metrics",
-            "group": "",
-            "taskDisplayName": "baz",
-            "taskName": "baz",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "best practices",
-            "group": "lint",
-            "taskDisplayName": "fod",
-            "taskName": "fod",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "best practices",
-            "group": "lint",
-            "taskDisplayName": "bad",
-            "taskName": "bad",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "best practices",
-            "group": "",
-            "taskDisplayName": "bar",
-            "taskName": "bar",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "dependencies",
-            "group": "",
-            "taskDisplayName": "bag",
-            "taskName": "bag",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "linting",
-            "group": "",
-            "taskDisplayName": "foo",
-            "taskName": "foo",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "metrics",
+      "group": "",
+      "taskDisplayName": "baz",
+      "taskName": "baz",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "best practices",
+      "group": "lint",
+      "taskDisplayName": "fod",
+      "taskName": "fod",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "best practices",
+      "group": "lint",
+      "taskDisplayName": "bad",
+      "taskName": "bad",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "best practices",
+      "group": "",
+      "taskDisplayName": "bar",
+      "taskName": "bar",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "dependencies",
+      "group": "",
+      "taskDisplayName": "bag",
+      "taskName": "bag",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "linting",
+      "group": "",
+      "taskDisplayName": "foo",
+      "taskName": "foo",
+    },
+  },
+]
+`);
   });
 
   it('should sort task results with custom category by category with group', () => {
@@ -271,74 +271,74 @@ describe('taskResultComparator', () => {
     ];
 
     expect(results.sort(taskResultComparator)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "metrics",
-            "group": "",
-            "taskDisplayName": "baz",
-            "taskName": "baz",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "best practices",
-            "group": "",
-            "taskDisplayName": "bar",
-            "taskName": "bar",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "dependencies",
-            "group": "",
-            "taskDisplayName": "bad",
-            "taskName": "bad",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "linting",
-            "group": "",
-            "taskDisplayName": "foo",
-            "taskName": "foo",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "grouped linting",
-            "group": "lint",
-            "taskDisplayName": "fod",
-            "taskName": "fod",
-          },
-        },
-        Object {
-          "message": Object {
-            "text": "hey",
-          },
-          "properties": Object {
-            "category": "grouped linting2",
-            "group": "lint",
-            "taskDisplayName": "bag",
-            "taskName": "bag",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "metrics",
+      "group": "",
+      "taskDisplayName": "baz",
+      "taskName": "baz",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "best practices",
+      "group": "",
+      "taskDisplayName": "bar",
+      "taskName": "bar",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "dependencies",
+      "group": "",
+      "taskDisplayName": "bad",
+      "taskName": "bad",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "linting",
+      "group": "",
+      "taskDisplayName": "foo",
+      "taskName": "foo",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "grouped linting",
+      "group": "lint",
+      "taskDisplayName": "fod",
+      "taskName": "fod",
+    },
+  },
+  {
+    "message": {
+      "text": "hey",
+    },
+    "properties": {
+      "category": "grouped linting2",
+      "group": "lint",
+      "taskDisplayName": "bag",
+      "taskName": "bag",
+    },
+  },
+]
+`);
   });
 });

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -17,5 +17,8 @@ module.exports = {
     },
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   testPathIgnorePatterns: ['/__utils__/', '/__fixtures__/'],
 };

--- a/packages/core/__tests__/analyzers/ember-template-lint-analyzer-test.ts
+++ b/packages/core/__tests__/analyzers/ember-template-lint-analyzer-test.ts
@@ -11,18 +11,18 @@ describe('ember-template-lint-analyzer', () => {
 
     expect(analyzer.engine).toBeInstanceOf(TemplateLinter);
     expect(Object.keys(analyzer.engine.config)).toMatchInlineSnapshot(`
-      Array [
-        "rules",
-        "pending",
-        "overrides",
-        "ignore",
-        "extends",
-        "plugins",
-        "loadedRules",
-        "loadedConfigurations",
-        "_processed",
-      ]
-    `);
+[
+  "rules",
+  "pending",
+  "overrides",
+  "ignore",
+  "extends",
+  "plugins",
+  "loadedRules",
+  "loadedConfigurations",
+  "_processed",
+]
+`);
   });
 
   it('can create an ember-template-lint analyzer with custom rule configuration', () => {
@@ -37,10 +37,10 @@ describe('ember-template-lint-analyzer', () => {
 
     expect(analyzer.engine).toBeInstanceOf(TemplateLinter);
     expect(optionsForRule).toMatchInlineSnapshot(`
-      Object {
-        "config": 6,
-        "severity": 2,
-      }
-    `);
+{
+  "config": 6,
+  "severity": 2,
+}
+`);
   });
 });

--- a/packages/core/__tests__/analyzers/eslint-analyzer-test.ts
+++ b/packages/core/__tests__/analyzers/eslint-analyzer-test.ts
@@ -24,19 +24,19 @@ describe('eslint-analyzer', () => {
 
     expect(analyzer.engine).toBeInstanceOf(CLIEngine);
     expect(Object.keys(configForFile)).toMatchInlineSnapshot(`
-      Array [
-        "env",
-        "globals",
-        "noInlineConfig",
-        "parser",
-        "parserOptions",
-        "plugins",
-        "reportUnusedDisableDirectives",
-        "rules",
-        "settings",
-        "ignorePatterns",
-      ]
-    `);
+[
+  "env",
+  "globals",
+  "noInlineConfig",
+  "parser",
+  "parserOptions",
+  "plugins",
+  "reportUnusedDisableDirectives",
+  "rules",
+  "settings",
+  "ignorePatterns",
+]
+`);
   });
 
   it('can create an eslint analyzer with custom rule configuration', () => {
@@ -65,12 +65,12 @@ describe('eslint-analyzer', () => {
 
     expect(analyzer.engine).toBeInstanceOf(CLIEngine);
     expect(configForFile.rules!['no-tabs']).toMatchInlineSnapshot(`
-      Array [
-        "error",
-        Object {
-          "allowIndentationTabs": true,
-        },
-      ]
-    `);
+[
+  "error",
+  {
+    "allowIndentationTabs": true,
+  },
+]
+`);
   });
 });

--- a/packages/core/__tests__/base-task-test.ts
+++ b/packages/core/__tests__/base-task-test.ts
@@ -69,32 +69,32 @@ describe('BaseTask', () => {
       let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
       expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-              Array [
-                Object {
-                  "id": "my-fake",
-                  "properties": Object {
-                    "category": "foo",
-                    "taskDisplayName": "Fake",
-                  },
-                  "shortDescription": Object {
-                    "text": "description",
-                  },
-                },
-              ]
-          `);
+[
+  {
+    "id": "my-fake",
+    "properties": {
+      "category": "foo",
+      "taskDisplayName": "Fake",
+    },
+    "shortDescription": {
+      "text": "description",
+    },
+  },
+]
+`);
       expect(run.results).toMatchInlineSnapshot(`
-              Array [
-                Object {
-                  "kind": "informational",
-                  "level": "note",
-                  "message": Object {
-                    "text": "The is a fake message",
-                  },
-                  "ruleId": "my-fake",
-                  "ruleIndex": 0,
-                },
-              ]
-          `);
+[
+  {
+    "kind": "informational",
+    "level": "note",
+    "message": {
+      "text": "The is a fake message",
+    },
+    "ruleId": "my-fake",
+    "ruleIndex": 0,
+  },
+]
+`);
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
@@ -112,41 +112,41 @@ describe('BaseTask', () => {
       let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
       expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-              Array [
-                Object {
-                  "id": "my-fake",
-                  "properties": Object {
-                    "category": "foo",
-                    "taskDisplayName": "Fake",
-                  },
-                  "shortDescription": Object {
-                    "text": "description",
-                  },
-                },
-              ]
-          `);
+[
+  {
+    "id": "my-fake",
+    "properties": {
+      "category": "foo",
+      "taskDisplayName": "Fake",
+    },
+    "shortDescription": {
+      "text": "description",
+    },
+  },
+]
+`);
       expect(run.results).toMatchInlineSnapshot(`
-              Array [
-                Object {
-                  "kind": "informational",
-                  "level": "note",
-                  "locations": Array [
-                    Object {
-                      "physicalLocation": Object {
-                        "artifactLocation": Object {
-                          "uri": "path/to/file.js",
-                        },
-                      },
-                    },
-                  ],
-                  "message": Object {
-                    "text": "The is a fake message",
-                  },
-                  "ruleId": "my-fake",
-                  "ruleIndex": 0,
-                },
-              ]
-          `);
+[
+  {
+    "kind": "informational",
+    "level": "note",
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "path/to/file.js",
+          },
+        },
+      },
+    ],
+    "message": {
+      "text": "The is a fake message",
+    },
+    "ruleId": "my-fake",
+    "ruleIndex": 0,
+  },
+]
+`);
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
@@ -164,47 +164,47 @@ describe('BaseTask', () => {
       let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
       expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-              Array [
-                Object {
-                  "id": "my-fake",
-                  "properties": Object {
-                    "category": "foo",
-                    "taskDisplayName": "Fake",
-                  },
-                  "shortDescription": Object {
-                    "text": "description",
-                  },
-                },
-              ]
-          `);
+[
+  {
+    "id": "my-fake",
+    "properties": {
+      "category": "foo",
+      "taskDisplayName": "Fake",
+    },
+    "shortDescription": {
+      "text": "description",
+    },
+  },
+]
+`);
       expect(run.results).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "kind": "informational",
-            "level": "note",
-            "locations": Array [
-              Object {
-                "physicalLocation": Object {
-                  "artifactLocation": Object {
-                    "uri": "path/to/file.js",
-                  },
-                  "region": Object {
-                    "endColumn": 1,
-                    "endLine": 1,
-                    "startColumn": 1,
-                    "startLine": 1,
-                  },
-                },
-              },
-            ],
-            "message": Object {
-              "text": "The is a fake message",
-            },
-            "ruleId": "my-fake",
-            "ruleIndex": 0,
+[
+  {
+    "kind": "informational",
+    "level": "note",
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "path/to/file.js",
           },
-        ]
-      `);
+          "region": {
+            "endColumn": 1,
+            "endLine": 1,
+            "startColumn": 1,
+            "startLine": 1,
+          },
+        },
+      },
+    ],
+    "message": {
+      "text": "The is a fake message",
+    },
+    "ruleId": "my-fake",
+    "ruleIndex": 0,
+  },
+]
+`);
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
@@ -221,32 +221,32 @@ describe('BaseTask', () => {
     let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
     expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "id": "my-fake",
-          "properties": Object {
-            "category": "foo",
-            "taskDisplayName": "Fake",
-          },
-          "shortDescription": Object {
-            "text": "description",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "id": "my-fake",
+    "properties": {
+      "category": "foo",
+      "taskDisplayName": "Fake",
+    },
+    "shortDescription": {
+      "text": "description",
+    },
+  },
+]
+`);
     expect(run.results).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "kind": "informational",
-          "level": "note",
-          "message": Object {
-            "text": "The is a fake message",
-          },
-          "ruleId": "my-fake",
-          "ruleIndex": 0,
-        },
-      ]
-    `);
+[
+  {
+    "kind": "informational",
+    "level": "note",
+    "message": {
+      "text": "The is a fake message",
+    },
+    "ruleId": "my-fake",
+    "ruleIndex": 0,
+  },
+]
+`);
     for (let result of run.results) {
       expect(result).toBeValidSarifFor('result');
     }

--- a/packages/core/__tests__/base-validation-task-test.ts
+++ b/packages/core/__tests__/base-validation-task-test.ts
@@ -104,27 +104,27 @@ describe('BaseValidationTask', () => {
     expect(steps.size).toEqual(3);
     expect(steps).toMatchInlineSnapshot(`
 Map {
-  "Check the first thing" => Object {
+  "Check the first thing" => {
     "isValid": true,
   },
-  "Check the second thing" => Object {
+  "Check the second thing" => {
     "isValid": true,
-    "options": Object {
-      "location": Object {
+    "options": {
+      "location": {
         "uri": "some/path/to/second.js",
       },
-      "properties": Object {
+      "properties": {
         "foo": "bar",
       },
     },
   },
-  "Check the third thing" => Object {
+  "Check the third thing" => {
     "isValid": false,
-    "options": Object {
-      "location": Object {
+    "options": {
+      "location": {
         "uri": "some/path/to/third.js",
       },
-      "properties": Object {
+      "properties": {
         "foo": "bar",
       },
     },
@@ -141,29 +141,29 @@ Map {
     await fakeTask.run();
 
     expect(fakeTask.log.runs[0].results).toMatchInlineSnapshot(`
-Array [
-  Object {
+[
+  {
     "kind": "pass",
     "level": "none",
-    "message": Object {
+    "message": {
       "text": "Check the first thing",
     },
     "ruleId": "my-fake-validation",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "pass",
     "level": "none",
-    "message": Object {
+    "message": {
       "text": "Check the second thing",
     },
     "ruleId": "my-fake-validation",
     "ruleIndex": 0,
   },
-  Object {
+  {
     "kind": "fail",
     "level": "error",
-    "message": Object {
+    "message": {
       "text": "Check the third thing",
     },
     "ruleId": "my-fake-validation",

--- a/packages/core/__tests__/config-test.ts
+++ b/packages/core/__tests__/config-test.ts
@@ -125,17 +125,17 @@ describe('config', () => {
       let config = readConfig(configPath);
 
       expect(config).toMatchInlineSnapshot(`
-        Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [
-            "checkup-plugin-ember",
-          ],
-          "tasks": Object {
-            "foo/bar": "on",
-          },
-        }
-      `);
+{
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+  "excludePaths": [],
+  "plugins": [
+    "checkup-plugin-ember",
+  ],
+  "tasks": {
+    "foo/bar": "on",
+  },
+}
+`);
     });
 
     it('can read a valid config with valid task config string value set to "off"', () => {
@@ -149,17 +149,17 @@ describe('config', () => {
       let config = readConfig(configPath);
 
       expect(config).toMatchInlineSnapshot(`
-        Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [
-            "checkup-plugin-ember",
-          ],
-          "tasks": Object {
-            "foo/bar": "off",
-          },
-        }
-      `);
+{
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+  "excludePaths": [],
+  "plugins": [
+    "checkup-plugin-ember",
+  ],
+  "tasks": {
+    "foo/bar": "off",
+  },
+}
+`);
     });
 
     it('can read a valid config with valid task config tuple value set to ["on", {}]', () => {
@@ -173,20 +173,20 @@ describe('config', () => {
       let config = readConfig(configPath);
 
       expect(config).toMatchInlineSnapshot(`
-        Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [
-            "checkup-plugin-ember",
-          ],
-          "tasks": Object {
-            "foo/bar": Array [
-              "on",
-              Object {},
-            ],
-          },
-        }
-      `);
+{
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+  "excludePaths": [],
+  "plugins": [
+    "checkup-plugin-ember",
+  ],
+  "tasks": {
+    "foo/bar": [
+      "on",
+      {},
+    ],
+  },
+}
+`);
     });
   });
 
@@ -207,13 +207,13 @@ describe('config', () => {
       let path = writeConfig(tmp);
 
       expect(readJsonSync(path)).toMatchInlineSnapshot(`
-        Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [],
-          "tasks": Object {},
-        }
-      `);
+{
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+  "excludePaths": [],
+  "plugins": [],
+  "tasks": {},
+}
+`);
     });
 
     it('writes specific config when config is passed', () => {
@@ -225,17 +225,17 @@ describe('config', () => {
       });
 
       expect(readJsonSync(path)).toMatchInlineSnapshot(`
-        Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [
-            "ember",
-          ],
-          "tasks": Object {
-            "ember/ember-tests-task": "off",
-          },
-        }
-      `);
+{
+  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+  "excludePaths": [],
+  "plugins": [
+    "ember",
+  ],
+  "tasks": {
+    "ember/ember-tests-task": "off",
+  },
+}
+`);
     });
   });
 

--- a/packages/core/__tests__/data/checkup-log-builder-test.ts
+++ b/packages/core/__tests__/data/checkup-log-builder-test.ts
@@ -42,60 +42,60 @@ describe('checkup-log-builder-test', () => {
     builder.currentRunBuilder.currentInvocation.arguments = [];
 
     expect(builder.log).toMatchInlineSnapshot(`
-      Object {
-        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
-        "runs": Array [
-          Object {
-            "invocations": Array [
-              Object {
-                "arguments": Array [],
-                "endTimeUtc": "2000-01-23T00:00:00.000Z",
-                "executionSuccessful": true,
-                "startTimeUtc": "2000-01-23T00:00:00.000Z",
-              },
-            ],
-            "results": Array [],
-            "tool": Object {
-              "driver": Object {
-                "informationUri": "https://github.com/checkupjs/checkup",
-                "language": "en-US",
-                "name": "checkup",
-                "properties": Object {
-                  "checkup": Object {
-                    "analyzedFiles": FilePathArray [],
-                    "analyzedFilesCount": 0,
-                    "cli": Object {
-                      "config": Object {
-                        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
-                        "excludePaths": Array [],
-                        "plugins": Array [],
-                        "tasks": Object {},
-                      },
-                      "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
-                      "schema": 1,
-                      "version": "0.0.0",
-                    },
-                    "project": Object {
-                      "name": "fake-package",
-                      "repository": Object {
-                        "activeDays": "0 days",
-                        "age": "0 days",
-                        "totalCommits": 0,
-                        "totalFiles": 0,
-                      },
-                      "version": "0.0.0",
-                    },
-                    "timings": Object {},
-                  },
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "invocations": [
+        {
+          "arguments": [],
+          "endTimeUtc": "2000-01-23T00:00:00.000Z",
+          "executionSuccessful": true,
+          "startTimeUtc": "2000-01-23T00:00:00.000Z",
+        },
+      ],
+      "results": [],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/checkupjs/checkup",
+          "language": "en-US",
+          "name": "checkup",
+          "properties": {
+            "checkup": {
+              "analyzedFiles": FilePathArray [],
+              "analyzedFilesCount": 0,
+              "cli": {
+                "config": {
+                  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+                  "excludePaths": [],
+                  "plugins": [],
+                  "tasks": {},
                 },
-                "rules": Array [],
+                "configHash": "dd17cda1fc2eb2bc6bb5206b41fc1a84",
+                "schema": 1,
+                "version": "0.0.0",
               },
+              "project": {
+                "name": "fake-package",
+                "repository": {
+                  "activeDays": "0 days",
+                  "age": "0 days",
+                  "totalCommits": 0,
+                  "totalFiles": 0,
+                },
+                "version": "0.0.0",
+              },
+              "timings": {},
             },
           },
-        ],
-        "version": "2.1.0",
-      }
-    `);
+          "rules": [],
+        },
+      },
+    },
+  ],
+  "version": "2.1.0",
+}
+`);
     expect(builder.log).toBeValidSarifLog();
   });
 });

--- a/packages/core/__tests__/data/checkup-log-parser-test.ts
+++ b/packages/core/__tests__/data/checkup-log-parser-test.ts
@@ -9,76 +9,76 @@ describe('checkup-log-parser-test', () => {
     let logParser = new CheckupLogParser(log);
 
     expect(logParser.metaData.cli).toMatchInlineSnapshot(`
-      Object {
-        "config": Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [
-            "checkup-plugin-javascript",
-            "checkup-plugin-ember",
-          ],
-          "tasks": Object {},
-        },
-        "configHash": "7bca477eada135bcfae0876e271fff89",
-        "schema": 1,
-        "version": "1.0.0-beta.11",
-      }
-    `);
+{
+  "config": {
+    "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+    "excludePaths": [],
+    "plugins": [
+      "checkup-plugin-javascript",
+      "checkup-plugin-ember",
+    ],
+    "tasks": {},
+  },
+  "configHash": "7bca477eada135bcfae0876e271fff89",
+  "schema": 1,
+  "version": "1.0.0-beta.11",
+}
+`);
     expect(logParser.metaData.project).toMatchInlineSnapshot(`
-      Object {
-        "name": "travis",
-        "repository": Object {
-          "activeDays": "1448",
-          "age": "9 years",
-          "linesOfCode": Object {
-            "total": 101513,
-            "types": Array [
-              Object {
-                "extension": "js",
-                "total": 49161,
-              },
-              Object {
-                "extension": "svg",
-                "total": 24112,
-              },
-              Object {
-                "extension": "scss",
-                "total": 14936,
-              },
-              Object {
-                "extension": "hbs",
-                "total": 12464,
-              },
-              Object {
-                "extension": "rb",
-                "total": 639,
-              },
-              Object {
-                "extension": "html",
-                "total": 201,
-              },
-            ],
-          },
-          "totalCommits": 5983,
-          "totalFiles": 1667,
+{
+  "name": "travis",
+  "repository": {
+    "activeDays": "1448",
+    "age": "9 years",
+    "linesOfCode": {
+      "total": 101513,
+      "types": [
+        {
+          "extension": "js",
+          "total": 49161,
         },
-        "version": "0.0.1",
-      }
-    `);
+        {
+          "extension": "svg",
+          "total": 24112,
+        },
+        {
+          "extension": "scss",
+          "total": 14936,
+        },
+        {
+          "extension": "hbs",
+          "total": 12464,
+        },
+        {
+          "extension": "rb",
+          "total": 639,
+        },
+        {
+          "extension": "html",
+          "total": 201,
+        },
+      ],
+    },
+    "totalCommits": 5983,
+    "totalFiles": 1667,
+  },
+  "version": "0.0.1",
+}
+`);
     expect(logParser.rules).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "id": "ember-types",
-          "properties": Object {
-            "category": "metrics",
-            "taskDisplayName": "Ember Types",
-          },
-          "shortDescription": Object {
-            "text": "Gets a breakdown of all Ember types in an Ember.js project",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "id": "ember-types",
+    "properties": {
+      "category": "metrics",
+      "taskDisplayName": "Ember Types",
+    },
+    "shortDescription": {
+      "text": "Gets a breakdown of all Ember types in an Ember.js project",
+    },
+  },
+]
+`);
     expect(logParser.results).toHaveLength(810);
   });
 
@@ -88,176 +88,176 @@ describe('checkup-log-parser-test', () => {
     let logParser = new CheckupLogParser(log);
 
     expect(logParser.metaData.cli).toMatchInlineSnapshot(`
-      Object {
-        "config": Object {
-          "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
-          "excludePaths": Array [],
-          "plugins": Array [
-            "checkup-plugin-javascript",
-            "checkup-plugin-ember",
-          ],
-          "tasks": Object {},
-        },
-        "configHash": "7bca477eada135bcfae0876e271fff89",
-        "schema": 1,
-        "version": "1.0.0-beta.11",
-      }
-    `);
+{
+  "config": {
+    "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/config/config-schema.json",
+    "excludePaths": [],
+    "plugins": [
+      "checkup-plugin-javascript",
+      "checkup-plugin-ember",
+    ],
+    "tasks": {},
+  },
+  "configHash": "7bca477eada135bcfae0876e271fff89",
+  "schema": 1,
+  "version": "1.0.0-beta.11",
+}
+`);
     expect(logParser.metaData.project).toMatchInlineSnapshot(`
-      Object {
-        "name": "travis",
-        "repository": Object {
-          "activeDays": "1448",
-          "age": "9 years",
-          "linesOfCode": Object {
-            "total": 101513,
-            "types": Array [
-              Object {
-                "extension": "js",
-                "total": 49161,
-              },
-              Object {
-                "extension": "svg",
-                "total": 24112,
-              },
-              Object {
-                "extension": "scss",
-                "total": 14936,
-              },
-              Object {
-                "extension": "hbs",
-                "total": 12464,
-              },
-              Object {
-                "extension": "rb",
-                "total": 639,
-              },
-              Object {
-                "extension": "html",
-                "total": 201,
-              },
-            ],
-          },
-          "totalCommits": 5983,
-          "totalFiles": 1667,
+{
+  "name": "travis",
+  "repository": {
+    "activeDays": "1448",
+    "age": "9 years",
+    "linesOfCode": {
+      "total": 101513,
+      "types": [
+        {
+          "extension": "js",
+          "total": 49161,
         },
-        "version": "0.0.1",
-      }
-    `);
+        {
+          "extension": "svg",
+          "total": 24112,
+        },
+        {
+          "extension": "scss",
+          "total": 14936,
+        },
+        {
+          "extension": "hbs",
+          "total": 12464,
+        },
+        {
+          "extension": "rb",
+          "total": 639,
+        },
+        {
+          "extension": "html",
+          "total": 201,
+        },
+      ],
+    },
+    "totalCommits": 5983,
+    "totalFiles": 1667,
+  },
+  "version": "0.0.1",
+}
+`);
     expect(logParser.rules).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "id": "ember-types",
-          "properties": Object {
-            "category": "metrics",
-            "taskDisplayName": "Ember Types",
-          },
-          "shortDescription": Object {
-            "text": "Gets a breakdown of all Ember types in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "eslint-summary",
-          "properties": Object {
-            "category": "linting",
-            "taskDisplayName": "Eslint Summary",
-          },
-          "shortDescription": Object {
-            "text": "Gets a summary of all eslint results in a project",
-          },
-        },
-        Object {
-          "id": "ember-test-types",
-          "properties": Object {
-            "category": "testing",
-            "taskDisplayName": "Test Types",
-          },
-          "shortDescription": Object {
-            "text": "Gets a breakdown of all test types in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "ember-octane-migration-status-native-classes",
-          "properties": Object {
-            "parentRuleID": "ember-octane-migration-status",
-            "taskDisplayName": "Ember Octane Migration | Native Classes",
-          },
-          "shortDescription": Object {
-            "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "ember-octane-migration-status-glimmer-components",
-          "properties": Object {
-            "parentRuleID": "ember-octane-migration-status",
-            "taskDisplayName": "Ember Octane Migration | Glimmer Components",
-          },
-          "shortDescription": Object {
-            "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "ember-octane-migration-status-tagless-components",
-          "properties": Object {
-            "parentRuleID": "ember-octane-migration-status",
-            "taskDisplayName": "Ember Octane Migration | Tagless Components",
-          },
-          "shortDescription": Object {
-            "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "ember-octane-migration-status-tracked-properties",
-          "properties": Object {
-            "parentRuleID": "ember-octane-migration-status",
-            "taskDisplayName": "Ember Octane Migration | Tracked Properties",
-          },
-          "shortDescription": Object {
-            "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "ember-template-lint-summary",
-          "properties": Object {
-            "category": "linting",
-            "taskDisplayName": "Template Lint Summary",
-          },
-          "shortDescription": Object {
-            "text": "Gets a summary of all ember-template-lint results in an Ember.js project",
-          },
-        },
-        Object {
-          "id": "eslint-disables",
-          "properties": Object {
-            "category": "linting",
-            "taskDisplayName": "Number of eslint-disable Usages",
-          },
-          "shortDescription": Object {
-            "text": "Finds all disabled eslint rules in a project",
-          },
-        },
-        Object {
-          "id": "outdated-dependencies",
-          "properties": Object {
-            "category": "dependencies",
-            "taskDisplayName": "Outdated Dependencies",
-          },
-          "shortDescription": Object {
-            "text": "Gets a summary of all outdated dependencies in a project",
-          },
-        },
-        Object {
-          "id": "ember-dependencies",
-          "properties": Object {
-            "category": "dependencies",
-            "taskDisplayName": "Ember Dependencies",
-          },
-          "shortDescription": Object {
-            "text": "Finds Ember-specific dependencies and their versions in an Ember.js project",
-          },
-        },
-      ]
-    `);
+[
+  {
+    "id": "ember-types",
+    "properties": {
+      "category": "metrics",
+      "taskDisplayName": "Ember Types",
+    },
+    "shortDescription": {
+      "text": "Gets a breakdown of all Ember types in an Ember.js project",
+    },
+  },
+  {
+    "id": "eslint-summary",
+    "properties": {
+      "category": "linting",
+      "taskDisplayName": "Eslint Summary",
+    },
+    "shortDescription": {
+      "text": "Gets a summary of all eslint results in a project",
+    },
+  },
+  {
+    "id": "ember-test-types",
+    "properties": {
+      "category": "testing",
+      "taskDisplayName": "Test Types",
+    },
+    "shortDescription": {
+      "text": "Gets a breakdown of all test types in an Ember.js project",
+    },
+  },
+  {
+    "id": "ember-octane-migration-status-native-classes",
+    "properties": {
+      "parentRuleID": "ember-octane-migration-status",
+      "taskDisplayName": "Ember Octane Migration | Native Classes",
+    },
+    "shortDescription": {
+      "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
+    },
+  },
+  {
+    "id": "ember-octane-migration-status-glimmer-components",
+    "properties": {
+      "parentRuleID": "ember-octane-migration-status",
+      "taskDisplayName": "Ember Octane Migration | Glimmer Components",
+    },
+    "shortDescription": {
+      "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
+    },
+  },
+  {
+    "id": "ember-octane-migration-status-tagless-components",
+    "properties": {
+      "parentRuleID": "ember-octane-migration-status",
+      "taskDisplayName": "Ember Octane Migration | Tagless Components",
+    },
+    "shortDescription": {
+      "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
+    },
+  },
+  {
+    "id": "ember-octane-migration-status-tracked-properties",
+    "properties": {
+      "parentRuleID": "ember-octane-migration-status",
+      "taskDisplayName": "Ember Octane Migration | Tracked Properties",
+    },
+    "shortDescription": {
+      "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project",
+    },
+  },
+  {
+    "id": "ember-template-lint-summary",
+    "properties": {
+      "category": "linting",
+      "taskDisplayName": "Template Lint Summary",
+    },
+    "shortDescription": {
+      "text": "Gets a summary of all ember-template-lint results in an Ember.js project",
+    },
+  },
+  {
+    "id": "eslint-disables",
+    "properties": {
+      "category": "linting",
+      "taskDisplayName": "Number of eslint-disable Usages",
+    },
+    "shortDescription": {
+      "text": "Finds all disabled eslint rules in a project",
+    },
+  },
+  {
+    "id": "outdated-dependencies",
+    "properties": {
+      "category": "dependencies",
+      "taskDisplayName": "Outdated Dependencies",
+    },
+    "shortDescription": {
+      "text": "Gets a summary of all outdated dependencies in a project",
+    },
+  },
+  {
+    "id": "ember-dependencies",
+    "properties": {
+      "category": "dependencies",
+      "taskDisplayName": "Ember Dependencies",
+    },
+    "shortDescription": {
+      "text": "Finds Ember-specific dependencies and their versions in an Ember.js project",
+    },
+  },
+]
+`);
     expect(logParser.results).toHaveLength(3019);
   });
 });

--- a/packages/core/__tests__/data/sarif-log-builder-test.ts
+++ b/packages/core/__tests__/data/sarif-log-builder-test.ts
@@ -8,25 +8,25 @@ describe('sarif-builder', () => {
     builder.addRun();
 
     expect(builder.log).toMatchInlineSnapshot(`
-      Object {
-        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
-        "runs": Array [
-          Object {
-            "invocations": Array [],
-            "results": Array [],
-            "tool": Object {
-              "driver": Object {
-                "informationUri": "https://github.com/checkupjs/checkup",
-                "language": "en-US",
-                "name": "checkup",
-                "rules": Array [],
-              },
-            },
-          },
-        ],
-        "version": "2.1.0",
-      }
-    `);
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "invocations": [],
+      "results": [],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/checkupjs/checkup",
+          "language": "en-US",
+          "name": "checkup",
+          "rules": [],
+        },
+      },
+    },
+  ],
+  "version": "2.1.0",
+}
+`);
   });
 
   it('can add runs to a log', () => {
@@ -56,31 +56,31 @@ describe('sarif-builder', () => {
 
     expect(builder.log.runs[0].tool.driver.rules).toHaveLength(3);
     expect(builder.log.runs).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "invocations": Array [],
-          "results": Array [],
-          "tool": Object {
-            "driver": Object {
-              "informationUri": "https://github.com/checkupjs/checkup",
-              "language": "en-US",
-              "name": "checkup",
-              "rules": Array [
-                Object {
-                  "id": "FOO",
-                },
-                Object {
-                  "id": "BAR",
-                },
-                Object {
-                  "id": "BAZ",
-                },
-              ],
-            },
+[
+  {
+    "invocations": [],
+    "results": [],
+    "tool": {
+      "driver": {
+        "informationUri": "https://github.com/checkupjs/checkup",
+        "language": "en-US",
+        "name": "checkup",
+        "rules": [
+          {
+            "id": "FOO",
           },
-        },
-      ]
-    `);
+          {
+            "id": "BAR",
+          },
+          {
+            "id": "BAZ",
+          },
+        ],
+      },
+    },
+  },
+]
+`);
   });
 
   it('can add results to a log', () => {
@@ -98,39 +98,39 @@ describe('sarif-builder', () => {
     });
 
     expect(builder.log).toMatchInlineSnapshot(`
-      Object {
-        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
-        "runs": Array [
-          Object {
-            "invocations": Array [],
-            "results": Array [
-              Object {
-                "kind": "fail",
-                "level": "error",
-                "message": Object {
-                  "text": "THIS IS A MESSAGE",
-                },
-                "ruleId": "test-rule",
-                "ruleIndex": 0,
-              },
-            ],
-            "tool": Object {
-              "driver": Object {
-                "informationUri": "https://github.com/checkupjs/checkup",
-                "language": "en-US",
-                "name": "checkup",
-                "rules": Array [
-                  Object {
-                    "id": "test-rule",
-                  },
-                ],
-              },
-            },
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "invocations": [],
+      "results": [
+        {
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "text": "THIS IS A MESSAGE",
           },
-        ],
-        "version": "2.1.0",
-      }
-    `);
+          "ruleId": "test-rule",
+          "ruleIndex": 0,
+        },
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/checkupjs/checkup",
+          "language": "en-US",
+          "name": "checkup",
+          "rules": [
+            {
+              "id": "test-rule",
+            },
+          ],
+        },
+      },
+    },
+  ],
+  "version": "2.1.0",
+}
+`);
     expect(builder.log).toBeValidSarifLog();
   });
 
@@ -158,43 +158,43 @@ describe('sarif-builder', () => {
     let run = builder.log.runs[0];
 
     expect(builder.log).toMatchInlineSnapshot(`
-      Object {
-        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
-        "runs": Array [
-          Object {
-            "invocations": Array [],
-            "results": Array [
-              Object {
-                "kind": "fail",
-                "level": "error",
-                "message": Object {
-                  "text": "THIS IS A MESSAGE",
-                },
-                "ruleId": "test-rule",
-                "ruleIndex": 0,
-              },
-            ],
-            "tool": Object {
-              "driver": Object {
-                "informationUri": "https://github.com/checkupjs/checkup",
-                "language": "en-US",
-                "name": "checkup",
-                "rules": Array [
-                  Object {
-                    "helpUri": "http://fat-chance-youre-gonna-get-help-here.com",
-                    "id": "test-rule",
-                    "shortDescription": Object {
-                      "text": "This is only a test rule",
-                    },
-                  },
-                ],
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "invocations": [],
+      "results": [
+        {
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "text": "THIS IS A MESSAGE",
+          },
+          "ruleId": "test-rule",
+          "ruleIndex": 0,
+        },
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/checkupjs/checkup",
+          "language": "en-US",
+          "name": "checkup",
+          "rules": [
+            {
+              "helpUri": "http://fat-chance-youre-gonna-get-help-here.com",
+              "id": "test-rule",
+              "shortDescription": {
+                "text": "This is only a test rule",
               },
             },
-          },
-        ],
-        "version": "2.1.0",
-      }
-    `);
+          ],
+        },
+      },
+    },
+  ],
+  "version": "2.1.0",
+}
+`);
     expect(run.tool.driver.rules![0].id).toEqual(run.results![0].ruleId);
     expect(builder.log).toBeValidSarifLog();
   });

--- a/packages/core/__tests__/utils/__snapshots__/calculate-section-bar-test.ts.snap
+++ b/packages/core/__tests__/utils/__snapshots__/calculate-section-bar-test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`calculate-sectioned-bar calculateSectionBar should calculateSectionBar segments correctly 1`] = `
-Object {
-  "completedSegments": Array [
-    Object {
+{
+  "completedSegments": [
+    {
       "completed": 50,
       "count": 495,
       "title": "bar",
     },
-    Object {
+    {
       "completed": 1,
       "count": 5,
       "title": "foo",
@@ -19,14 +19,14 @@ Object {
 `;
 
 exports[`calculate-sectioned-bar calculateSectionBar should calculateSectionBar segments correctly 3`] = `
-Object {
-  "completedSegments": Array [
-    Object {
+{
+  "completedSegments": [
+    {
       "completed": 25,
       "count": 10,
       "title": "bar",
     },
-    Object {
+    {
       "completed": 25,
       "count": 10,
       "title": "foo",
@@ -37,19 +37,19 @@ Object {
 `;
 
 exports[`calculate-sectioned-bar calculateSectionBar should calculateSectionBar segments correctly 4`] = `
-Object {
-  "completedSegments": Array [
-    Object {
+{
+  "completedSegments": [
+    {
       "completed": 17,
       "count": 10,
       "title": "bar",
     },
-    Object {
+    {
       "completed": 17,
       "count": 10,
       "title": "foo",
     },
-    Object {
+    {
       "completed": 17,
       "count": 10,
       "title": "moo",
@@ -60,19 +60,19 @@ Object {
 `;
 
 exports[`calculate-sectioned-bar calculateSectionBar should calculateSectionBar segments correctly 5`] = `
-Object {
-  "completedSegments": Array [
-    Object {
+{
+  "completedSegments": [
+    {
       "completed": 17,
       "count": 50,
       "title": "bar",
     },
-    Object {
+    {
       "completed": 17,
       "count": 50,
       "title": "foo",
     },
-    Object {
+    {
       "completed": 17,
       "count": 50,
       "title": "foo",
@@ -83,19 +83,19 @@ Object {
 `;
 
 exports[`calculate-sectioned-bar calculateSectionBar should calculateSectionBar segments correctly 6`] = `
-Object {
-  "completedSegments": Array [
-    Object {
+{
+  "completedSegments": [
+    {
       "completed": 17,
       "count": 50,
       "title": "foo",
     },
-    Object {
+    {
       "completed": 17,
       "count": 50,
       "title": "foo",
     },
-    Object {
+    {
       "completed": 7,
       "count": 20,
       "title": "bar",

--- a/packages/core/__tests__/utils/calculate-section-bar-test.ts
+++ b/packages/core/__tests__/utils/calculate-section-bar-test.ts
@@ -26,25 +26,27 @@ describe('calculate-sectioned-bar', () => {
               title: 'foo',
               count: 5,
             },
+
             {
               title: 'bar',
               count: 10,
             },
           ],
+
           20,
           50
         )
       ).toMatchInlineSnapshot(
         {},
         `
-        Object {
-          "completedSegments": Array [
-            Object {
+        {
+          "completedSegments": [
+            {
               "completed": 25,
               "count": 10,
               "title": "bar",
             },
-            Object {
+            {
               "completed": 13,
               "count": 5,
               "title": "foo",

--- a/packages/core/__tests__/utils/file-paths-array-test.ts
+++ b/packages/core/__tests__/utils/file-paths-array-test.ts
@@ -7,9 +7,9 @@ describe('FilePathsArray', function () {
     let files = new FilePathArray(...['foo.js', 'blue.hbs', 'goo.hbs']);
 
     expect(files.filterByGlob('**.js')).toMatchInlineSnapshot(`
-      Array [
-        "foo.js",
-      ]
-    `);
+[
+  "foo.js",
+]
+`);
   });
 });

--- a/packages/core/__tests__/utils/merge-lint-config-test.ts
+++ b/packages/core/__tests__/utils/merge-lint-config-test.ts
@@ -24,18 +24,18 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-eslint-rule": Array [
-              "warn",
-              Object {
-                "prop1": "error",
-                "prop2": "off",
-              },
-            ],
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-eslint-rule": [
+      "warn",
+      {
+        "prop1": "error",
+        "prop2": "off",
+      },
+    ],
+  },
+}
+`);
     });
 
     it('should merge strings and tuples when tuples are leftmost, string takes precedence', () => {
@@ -58,12 +58,12 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-eslint-rule": "error",
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-eslint-rule": "error",
+  },
+}
+`);
     });
 
     it('should merge rule tuples when there are rule overrides', () => {
@@ -93,19 +93,19 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-eslint-rule": Array [
-              "error",
-              Object {
-                "prop1": "warn",
-                "prop2": "off",
-                "prop3": "error",
-              },
-            ],
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-eslint-rule": [
+      "error",
+      {
+        "prop1": "warn",
+        "prop2": "off",
+        "prop3": "error",
+      },
+    ],
+  },
+}
+`);
     });
 
     it('should merge rule tuples when there are rule overrides with true merge', () => {
@@ -134,19 +134,19 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-eslint-rule": Array [
-              "error",
-              Object {
-                "prop1": "warn",
-                "prop2": "off",
-                "prop3": "error",
-              },
-            ],
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-eslint-rule": [
+      "error",
+      {
+        "prop1": "warn",
+        "prop2": "off",
+        "prop3": "error",
+      },
+    ],
+  },
+}
+`);
     });
   });
 
@@ -171,18 +171,18 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-ember-template-lint-rule": Array [
-              "warn",
-              Object {
-                "prop1": "error",
-                "prop2": "off",
-              },
-            ],
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-ember-template-lint-rule": [
+      "warn",
+      {
+        "prop1": "error",
+        "prop2": "off",
+      },
+    ],
+  },
+}
+`);
     });
 
     it('should merge strings and tuples when tuples are leftmost, string takes precedence', () => {
@@ -205,12 +205,12 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-ember-template-lint-rule": "error",
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-ember-template-lint-rule": "error",
+  },
+}
+`);
     });
 
     it('should merge rule tuples when there are rule overrides', () => {
@@ -240,19 +240,19 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-ember-template-lint-rule": Array [
-              "error",
-              Object {
-                "prop1": "warn",
-                "prop2": "off",
-                "prop3": "error",
-              },
-            ],
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-ember-template-lint-rule": [
+      "error",
+      {
+        "prop1": "warn",
+        "prop2": "off",
+        "prop3": "error",
+      },
+    ],
+  },
+}
+`);
     });
 
     it('should merge rule tuples when there are rule overrides with true merge', () => {
@@ -281,19 +281,19 @@ describe('mergeLintConfig', () => {
       };
 
       expect(mergeLintConfig(original, overrides)).toMatchInlineSnapshot(`
-        Object {
-          "rules": Object {
-            "fake-ember-template-lint-rule": Array [
-              "error",
-              Object {
-                "prop1": "warn",
-                "prop2": "off",
-                "prop3": "error",
-              },
-            ],
-          },
-        }
-      `);
+{
+  "rules": {
+    "fake-ember-template-lint-rule": [
+      "error",
+      {
+        "prop1": "warn",
+        "prop2": "off",
+        "prop3": "error",
+      },
+    ],
+  },
+}
+`);
     });
   });
 });

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -15,5 +15,8 @@ module.exports = {
     },
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   testPathIgnorePatterns: ['/__fixtures__/', '/__utils__/'],
 };

--- a/packages/plugin/jest.config.js
+++ b/packages/plugin/jest.config.js
@@ -14,5 +14,8 @@ module.exports = {
       statements: 100,
     },
   },
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   testPathIgnorePatterns: ['/__fixtures__/'],
 };


### PR DESCRIPTION
Using the jest setting `snapshotFormat.printBasicPrototype = false` produces more readable, copyable snapshots. This change sets all configs to use this setting, and regenerates all snapshots.