### PR TITLE
Fixes @babel/traverse import

### DIFF
--- a/packages/core/src/analyzers/typescript-analyzer.ts
+++ b/packages/core/src/analyzers/typescript-analyzer.ts
@@ -20,7 +20,7 @@ export default class TypeScriptAnalyzer extends AstAnalyzer<
   typeof traverse
 > {
   constructor(source: string) {
-    super(source, recast.parse, traverse, {
+    super(source, recast.parse, (<any>traverse).default, {
       parser: require('recast/parsers/typescript'),
     });
   }


### PR DESCRIPTION
Fixes import for `@babel/traverse` to use `default` import.