### PR TITLE
Uses fully qualified task name everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "type-fest": "^1.0.2",
     "typescript": "^4.7.4",
     "vite": "^2.7.13",
-    "vitest": "^0.21.1"
+    "vitest": "0.12.6"
   },
   "volta": {
     "node": "14.18.3",

--- a/packages/checkup-plugin-ember/tests/__snapshots__/ember-octane-migration-status-task-test.ts.snap
+++ b/packages/checkup-plugin-ember/tests/__snapshots__/ember-octane-migration-status-task-test.ts.snap
@@ -29,7 +29,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -59,7 +59,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -89,7 +89,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -119,7 +119,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -149,7 +149,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -179,7 +179,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -209,7 +209,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -239,7 +239,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -269,7 +269,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -299,7 +299,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -329,7 +329,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -359,7 +359,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -389,7 +389,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -419,7 +419,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -449,7 +449,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -479,7 +479,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -509,7 +509,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -539,7 +539,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -569,7 +569,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -599,7 +599,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -629,7 +629,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -659,7 +659,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -689,7 +689,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -719,7 +719,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
 ]
@@ -754,7 +754,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -784,7 +784,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -814,7 +814,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -844,7 +844,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -874,7 +874,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -904,7 +904,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -934,7 +934,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -964,7 +964,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -994,7 +994,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1024,7 +1024,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1054,7 +1054,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1084,7 +1084,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1114,7 +1114,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1144,7 +1144,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1174,7 +1174,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1204,7 +1204,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1234,7 +1234,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1264,7 +1264,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1294,7 +1294,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1324,7 +1324,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1354,7 +1354,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1384,7 +1384,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1414,7 +1414,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
   {
@@ -1444,7 +1444,7 @@ exports[`ember-octane-migration-status-task > detects octane migration status fo
         "name": "Octane",
       },
     },
-    "ruleId": "ember-octane-migration-status",
+    "ruleId": "ember/ember-octane-migration-status",
     "ruleIndex": 0,
   },
 ]

--- a/packages/checkup-plugin-javascript/tests/lines-of-code-task-test.ts
+++ b/packages/checkup-plugin-javascript/tests/lines-of-code-task-test.ts
@@ -30,54 +30,54 @@ describe('lines-of-code-task', () => {
     ).run();
 
     expect(result).toMatchInlineSnapshot(`
-[
-  {
-    "kind": "informational",
-    "level": "note",
-    "locations": [
-      {
-        "physicalLocation": {
-          "artifactLocation": {
-            "uri": "index.hbs",
+      [
+        {
+          "kind": "informational",
+          "level": "note",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "index.hbs",
+                },
+              },
+            },
+          ],
+          "message": {
+            "text": "Lines of code count for index.hbs - total lines: 1",
           },
-        },
-      },
-    ],
-    "message": {
-      "text": "Lines of code count for index.hbs - total lines: 1",
-    },
-    "properties": {
-      "extension": "hbs",
-      "filePath": "index.hbs",
-      "lines": 1,
-    },
-    "ruleId": "lines-of-code",
-    "ruleIndex": 0,
-  },
-  {
-    "kind": "informational",
-    "level": "note",
-    "locations": [
-      {
-        "physicalLocation": {
-          "artifactLocation": {
-            "uri": "index.js",
+          "properties": {
+            "extension": "hbs",
+            "filePath": "index.hbs",
+            "lines": 1,
           },
+          "ruleId": "javascript/lines-of-code",
+          "ruleIndex": 0,
         },
-      },
-    ],
-    "message": {
-      "text": "Lines of code count for index.js - total lines: 1",
-    },
-    "properties": {
-      "extension": "js",
-      "filePath": "index.js",
-      "lines": 1,
-    },
-    "ruleId": "lines-of-code",
-    "ruleIndex": 0,
-  },
-]
-`);
+        {
+          "kind": "informational",
+          "level": "note",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "index.js",
+                },
+              },
+            },
+          ],
+          "message": {
+            "text": "Lines of code count for index.js - total lines: 1",
+          },
+          "properties": {
+            "extension": "js",
+            "filePath": "index.js",
+            "lines": 1,
+          },
+          "ruleId": "javascript/lines-of-code",
+          "ruleIndex": 0,
+        },
+      ]
+    `);
   });
 });

--- a/packages/cli/bin/checkup.js
+++ b/packages/cli/bin/checkup.js
@@ -4,6 +4,8 @@ import 'v8-compile-cache';
 import { createRequire } from 'module';
 import importLocal from 'import-local';
 
+process.env.NODE_ENV = 'production';
+
 const require = createRequire(import.meta.url);
 const checkup = importLocal(require.resolve('../lib/checkup.js'));
 

--- a/packages/cli/src/formatters/components/Pretty.tsx
+++ b/packages/cli/src/formatters/components/Pretty.tsx
@@ -23,7 +23,7 @@ const Pretty: React.FC<{ logParser: CheckupLogParser }> = ({ logParser }) => {
     timings,
     tasksWithExceptions,
   } = logParser;
-
+  debugger;
   return (
     <Box flexDirection={'column'} marginTop={1} marginBottom={1}>
       <MetaData metaData={metaData} />
@@ -44,7 +44,7 @@ const TaskResults: React.FC<{
   let r: { Component: React.FC<any>; taskResult: RuleResults }[] = [];
 
   [...taskResults!.values()].forEach((taskResult) => {
-    let taskProps = taskResult!.rule?.properties!;
+    let taskProps = taskResult?.rule?.properties!;
     let componentName = taskProps.component.name;
 
     r.push({

--- a/packages/cli/src/formatters/components/Pretty.tsx
+++ b/packages/cli/src/formatters/components/Pretty.tsx
@@ -43,56 +43,52 @@ const TaskResults: React.FC<{
 }> = ({ taskResults, rules, executedTasks }) => {
   let r: { Component: React.FC<any>; taskResult: RuleResults }[] = [];
 
-  if (taskResults!.size > 0) {
-    [...taskResults!.values()].forEach((taskResult) => {
-      let taskProps = taskResult!.rule?.properties!;
-      let componentName = taskProps.component.name;
+  [...taskResults!.values()].forEach((taskResult) => {
+    let taskProps = taskResult!.rule?.properties!;
+    let componentName = taskProps.component.name;
+
+    r.push({
+      Component: registeredComponents.get(componentName ?? 'list')!,
+      taskResult,
+    });
+  });
+
+  // For any executed task, we want to set its values to empty for output, to indicate the task ran with no results.
+  for (let rule of rules) {
+    if (
+      !r.some((item) => {
+        return rule.id === item.taskResult.rule.id;
+      }) &&
+      executedTasks.some((ruleDescriptor) => ruleDescriptor.id === rule.id)
+    ) {
+      let taskProps = rule.properties;
+      let componentName = taskProps!.component.name;
 
       r.push({
         Component: registeredComponents.get(componentName ?? 'list')!,
-        taskResult,
+        taskResult: {
+          results: [],
+          rule: rule,
+        },
       });
-    });
-
-    // For any executed task, we want to set its values to empty for output, to indicate the task ran with no results.
-    for (let rule of rules) {
-      if (
-        !r.some((item) => {
-          return rule.id === item.taskResult.rule.id;
-        }) &&
-        executedTasks.some((ruleDescriptor) => ruleDescriptor.id === rule.id)
-      ) {
-        let taskProps = rule.properties;
-        let componentName = taskProps!.component.name;
-
-        r.push({
-          Component: registeredComponents.get(componentName ?? 'list')!,
-          taskResult: {
-            results: [],
-            rule: rule,
-          },
-        });
-      }
     }
-
-    return (
-      <>
-        <Box marginBottom={1}>
-          <Text>Checkup ran the following task(s):</Text>
-        </Box>
-        {r.map(({ Component, taskResult }) => {
-          return (
-            <Box flexDirection="column" key={taskResult.rule.id}>
-              <Component taskResult={taskResult} />
-              <Newline />
-            </Box>
-          );
-        })}
-      </>
-    );
-  } else {
-    return <Text></Text>;
   }
+
+  return (
+    <>
+      <Box marginBottom={1}>
+        <Text>Checkup ran the following task(s):</Text>
+      </Box>
+      {r.map(({ Component, taskResult }) => {
+        return (
+          <Box flexDirection="column" key={taskResult.rule.id}>
+            <Component taskResult={taskResult} />
+            <Newline />
+          </Box>
+        );
+      })}
+    </>
+  );
 };
 
 export default Pretty;

--- a/packages/cli/src/formatters/components/Pretty.tsx
+++ b/packages/cli/src/formatters/components/Pretty.tsx
@@ -23,7 +23,6 @@ const Pretty: React.FC<{ logParser: CheckupLogParser }> = ({ logParser }) => {
     timings,
     tasksWithExceptions,
   } = logParser;
-  debugger;
   return (
     <Box flexDirection={'column'} marginTop={1} marginBottom={1}>
       <MetaData metaData={metaData} />

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -209,7 +209,7 @@ export default abstract class BaseTask {
   public addRule(additionalRuleProps?: TaskRule) {
     let taskRule;
     let ruleProps = {
-      id: this.taskName,
+      id: this.fullyQualifiedTaskName,
       shortDescription: {
         text: this.description,
       },

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -141,12 +141,12 @@ export default abstract class BaseTask {
       message: {
         text: messageText,
       },
-      ruleId: this.taskName,
+      ruleId: this.fullyQualifiedTaskName,
       kind,
       level,
     };
 
-    if (!this._logBuilder.hasRule(this.taskName)) {
+    if (!this._logBuilder.hasRule(this.fullyQualifiedTaskName)) {
       throw new Error(
         'You must call `addRule` in your Task implemenation prior to calling `addResult`'
       );
@@ -232,7 +232,7 @@ export default abstract class BaseTask {
    * @param properties - A {PropertyBag} to be merged with the rule metadata's properties.
    */
   public addRuleProperties(properties: PropertyBag) {
-    let rule = this._logBuilder.getRule(this.taskName);
+    let rule = this._logBuilder.getRule(this.fullyQualifiedTaskName);
 
     if (!rule) {
       throw new Error(

--- a/packages/core/src/base-task.ts
+++ b/packages/core/src/base-task.ts
@@ -109,9 +109,8 @@ export default abstract class BaseTask {
       return;
     }
 
-    let config: ConfigValue<TaskConfig> | undefined = this.context.config.tasks[
-      this.fullyQualifiedTaskName
-    ];
+    let config: ConfigValue<TaskConfig> | undefined =
+      this.context.config.tasks[this.fullyQualifiedTaskName];
 
     let [enabled, taskConfig] = parseConfigTuple<TaskConfig>(config);
 

--- a/packages/core/tests/base-task-test.ts
+++ b/packages/core/tests/base-task-test.ts
@@ -69,32 +69,32 @@ describe('BaseTask', () => {
       let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
       expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-[
-  {
-    "id": "my-fake",
-    "properties": {
-      "category": "foo",
-      "taskDisplayName": "Fake",
-    },
-    "shortDescription": {
-      "text": "description",
-    },
-  },
-]
-`);
+        [
+          {
+            "id": "fake/my-fake",
+            "properties": {
+              "category": "foo",
+              "taskDisplayName": "Fake",
+            },
+            "shortDescription": {
+              "text": "description",
+            },
+          },
+        ]
+      `);
       expect(run.results).toMatchInlineSnapshot(`
-[
-  {
-    "kind": "informational",
-    "level": "note",
-    "message": {
-      "text": "The is a fake message",
-    },
-    "ruleId": "my-fake",
-    "ruleIndex": 0,
-  },
-]
-`);
+        [
+          {
+            "kind": "informational",
+            "level": "note",
+            "message": {
+              "text": "The is a fake message",
+            },
+            "ruleId": "fake/my-fake",
+            "ruleIndex": 0,
+          },
+        ]
+      `);
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
@@ -112,41 +112,41 @@ describe('BaseTask', () => {
       let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
       expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-[
-  {
-    "id": "my-fake",
-    "properties": {
-      "category": "foo",
-      "taskDisplayName": "Fake",
-    },
-    "shortDescription": {
-      "text": "description",
-    },
-  },
-]
-`);
-      expect(run.results).toMatchInlineSnapshot(`
-[
-  {
-    "kind": "informational",
-    "level": "note",
-    "locations": [
-      {
-        "physicalLocation": {
-          "artifactLocation": {
-            "uri": "path/to/file.js",
+        [
+          {
+            "id": "fake/my-fake",
+            "properties": {
+              "category": "foo",
+              "taskDisplayName": "Fake",
+            },
+            "shortDescription": {
+              "text": "description",
+            },
           },
-        },
-      },
-    ],
-    "message": {
-      "text": "The is a fake message",
-    },
-    "ruleId": "my-fake",
-    "ruleIndex": 0,
-  },
-]
-`);
+        ]
+      `);
+      expect(run.results).toMatchInlineSnapshot(`
+        [
+          {
+            "kind": "informational",
+            "level": "note",
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "path/to/file.js",
+                  },
+                },
+              },
+            ],
+            "message": {
+              "text": "The is a fake message",
+            },
+            "ruleId": "fake/my-fake",
+            "ruleIndex": 0,
+          },
+        ]
+      `);
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
@@ -164,47 +164,47 @@ describe('BaseTask', () => {
       let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
       expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-[
-  {
-    "id": "my-fake",
-    "properties": {
-      "category": "foo",
-      "taskDisplayName": "Fake",
-    },
-    "shortDescription": {
-      "text": "description",
-    },
-  },
-]
-`);
+        [
+          {
+            "id": "fake/my-fake",
+            "properties": {
+              "category": "foo",
+              "taskDisplayName": "Fake",
+            },
+            "shortDescription": {
+              "text": "description",
+            },
+          },
+        ]
+      `);
       expect(run.results).toMatchInlineSnapshot(`
-[
-  {
-    "kind": "informational",
-    "level": "note",
-    "locations": [
-      {
-        "physicalLocation": {
-          "artifactLocation": {
-            "uri": "path/to/file.js",
+        [
+          {
+            "kind": "informational",
+            "level": "note",
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "path/to/file.js",
+                  },
+                  "region": {
+                    "endColumn": 1,
+                    "endLine": 1,
+                    "startColumn": 1,
+                    "startLine": 1,
+                  },
+                },
+              },
+            ],
+            "message": {
+              "text": "The is a fake message",
+            },
+            "ruleId": "fake/my-fake",
+            "ruleIndex": 0,
           },
-          "region": {
-            "endColumn": 1,
-            "endLine": 1,
-            "startColumn": 1,
-            "startLine": 1,
-          },
-        },
-      },
-    ],
-    "message": {
-      "text": "The is a fake message",
-    },
-    "ruleId": "my-fake",
-    "ruleIndex": 0,
-  },
-]
-`);
+        ]
+      `);
       for (let result of run.results) {
         expect(result).toBeValidSarifFor('result');
       }
@@ -221,32 +221,32 @@ describe('BaseTask', () => {
     let run = fakeTask.context.logBuilder.currentRunBuilder.run;
 
     expect(run.tool.driver.rules).toMatchInlineSnapshot(`
-[
-  {
-    "id": "my-fake",
-    "properties": {
-      "category": "foo",
-      "taskDisplayName": "Fake",
-    },
-    "shortDescription": {
-      "text": "description",
-    },
-  },
-]
-`);
+      [
+        {
+          "id": "fake/my-fake",
+          "properties": {
+            "category": "foo",
+            "taskDisplayName": "Fake",
+          },
+          "shortDescription": {
+            "text": "description",
+          },
+        },
+      ]
+    `);
     expect(run.results).toMatchInlineSnapshot(`
-[
-  {
-    "kind": "informational",
-    "level": "note",
-    "message": {
-      "text": "The is a fake message",
-    },
-    "ruleId": "my-fake",
-    "ruleIndex": 0,
-  },
-]
-`);
+      [
+        {
+          "kind": "informational",
+          "level": "note",
+          "message": {
+            "text": "The is a fake message",
+          },
+          "ruleId": "fake/my-fake",
+          "ruleIndex": 0,
+        },
+      ]
+    `);
     for (let result of run.results) {
       expect(result).toBeValidSarifFor('result');
     }

--- a/packages/core/tests/base-validation-task-test.ts
+++ b/packages/core/tests/base-validation-task-test.ts
@@ -72,7 +72,7 @@ describe('BaseValidationTask', () => {
     let fakeTask = new FakeValidationTask('fake validation', context);
 
     expect(fakeTask.rule).toEqual({
-      id: 'my-fake-validation',
+      id: 'fake validation/my-fake-validation',
       shortDescription: {
         text: 'description',
       },
@@ -141,35 +141,35 @@ Map {
     await fakeTask.run();
 
     expect(fakeTask.log.runs[0].results).toMatchInlineSnapshot(`
-[
-  {
-    "kind": "pass",
-    "level": "none",
-    "message": {
-      "text": "Check the first thing",
-    },
-    "ruleId": "my-fake-validation",
-    "ruleIndex": 0,
-  },
-  {
-    "kind": "pass",
-    "level": "none",
-    "message": {
-      "text": "Check the second thing",
-    },
-    "ruleId": "my-fake-validation",
-    "ruleIndex": 0,
-  },
-  {
-    "kind": "fail",
-    "level": "error",
-    "message": {
-      "text": "Check the third thing",
-    },
-    "ruleId": "my-fake-validation",
-    "ruleIndex": 0,
-  },
-]
-`);
+      [
+        {
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "Check the first thing",
+          },
+          "ruleId": "fake validation/my-fake-validation",
+          "ruleIndex": 0,
+        },
+        {
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "Check the second thing",
+          },
+          "ruleId": "fake validation/my-fake-validation",
+          "ruleIndex": 0,
+        },
+        {
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "text": "Check the third thing",
+          },
+          "ruleId": "fake validation/my-fake-validation",
+          "ruleIndex": 0,
+        },
+      ]
+    `);
   });
 });

--- a/packages/ui/src/base-ui-formatter.ts
+++ b/packages/ui/src/base-ui-formatter.ts
@@ -23,14 +23,13 @@ export default class BaseUIFormatter implements Formatter {
       const result = render(
         React.createElement(this.component, { logParser, options: this.options })
       );
-      debugger;
+
       if (result.output.includes('ERROR')) {
         throw result;
       } else {
         return result.output;
       }
     } catch (error) {
-      debugger;
       throw new CheckupError(ErrorKind.InvalidCustomComponent, {
         details: error,
       });

--- a/packages/ui/src/base-ui-formatter.ts
+++ b/packages/ui/src/base-ui-formatter.ts
@@ -23,13 +23,14 @@ export default class BaseUIFormatter implements Formatter {
       const result = render(
         React.createElement(this.component, { logParser, options: this.options })
       );
-
+      debugger;
       if (result.output.includes('ERROR')) {
         throw result;
       } else {
         return result.output;
       }
     } catch (error) {
+      debugger;
       throw new CheckupError(ErrorKind.InvalidCustomComponent, {
         details: error,
       });

--- a/packages/ui/src/components/List.tsx
+++ b/packages/ui/src/components/List.tsx
@@ -17,7 +17,7 @@ type ListItem = {
 
 export const List: React.FC<{ taskResult: RuleResults }> = ({ taskResult }) => {
   let listItems = buildListData(taskResult);
-
+  debugger;
   return (
     <>
       <TaskDisplayName taskResult={taskResult} />

--- a/packages/ui/src/components/List.tsx
+++ b/packages/ui/src/components/List.tsx
@@ -17,7 +17,7 @@ type ListItem = {
 
 export const List: React.FC<{ taskResult: RuleResults }> = ({ taskResult }) => {
   let listItems = buildListData(taskResult);
-  debugger;
+
   return (
     <>
       <TaskDisplayName taskResult={taskResult} />

--- a/packages/ui/src/components/List.tsx
+++ b/packages/ui/src/components/List.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Box, Text } from 'ink';
 import { RuleResults } from '@checkup/core';
-import * as objectPath from 'object-path';
+import objectPath from 'object-path';
 import startCase from 'lodash.startcase';
 import { TaskDisplayName } from '../components/TaskDisplayName.js';
 import { getOptions } from '../get-options.js';

--- a/packages/ui/src/components/Table.tsx
+++ b/packages/ui/src/components/Table.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { default as InkTable } from 'ink-table';
 import { Box } from 'ink';
-import * as objectPath from 'object-path';
+import objectPath from 'object-path';
 import { Result } from 'sarif';
 import { RuleResults } from '@checkup/core';
 import { TaskDisplayName } from '../components/TaskDisplayName.js';

--- a/packages/ui/tests/components/list-test.tsx
+++ b/packages/ui/tests/components/list-test.tsx
@@ -35,8 +35,7 @@ describe('List', () => {
       results: [
         {
           message: {
-            text:
-              'Do not use `action` as <button {{action ...}} />. Instead, use the `on` modifier and `fn` helper.',
+            text: 'Do not use `action` as <button {{action ...}} />. Instead, use the `on` modifier and `fn` helper.',
           },
           ruleId: 'ember-template-lint-summary',
           kind: 'review',

--- a/packages/ui/tests/components/migration-test.tsx
+++ b/packages/ui/tests/components/migration-test.tsx
@@ -10,8 +10,7 @@ const TASK_RESULT: RuleResults = {
   rule: {
     id: 'ember-octane-migration-status',
     shortDescription: {
-      text:
-        'Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project',
+      text: 'Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project',
     },
     properties: {
       taskDisplayName: 'Ember Octane Migration Status',
@@ -35,8 +34,7 @@ const TASK_RESULT: RuleResults = {
   results: [
     {
       message: {
-        text:
-          'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
+        text: 'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
       },
       ruleId: 'ember-octane-migration-status',
       kind: 'review',
@@ -67,8 +65,7 @@ const TASK_RESULT: RuleResults = {
     },
     {
       message: {
-        text:
-          'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
+        text: 'Octane | Native Classes : Use native JS classes to extend the built-in classes provided by Ember. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__js-boilerplate',
       },
       ruleId: 'ember-octane-migration-status',
       kind: 'review',
@@ -99,8 +96,7 @@ const TASK_RESULT: RuleResults = {
     },
     {
       message: {
-        text:
-          'Octane | Glimmer Components : Use native DOM APIs over jQuery. More info: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-jquery.md',
+        text: 'Octane | Glimmer Components : Use native DOM APIs over jQuery. More info: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-jquery.md',
       },
       ruleId: 'ember-octane-migration-status',
       kind: 'review',
@@ -131,8 +127,7 @@ const TASK_RESULT: RuleResults = {
     },
     {
       message: {
-        text:
-          'Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name',
+        text: 'Octane | Tagless Components : Use tagless components to avoid unnecessary outer element wrapping. More info: https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-templates__tag-name',
       },
       ruleId: 'ember-octane-migration-status',
       kind: 'review',

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,11 +603,6 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@esbuild/linux-loong64@0.14.54":
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
-  integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
-
 "@eslint/eslintrc@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.3.tgz#fcaa2bcef39e13d6e9e7f6271f4cc7cae1174886"
@@ -1711,7 +1706,7 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*", "@types/chai@^4.3.3":
+"@types/chai@*", "@types/chai@^4.3.1":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
   integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
@@ -4394,200 +4389,100 @@ esbuild-android-64@0.14.39:
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz#09f12a372eed9743fd77ff6d889ac14f7b340c21"
   integrity sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==
 
-esbuild-android-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz#505f41832884313bbaffb27704b8bcaa2d8616be"
-  integrity sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==
-
 esbuild-android-arm64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz#f608d00ea03fe26f3b1ab92a30f99220390f3071"
   integrity sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==
-
-esbuild-android-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz#8ce69d7caba49646e009968fe5754a21a9871771"
-  integrity sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==
 
 esbuild-darwin-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz#31528daa75b4c9317721ede344195163fae3e041"
   integrity sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==
 
-esbuild-darwin-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz#24ba67b9a8cb890a3c08d9018f887cc221cdda25"
-  integrity sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==
-
 esbuild-darwin-arm64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz#247f770d86d90a215fa194f24f90e30a0bd97245"
   integrity sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==
-
-esbuild-darwin-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz#3f7cdb78888ee05e488d250a2bdaab1fa671bf73"
-  integrity sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==
 
 esbuild-freebsd-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz#479414d294905055eb396ebe455ed42213284ee0"
   integrity sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==
 
-esbuild-freebsd-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz#09250f997a56ed4650f3e1979c905ffc40bbe94d"
-  integrity sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==
-
 esbuild-freebsd-arm64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz#cedeb10357c88533615921ae767a67dc870a474c"
   integrity sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==
-
-esbuild-freebsd-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz#bafb46ed04fc5f97cbdb016d86947a79579f8e48"
-  integrity sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==
 
 esbuild-linux-32@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz#d9f008c4322d771f3958f59c1eee5a05cdf92485"
   integrity sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==
 
-esbuild-linux-32@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz#e2a8c4a8efdc355405325033fcebeb941f781fe5"
-  integrity sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==
-
 esbuild-linux-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz#ba58d7f66858913aeb1ab5c6bde1bbd824731795"
   integrity sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==
-
-esbuild-linux-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz#de5fdba1c95666cf72369f52b40b03be71226652"
-  integrity sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==
 
 esbuild-linux-arm64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz#708785a30072702b5b1c16b65cf9c25c51202529"
   integrity sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==
 
-esbuild-linux-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz#dae4cd42ae9787468b6a5c158da4c84e83b0ce8b"
-  integrity sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==
-
 esbuild-linux-arm@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz#4e8b5deaa7ab60d0d28fab131244ef82b40684f4"
   integrity sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==
-
-esbuild-linux-arm@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz#a2c1dff6d0f21dbe8fc6998a122675533ddfcd59"
-  integrity sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==
 
 esbuild-linux-mips64le@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz#6f3bf3023f711084e5a1e8190487d2020f39f0f7"
   integrity sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==
 
-esbuild-linux-mips64le@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz#d9918e9e4cb972f8d6dae8e8655bf9ee131eda34"
-  integrity sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==
-
 esbuild-linux-ppc64le@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz#900e718a4ea3f6aedde8424828eeefdd4b48d4b9"
   integrity sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==
-
-esbuild-linux-ppc64le@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz#3f9a0f6d41073fb1a640680845c7de52995f137e"
-  integrity sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==
 
 esbuild-linux-riscv64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz#dcbff622fa37047a75d2ff7a1d8d2949d80277e4"
   integrity sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==
 
-esbuild-linux-riscv64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz#618853c028178a61837bc799d2013d4695e451c8"
-  integrity sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==
-
 esbuild-linux-s390x@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz#3f725a7945b419406c99d93744b28552561dcdfd"
   integrity sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==
-
-esbuild-linux-s390x@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz#d1885c4c5a76bbb5a0fe182e2c8c60eb9e29f2a6"
-  integrity sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==
 
 esbuild-netbsd-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz#e10e40b6a765798b90d4eb85901cc85c8b7ff85e"
   integrity sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==
 
-esbuild-netbsd-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz#69ae917a2ff241b7df1dbf22baf04bd330349e81"
-  integrity sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==
-
 esbuild-openbsd-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz#935ec143f75ce10bd9cdb1c87fee00287eb0edbc"
   integrity sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==
-
-esbuild-openbsd-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz#db4c8495287a350a6790de22edea247a57c5d47b"
-  integrity sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==
 
 esbuild-sunos-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz#0e7aa82b022a2e6d55b0646738b2582c2d72c3c0"
   integrity sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==
 
-esbuild-sunos-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz#54287ee3da73d3844b721c21bc80c1dc7e1bf7da"
-  integrity sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==
-
 esbuild-windows-32@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz#3f1538241f31b538545f4b5841b248cac260fa35"
   integrity sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==
-
-esbuild-windows-32@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz#f8aaf9a5667630b40f0fb3aa37bf01bbd340ce31"
-  integrity sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==
 
 esbuild-windows-64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz#b100c59f96d3c2da2e796e42fee4900d755d3e03"
   integrity sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==
 
-esbuild-windows-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz#bf54b51bd3e9b0f1886ffdb224a4176031ea0af4"
-  integrity sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==
-
 esbuild-windows-arm64@0.14.39:
   version "0.14.39"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz#00268517e665b33c89778d61f144e4256b39f631"
   integrity sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==
-
-esbuild-windows-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz#937d15675a15e4b0e4fafdbaa3a01a776a2be982"
-  integrity sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==
 
 esbuild@^0.14.27:
   version "0.14.39"
@@ -4614,33 +4509,6 @@ esbuild@^0.14.27:
     esbuild-windows-32 "0.14.39"
     esbuild-windows-64 "0.14.39"
     esbuild-windows-arm64 "0.14.39"
-
-esbuild@^0.14.47:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.54.tgz#8b44dcf2b0f1a66fc22459943dccf477535e9aa2"
-  integrity sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==
-  optionalDependencies:
-    "@esbuild/linux-loong64" "0.14.54"
-    esbuild-android-64 "0.14.54"
-    esbuild-android-arm64 "0.14.54"
-    esbuild-darwin-64 "0.14.54"
-    esbuild-darwin-arm64 "0.14.54"
-    esbuild-freebsd-64 "0.14.54"
-    esbuild-freebsd-arm64 "0.14.54"
-    esbuild-linux-32 "0.14.54"
-    esbuild-linux-64 "0.14.54"
-    esbuild-linux-arm "0.14.54"
-    esbuild-linux-arm64 "0.14.54"
-    esbuild-linux-mips64le "0.14.54"
-    esbuild-linux-ppc64le "0.14.54"
-    esbuild-linux-riscv64 "0.14.54"
-    esbuild-linux-s390x "0.14.54"
-    esbuild-netbsd-64 "0.14.54"
-    esbuild-openbsd-64 "0.14.54"
-    esbuild-sunos-64 "0.14.54"
-    esbuild-windows-32 "0.14.54"
-    esbuild-windows-64 "0.14.54"
-    esbuild-windows-arm64 "0.14.54"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -7672,7 +7540,7 @@ load-yaml-file@^0.2.0:
     pify "^4.0.1"
     strip-bom "^3.0.0"
 
-local-pkg@^0.4.2:
+local-pkg@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
   integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
@@ -9700,15 +9568,6 @@ postcss@^8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.16:
-  version "8.4.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
-  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 preferred-pm@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-1.0.1.tgz#539df37ce944b1b765ae944a8ba34a7e68694e8d"
@@ -10369,7 +10228,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.1.6, resolve@^1.22.1:
+resolve@^1.1.6:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -10445,17 +10304,17 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+"rollup@>=2.59.0 <2.78.0":
+  version "2.77.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz#8f00418d3a2740036e15deb653bed1a90ee0cc12"
+  integrity sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 rollup@^2.59.0:
   version "2.73.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.73.0.tgz#128fef4b333fd92d02d6929afbb6ee38d7feb32d"
   integrity sha512-h/UngC3S4Zt28mB3g0+2YCMegT5yoftnQplwzPqGZcKvlld5e+kT/QRmJiL+qxGyZKOYpgirWGdLyEO1b0dpLQ==
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-rollup@^2.75.6:
-  version "2.77.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.2.tgz#6b6075c55f9cc2040a5912e6e062151e42e2c4e3"
-  integrity sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -11407,15 +11266,15 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
-tinypool@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.4.tgz#4d2598c4689d1a2ce267ddf3360a9c6b3925a20c"
-  integrity sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==
+tinypool@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
+  integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
 
-tinyspy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.0.tgz#0cb34587287b0432b33fe36a9bd945fe22b1eb89"
-  integrity sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==
+tinyspy@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.3.tgz#8b57f8aec7fe1bf583a3a49cb9ab30c742f69237"
+  integrity sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -11875,32 +11734,30 @@ vite@^2.7.13:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"vite@^2.9.12 || ^3.0.0-0":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.5.tgz#56b8d52e00bbbd5f21d02f0868dc613b3246ecc6"
-  integrity sha512-bRvrt9Tw8EGW4jj64aYFTnVg134E8hgDxyl/eEHnxiGqYk7/pTPss6CWlurqPOUzqvEoZkZ58Ws+Iu8MB87iMA==
+vite@^2.9.8:
+  version "2.9.15"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.15.tgz#2858dd5b2be26aa394a283e62324281892546f0b"
+  integrity sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==
   dependencies:
-    esbuild "^0.14.47"
-    postcss "^8.4.16"
-    resolve "^1.22.1"
-    rollup "^2.75.6"
+    esbuild "^0.14.27"
+    postcss "^8.4.13"
+    resolve "^1.22.0"
+    rollup ">=2.59.0 <2.78.0"
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.21.1.tgz#b4f5b901c9a23a3aaec76d3404f3072821d93d00"
-  integrity sha512-WBIxuFmIDPuK47GO6Lu9eNeRMqHj/FWL3dk73OHH3eyPPWPiu+UB3QHLkLK2PEggCqJW4FaWoWg8R68S7p9+9Q==
+vitest@0.12.6:
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.12.6.tgz#9de2cca78e97effe5395230486ebd3830d0721dd"
+  integrity sha512-YWbCTv0XKBuBw5YtuW/iufuguoi8QhGpYyi2g57Oo7akpscMkkWTAaZGgY0ux1oJJtO/pc/8GFt0EF32WFBUUQ==
   dependencies:
-    "@types/chai" "^4.3.3"
+    "@types/chai" "^4.3.1"
     "@types/chai-subset" "^1.3.3"
-    "@types/node" "*"
     chai "^4.3.6"
-    debug "^4.3.4"
-    local-pkg "^0.4.2"
-    tinypool "^0.2.4"
-    tinyspy "^1.0.0"
-    vite "^2.9.12 || ^3.0.0-0"
+    local-pkg "^0.4.1"
+    tinypool "^0.1.3"
+    tinyspy "^0.3.2"
+    vite "^2.9.8"
 
 vm2@^3.9.8:
   version "3.9.10"


### PR DESCRIPTION
There's a current mismatch of the tasknames that are stored in the rules meta vs. the tasks themselves, in that the rules meta stores the fully qualified task name, and the tasks themselves to not. This PR fixes this inconsistency.