### PR TITLE
Minor fixes to paths in test, adding missing dependency

### DIFF
--- a/packages/core/tests/config-test.ts
+++ b/packages/core/tests/config-test.ts
@@ -81,7 +81,7 @@ describe('config', () => {
 
     it('can load a config from an HTTP endpoint', async () => {
       let configPath = await getConfigPath(
-        'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/__tests__/__fixtures__/.checkuprc.json'
+        'https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/tests/__fixtures__/.checkuprc.json'
       );
       let config = readConfig(configPath!);
 

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@checkup/core": "2.0.0-beta.3",
     "fixturify-project": "^2.1.1",
+    "fs-extra": "^10.1.0",
     "handlebars": "^4.7.7",
     "json-stable-stringify": "^1.0.1",
     "tmp": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,6 +5133,15 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"


### PR DESCRIPTION
Fixes a deprecated path from the test refactor (#1249) and adding missing dependency in `@checkup/test-helpers`.