### PR TITLE
Fixes invalid usage of ink-render-string

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "events": "^3.3.0",
     "fs-extra": "^10.0.0",
     "ink": "^3.0.9",
-    "ink-render-string": "^0.1.0",
+    "ink-render-string": "^1.0.0",
     "ink-table": "^3.0.0",
     "ink-task-list": "^1.1.0",
     "lodash.startcase": "^4.4.0",

--- a/packages/ui/src/base-ui-formatter.ts
+++ b/packages/ui/src/base-ui-formatter.ts
@@ -24,10 +24,10 @@ export default class BaseUIFormatter implements Formatter {
         React.createElement(this.component, { logParser, options: this.options })
       );
 
-      if (result.includes('ERROR')) {
+      if (result.output.includes('ERROR')) {
         throw result;
       } else {
-        return result;
+        return result.output;
       }
     } catch (error) {
       throw new CheckupError(ErrorKind.InvalidCustomComponent, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5965,10 +5965,10 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-ink-render-string@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ink-render-string/-/ink-render-string-0.1.0.tgz#09d7562d89a4ee2eb974bd92773a870a5fc6a9d4"
-  integrity sha512-XELD+/lHA2SaM0K7lrjlK4379ONwCbOwQqCZaliXDqznMvgz9EbGk+ZJUro8TKjmx/+bSDpI5XdO+2djUSkh5Q==
+ink-render-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ink-render-string/-/ink-render-string-1.0.0.tgz#dc9b0797059d3cd22aa30cda1c52eaafa5f6f857"
+  integrity sha512-3wuy6eoWjKul4gsTQwbS5Z43q75GoUrOL9jjmbFPt86ntZF3OuOn7BxTmKDpAKnW/N1VXdTECAepT+/UfEcNUQ==
   dependencies:
     events "^3.3.0"
     ink "^3.0.9"


### PR DESCRIPTION
The implementation of `ink-render-string` was incorrect within this repo. This was partly due to the fact that that repo wasn't being published correctly - it was publishing `.ts` files rather than transpiled `.js` files. [This PR fixed that issue](https://github.com/zhanwang626/ink-render-string/pull/4), and this PR is a follow up to address its usage within Checkup.