### PR TITLE
Update executed tasks to use fully qualified task name

### DIFF
--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -677,6 +677,7 @@ export default class FooTask extends BaseTask {
   category = 'best practices';
 
   async run() {
+    this.addRule();
     this.addResult('foo', 'review', 'error');
     return this.results;
   }

--- a/packages/cli/__tests__/cli-test.ts
+++ b/packages/cli/__tests__/cli-test.ts
@@ -281,7 +281,7 @@ describe('cli-test', () => {
 
     let result = await run(['run', '.', '--task', 'fake/file-count']);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
   });
 
   it('can run multiple tasks if the tasks option is specified with multiple tasks', async () => {
@@ -315,8 +315,8 @@ describe('cli-test', () => {
       'summary',
     ]);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
-    expect(stripAnsi(result.stdout)).toContain('✔ foo');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/foo');
   });
 
   it('can run only one task if the category option is specified', async () => {
@@ -341,8 +341,8 @@ describe('cli-test', () => {
 
     let result = await run(['run', '.', '--category', 'files']);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
-    expect(stripAnsi(result.stdout)).not.toContain('✔ foo');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
+    expect(stripAnsi(result.stdout)).not.toContain('✔ fake/foo');
   });
 
   it('can run multiple tasks if the category option is specified with multiple categories', async () => {
@@ -376,8 +376,8 @@ describe('cli-test', () => {
       'summary',
     ]);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
-    expect(stripAnsi(result.stdout)).toContain('✔ foo');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/foo');
   });
 
   it('can run only one task if the group option is specified', async () => {
@@ -402,7 +402,7 @@ describe('cli-test', () => {
 
     let result = await run(['run', '.', '--group', 'group1']);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
   });
 
   it('can run multiple tasks if the group option is specified with multiple groups', async () => {
@@ -436,8 +436,8 @@ describe('cli-test', () => {
       'summary',
     ]);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
-    expect(stripAnsi(result.stdout)).toContain('✔ foo');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/foo');
   });
 
   it('can run a task if its passed in via command line, even if it is turned "off" in config', async () => {
@@ -458,7 +458,7 @@ describe('cli-test', () => {
 
     let result = await run(['run', '.', '--task', 'fake/file-count']);
 
-    expect(stripAnsi(result.stdout)).toContain('✔ file-count');
+    expect(stripAnsi(result.stdout)).toContain('✔ fake/file-count');
   });
 
   it('can use the config at the config path if provided', async () => {
@@ -634,7 +634,7 @@ describe('cli-test', () => {
     let result = await run(['run', '.', '--plugin-base-dir', newProject.baseDir]);
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatch('✔ foo');
+    expect(result.stdout).toMatch('✔ fake/foo');
   });
 
   it('can load plugins from nested (non-node_modules) pluginBaseDir', async () => {
@@ -691,7 +691,7 @@ export default class FooTask extends BaseTask {
 
     let result = await run(['run', '.', '--plugin-base-dir', join(project.baseDir, 'lib')]);
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatch('✔ foo');
+    expect(result.stdout).toMatch('✔ nested/foo');
   });
 
   function run(args: string[], options: execa.Options = {}) {

--- a/packages/core/src/data/checkup-log-builder.ts
+++ b/packages/core/src/data/checkup-log-builder.ts
@@ -96,8 +96,8 @@ export default class CheckupLogBuilder extends SarifLogBuilder {
   addTaskExecutionNotifications() {
     this.executedTasks.forEach((task) => {
       this.addNotification({
-        id: task.taskName,
-        name: 'Execution successful',
+        id: task.fullyQualifiedTaskName,
+        name: `Execution completed${task.nonFatalErrors.length > 0 ? ' with errors' : ''}`,
       });
     });
   }


### PR DESCRIPTION
The current output listing executed tasks used the `taskName`, not the `fullyQualifiedTaskName`. This created inconsistency between names when outputting tasks in different ways. For example, when using `--list-tasks`, we'd use the `fullyQualifiedTaskName`, but when outputting tasks that were run in the `summary` formatter, we were using the short `taskName`, which didn't include the task's plugin namespace. This PR fixes this so that all output is consistent.