### PR TITLE
Recursively ignore build files

### DIFF
--- a/packages/core/src/utils/get-paths.ts
+++ b/packages/core/src/utils/get-paths.ts
@@ -18,7 +18,7 @@ const PATHS_TO_IGNORE: string[] = [
   '**/tests/dummy/**',
   'concat-stats-for/**',
   'dist/**',
-  'build/**',
+  '**/build/**',
   'vendor/**',
   '.git/**',
   '**/*.log',


### PR DESCRIPTION
Certain repositories use things such as yarn workspaces, which nest addons in packages. Those build folders would not be ignored before. This fixes that.