### PR TITLE
Fixes destructure of fs-extra

### DIFF
--- a/packages/test-helpers/src/checkup-fixturify-project.ts
+++ b/packages/test-helpers/src/checkup-fixturify-project.ts
@@ -5,8 +5,10 @@ import * as fixturify from 'fixturify';
 import Project from 'fixturify-project';
 import stringify from 'json-stable-stringify';
 import type { PackageJson } from 'type-fest';
-import { symlinkSync, mkdirpSync } from 'fs-extra';
+import fs from 'fs-extra';
 import walkSync from 'walk-sync';
+
+const { symlinkSync, mkdirpSync } = fs;
 
 const ROOT = process.cwd();
 


### PR DESCRIPTION
Fixes issue with destructuring CJS module in ESM.

```
SyntaxError: Named export 'symlinkSync' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'fs-extra';
const { symlinkSync, mkdirpSync } = pkg;
```