### PR TITLE
Adding missing package required by tasks using eslint configurations

### DIFF
--- a/packages/checkup-plugin-javascript/package.json
+++ b/packages/checkup-plugin-javascript/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@babel/parser": "^7.13.13",
     "@checkup/core": "^1.4.1",
+    "babel-eslint": "^10.1.0",
     "ember-template-recast": "^5.0.3",
     "npm-check": "^5.9.2",
     "recast": "^0.20.5",


### PR DESCRIPTION
Fixes issue in `checkup-plugin-javascript` where `babel-eslint` was set as a parser in a task config, but wasn't present. 