### PR TITLE
Adding stylish formatter to replace pretty formatter (deprecated)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "shorthash": "^0.0.2",
     "stdout-stderr": "^0.1.13",
     "strip-ansi": "^6.0.0",
+    "text-table": "^0.2.0",
     "tmp": "^0.2.1",
     "tslib": "^2",
     "v8-compile-cache": "^2.3.0",

--- a/packages/cli/src/formatters/get-formatter.ts
+++ b/packages/cli/src/formatters/get-formatter.ts
@@ -17,6 +17,7 @@ import SummaryFormatter from './summary.js';
 import JsonFormatter from './json.js';
 import PrettyFormatter from './pretty.js';
 import SonarQubeFormatter from './sonarqube.js';
+import StylishFormatter from './stylish.js';
 
 const require = createRequire(import.meta.url);
 
@@ -42,6 +43,11 @@ export async function getFormatter(options: FormatterOptions) {
   switch (mergedOptions.format) {
     case OutputFormat.summary: {
       Formatter = SummaryFormatter;
+      break;
+    }
+
+    case OutputFormat.stylish: {
+      Formatter = StylishFormatter;
       break;
     }
 

--- a/packages/cli/src/formatters/stylish.ts
+++ b/packages/cli/src/formatters/stylish.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk';
-import { CheckupLogParser, Formatter, FormatterOptions } from '@checkup/core';
+import { CheckupLogParser, Formatter, FormatterOptions, Task } from '@checkup/core';
 import stripAnsi from 'strip-ansi';
 import table from 'text-table';
+import { Result } from 'sarif';
 
 export default class StylishFormatter implements Formatter {
   shouldWrite = true;
@@ -16,14 +17,27 @@ export default class StylishFormatter implements Formatter {
 
     if (logParser.results.length > 0) {
       let results = logParser.resultsByFile;
+      let total = logParser.results.length;
+      let summary = new Map<string, number>([
+        ['migrations', 0],
+        ['info', 0],
+        ['best practices', 0],
+        ['linting', 0],
+        ['testing', 0],
+        ['metrics', 0],
+        ['results', 0],
+      ]);
 
       for (const [uri, resultsForUri] of results) {
         output += `${chalk.underline(uri)}\n`;
 
         output += `${table(
           resultsForUri.map((result) => {
-            let messageType;
-            messageType = result.level === 'error' ? chalk.red('error') : chalk.yellow('warning');
+            let category = getCategory(logParser, result);
+            let messageType = getMessageType(category);
+            let count = summary.get(category) || 0;
+            summary.set(category, (count += 1));
+
             return [
               '',
               logParser.getPropertyValue(result, 'locations.0.physicalLocation.region.startLine') ||
@@ -45,11 +59,55 @@ export default class StylishFormatter implements Formatter {
           }
         )
           .split('\n')
-          // .map((el) => el.replace(/(\d+)\s+(\d+)/u, (m, p1, p2) => chalk.dim(`${p1}:${p2}`)))
+          .map((el) => el.replace(/(\d+)\s+(\d+)/u, (m, p1, p2) => chalk.dim(`${p1}:${p2}`)))
           .join('\n')}\n\n`;
       }
+
+      // loop summaries and add to list, enclose in parens
+      output += chalk.white.bold(
+        [
+          '✅ ',
+          total,
+          ' results',
+          ' (',
+          [...summary.entries()]
+            .filter(([, count]) => count > 0)
+            .map(([category, count]) => `${getMessageType(category)} ${count}`)
+            .join(', '),
+          ')\n',
+        ].join('')
+      );
     }
 
     return output;
   }
+}
+
+function getCategory(lp: CheckupLogParser, result: Result): Task['category'] {
+  let ruleId = result.ruleId;
+
+  if (!ruleId) {
+    return '';
+  }
+
+  let rule = lp.getRule(ruleId);
+
+  if (!rule) {
+    return '';
+  }
+
+  return lp.getPropertyValue(rule, 'properties.category') || 'results';
+}
+
+function getMessageType(category: Task['category']) {
+  let messageTypes = new Map<string, string>([
+    ['migrations', chalk.magenta('migrations')],
+    ['info', chalk.blueBright('info')],
+    ['best practices', chalk.green('best practices')],
+    ['linting', chalk.cyan('linting')],
+    ['testing', chalk.greenBright('testing')],
+    ['metrics', chalk.yellow('metrics')],
+  ]);
+
+  return messageTypes.has(category) ? messageTypes.get(category) : chalk.white(category);
 }

--- a/packages/cli/src/formatters/stylish.ts
+++ b/packages/cli/src/formatters/stylish.ts
@@ -1,0 +1,55 @@
+import chalk from 'chalk';
+import { CheckupLogParser, Formatter, FormatterOptions } from '@checkup/core';
+import stripAnsi from 'strip-ansi';
+import table from 'text-table';
+
+export default class StylishFormatter implements Formatter {
+  shouldWrite = true;
+  options: FormatterOptions;
+
+  constructor(options: FormatterOptions) {
+    this.options = options;
+  }
+
+  format(logParser: CheckupLogParser): string {
+    let output = '\n';
+
+    if (logParser.results.length > 0) {
+      let results = logParser.resultsByFile;
+
+      for (const [uri, resultsForUri] of results) {
+        output += `${chalk.underline(uri)}\n`;
+
+        output += `${table(
+          resultsForUri.map((result) => {
+            let messageType;
+            messageType = result.level === 'error' ? chalk.red('error') : chalk.yellow('warning');
+            return [
+              '',
+              logParser.getPropertyValue(result, 'locations.0.physicalLocation.region.startLine') ||
+                0,
+              logParser.getPropertyValue(
+                result,
+                'locations.0.physicalLocation.region.startColumn'
+              ) || 0,
+              messageType,
+              result.message.text?.replace(/([^ ])\.$/u, '$1'),
+              chalk.dim(result.ruleId || ''),
+            ];
+          }),
+          {
+            align: [null, 'r', 'l'],
+            stringLength(str: string) {
+              return stripAnsi(str).length;
+            },
+          }
+        )
+          .split('\n')
+          // .map((el) => el.replace(/(\d+)\s+(\d+)/u, (m, p1, p2) => chalk.dim(`${p1}:${p2}`)))
+          .join('\n')}\n\n`;
+      }
+    }
+
+    return output;
+  }
+}

--- a/packages/cli/tests/__fixtures__/checkup-result-short.sarif
+++ b/packages/cli/tests/__fixtures__/checkup-result-short.sarif
@@ -1,0 +1,5325 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "checkup",
+          "language": "en-US",
+          "informationUri": "https://github.com/checkupjs/checkup",
+          "rules": [
+            {
+              "id": "ember-types",
+              "shortDescription": {
+                "text": "Gets a breakdown of all Ember types in an Ember.js project"
+              },
+              "properties": {
+                "taskDisplayName": "Ember Types",
+                "category": "metrics",
+                "component": {
+                  "name": "list",
+                  "options": {
+                    "items": {
+                      "components": {
+                        "groupBy": "properties.type",
+                        "value": "components"
+                      },
+                      "controllers": {
+                        "groupBy": "properties.type",
+                        "value": "controllers"
+                      },
+                      "helpers": {
+                        "groupBy": "properties.type",
+                        "value": "helpers"
+                      },
+                      "initializers": {
+                        "groupBy": "properties.type",
+                        "value": "initializers"
+                      },
+                      "instance-initializers": {
+                        "groupBy": "properties.type",
+                        "value": "instance-initializers"
+                      },
+                      "mixins": {
+                        "groupBy": "properties.type",
+                        "value": "mixins"
+                      },
+                      "models": {
+                        "groupBy": "properties.type",
+                        "value": "models"
+                      },
+                      "routes": {
+                        "groupBy": "properties.type",
+                        "value": "routes"
+                      },
+                      "services": {
+                        "groupBy": "properties.type",
+                        "value": "services"
+                      },
+                      "templates": {
+                        "groupBy": "properties.type",
+                        "value": "templates"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "eslint-summary",
+              "shortDescription": {
+                "text": "Gets a summary of all eslint results in a project"
+              },
+              "properties": {
+                "taskDisplayName": "Eslint Summary",
+                "category": "linting",
+                "component": {
+                  "name": "list",
+                  "options": {
+                    "items": {
+                      "Errors": {
+                        "groupBy": "level",
+                        "value": "error"
+                      },
+                      "Warnings": {
+                        "groupBy": "level",
+                        "value": "warning"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "ember-test-types",
+              "shortDescription": {
+                "text": "Gets a breakdown of all test types in an Ember.js project"
+              },
+              "properties": {
+                "taskDisplayName": "Test Types",
+                "category": "testing",
+                "component": {
+                  "name": "list",
+                  "options": {
+                    "items": {
+                      "Application": {
+                        "groupBy": "properties.testType",
+                        "value": "application"
+                      },
+                      "Rendering": {
+                        "groupBy": "properties.testType",
+                        "value": "rendering"
+                      },
+                      "Unit": {
+                        "groupBy": "properties.testType",
+                        "value": "unit"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "ember-octane-migration-status",
+              "shortDescription": {
+                "text": "Tracks the migration status when moving from Ember Classic to Ember Octane in an Ember.js project"
+              },
+              "properties": {
+                "taskDisplayName": "Ember Octane Migration Status",
+                "category": "migrations",
+                "component": {
+                  "name": "migration"
+                },
+                "features": [
+                  "Native Classes",
+                  "Native Classes",
+                  "Native Classes",
+                  "Native Classes",
+                  "Glimmer Components",
+                  "Native Classes",
+                  "Native Classes",
+                  "Glimmer Components",
+                  "Native Classes",
+                  "Tagless Components",
+                  "Glimmer Components",
+                  "Tracked Properties",
+                  "Angle Bracket Syntax",
+                  "Named Arguments",
+                  "Own Properties",
+                  "Modifiers"
+                ]
+              }
+            },
+            {
+              "id": "ember-template-lint-summary",
+              "shortDescription": {
+                "text": "Gets a summary of all ember-template-lint results in an Ember.js project"
+              },
+              "properties": {
+                "taskDisplayName": "Template Lint Summary",
+                "category": "linting",
+                "component": {
+                  "name": "list",
+                  "options": {
+                    "items": {
+                      "Errors": {
+                        "groupBy": "level",
+                        "value": "error"
+                      },
+                      "Warnings": {
+                        "groupBy": "level",
+                        "value": "warning"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "eslint-disables",
+              "shortDescription": {
+                "text": "Finds all disabled eslint rules in a project"
+              },
+              "properties": {
+                "taskDisplayName": "Number of eslint-disable Usages",
+                "category": "linting",
+                "component": {
+                  "name": "list",
+                  "options": {
+                    "items": {
+                      "Disabled rules": {
+                        "groupBy": "level",
+                        "value": "note"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "lines-of-code",
+              "shortDescription": {
+                "text": "Counts lines of code within a project"
+              },
+              "properties": {
+                "taskDisplayName": "Lines Of Code",
+                "category": "info",
+                "component": {
+                  "name": "table",
+                  "options": {
+                    "sumBy": {
+                      "findGroupBy": "Language",
+                      "sumValueBy": "Total Lines"
+                    },
+                    "rows": {
+                      "Language": "properties.extension",
+                      "Total Lines": "properties.lines"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "outdated-dependencies",
+              "shortDescription": {
+                "text": "Gets a summary of all outdated dependencies in a project"
+              },
+              "properties": {
+                "taskDisplayName": "Outdated Dependencies",
+                "category": "dependencies",
+                "component": {
+                  "name": "table",
+                  "options": {
+                    "rows": {
+                      "Dependency": "properties.packageName",
+                      "Installed": "properties.packageVersion",
+                      "Latest": "properties.latestVersion"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "ember-dependencies",
+              "shortDescription": {
+                "text": "Finds Ember-specific dependencies and their versions in an Ember.js project"
+              },
+              "properties": {
+                "taskDisplayName": "Ember Dependencies",
+                "category": "dependencies",
+                "component": {
+                  "name": "table",
+                  "options": {
+                    "rows": {
+                      "Dependency": "properties.packageName",
+                      "Installed": "properties.packageVersion",
+                      "Latest": "properties.latestVersion"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": {
+            "checkup": {
+              "project": {
+                "name": "travis",
+                "version": "0.0.1",
+                "repository": {
+                  "totalCommits": 6012,
+                  "totalFiles": 1692,
+                  "age": "9 years",
+                  "activeDays": "1470"
+                }
+              },
+              "cli": {
+                "configHash": "257cda6f6d50eeef891fc6ec8d808bdb",
+                "config": {
+                  "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+                  "excludePaths": [],
+                  "plugins": [
+                    "checkup-plugin-javascript",
+                    "checkup-plugin-ember"
+                  ],
+                  "tasks": {}
+                },
+                "version": "1.0.0-beta.14",
+                "schema": 1
+              },
+              "analyzedFiles": [
+                ".checkup/checkup-error-2021-09-23-13_52_00.log",
+                ".checkuprc",
+                ".dockerignore",
+                ".editorconfig",
+                ".ember-cli",
+                ".env.example",
+                ".eslintignore",
+                ".eslintrc.js",
+                ".gitignore",
+                ".rspec",
+                ".ruby-version",
+                ".slugignore",
+                ".template-lintrc.js",
+                ".travis.yml",
+                "CODE_OF_CONDUCT.md",
+                "CONTRIBUTING.md",
+                "Dockerfile",
+                "Gemfile",
+                "Gemfile.lock",
+                "ISSUE_TEMPLATE.md",
+                "LICENSE",
+                "MODULE_REPORT.md",
+                "Makefile",
+                "Procfile",
+                "README.md",
+                "app/.eslintrc.js",
+                "app/adapters/allowance.js",
+                "app/adapters/application.js",
+                "app/adapters/beta-feature.js",
+                "app/adapters/beta-migration-request.js",
+                "app/adapters/branch.js",
+                "app/adapters/build.js",
+                "app/adapters/coupon.js",
+                "app/adapters/cron.js",
+                "app/adapters/env-var.js",
+                "app/adapters/invoice.js",
+                "app/adapters/job.js",
+                "app/adapters/lead.js",
+                "app/adapters/organization.js",
+                "app/adapters/owner.js",
+                "app/adapters/plan.js",
+                "app/adapters/preference.js",
+                "app/adapters/repo.js",
+                "app/adapters/request.js",
+                "app/adapters/ssh-key.js",
+                "app/adapters/stage.js",
+                "app/adapters/subscription.js",
+                "app/adapters/trial.js",
+                "app/adapters/user.js",
+                "app/adapters/v2-plan-config.js",
+                "app/adapters/v2-subscription.js",
+                "app/adapters/v3.js",
+                "app/app.js",
+                "app/components/account-token.js",
+                "app/components/active-repo-count.js",
+                "app/components/add-cron-job.js",
+                "app/components/add-env-var.js",
+                "app/components/add-ssh-key.js",
+                "app/components/annotated-yaml.js",
+                "app/components/beta-feature.js",
+                "app/components/billing-resubscribe-button.js",
+                "app/components/billing-summary-status.js",
+                "app/components/billing/account.js",
+                "app/components/billing/address.js",
+                "app/components/billing/authorization.js",
+                "app/components/billing/auto-refill.js",
+                "app/components/billing/contact-details.js",
+                "app/components/billing/credit-balance.js",
+                "app/components/billing/education.js",
+                "app/components/billing/information.js",
+                "app/components/billing/invoices.js",
+                "app/components/billing/oss-credit-toggle.js",
+                "app/components/billing/payment-details.js",
+                "app/components/billing/payment.js",
+                "app/components/billing/postal-address.js",
+                "app/components/billing/price.js",
+                "app/components/billing/process.js",
+                "app/components/billing/select-addon.js",
+                "app/components/billing/select-plan.js",
+                "app/components/billing/selected-addon.js",
+                "app/components/billing/selected-plan.js",
+                "app/components/billing/subscription.js",
+                "app/components/billing/summary-v2.js",
+                "app/components/billing/summary.js",
+                "app/components/billing/trial.js",
+                "app/components/billing/user-usage.js",
+                "app/components/billing/warning-message.js",
+                "app/components/branch-row.js",
+                "app/components/broadcast-tower.js",
+                "app/components/build-count.js",
+                "app/components/build-flow-diagram.js",
+                "app/components/build-header.js",
+                "app/components/build-layout.js",
+                "app/components/build-message-line.js",
+                "app/components/build-message.js",
+                "app/components/build-messages-list.js",
+                "app/components/build-minutes.js",
+                "app/components/build-not-found.js",
+                "app/components/build-status-chart.js",
+                "app/components/build-tabs.js",
+                "app/components/build-tile.js",
+                "app/components/build-wrapper.js",
+                "app/components/builds-backup-item.js",
+                "app/components/builds-item.js",
+                "app/components/button-activate-all-github.js",
+                "app/components/caches-item.js",
+                "app/components/created-by.js",
+                "app/components/cron-job.js",
+                "app/components/dashboard-row.js",
+                "app/components/dialogs/cancel-subscription-modal.js",
+                "app/components/dialogs/migrate-beta.js",
+                "app/components/dialogs/prioritize-build-modal.js",
+                "app/components/dialogs/switch-to-free-modal.js",
+                "app/components/dialogs/user-management-modal.js",
+                "app/components/dialogs/user-statistics-modal.js",
+                "app/components/email-unsubscribe.js",
+                "app/components/enterprise-banner.js",
+                "app/components/env-var.js",
+                "app/components/external-link-to.js",
+                "app/components/feature-toggle.js",
+                "app/components/flash-display.js",
+                "app/components/flash-item.js",
+                "app/components/forms/form-checkbox.js",
+                "app/components/forms/form-field.js",
+                "app/components/forms/form-input.js",
+                "app/components/forms/form-select-multiple.js",
+                "app/components/forms/form-select.js",
+                "app/components/forms/form-slider.js",
+                "app/components/forms/form-switch.js",
+                "app/components/forms/form-textarea.js",
+                "app/components/forms/multiple-inputs-field.js",
+                "app/components/getting-started-step.js",
+                "app/components/getting-started-steps-generic.js",
+                "app/components/github-apps-repository.js",
+                "app/components/header-broadcasts.js",
+                "app/components/header-burger-menu.js",
+                "app/components/header-links.js",
+                "app/components/insights-date-display.js",
+                "app/components/insights-glance.js",
+                "app/components/insights-overlay.js",
+                "app/components/insights-privacy-selector.js",
+                "app/components/insights-tabs.js",
+                "app/components/job-infrastructure-notification.js",
+                "app/components/job-log.js",
+                "app/components/job-tabs.js",
+                "app/components/job-wrapper.js",
+                "app/components/jobs-item.js",
+                "app/components/jobs-list.js",
+                "app/components/landing-default-page.js",
+                "app/components/landing-pro-page.js",
+                "app/components/lastbuild-tile.js",
+                "app/components/layouts/sidebar.js",
+                "app/components/layouts/striped-section.js",
+                "app/components/layouts/striped.js",
+                "app/components/limit-concurrent-builds.js",
+                "app/components/link-to-account.js",
+                "app/components/load-more.js",
+                "app/components/loading-indicator.js",
+                "app/components/loading-overlay.js",
+                "app/components/loading-page.js",
+                "app/components/loading-screen.js",
+                "app/components/log-content.js",
+                "app/components/manual-subscription-help.js",
+                "app/components/migration-banner.js",
+                "app/components/modal.js",
+                "app/components/multi-signin-button.js",
+                "app/components/my-build.js",
+                "app/components/new-subscription-button.js",
+                "app/components/no-repos.js",
+                "app/components/not-active.js",
+                "app/components/org-item.js",
+                "app/components/oss-usage-digit.js",
+                "app/components/oss-usage-numbers.js",
+                "app/components/overlay-backdrop.js",
+                "app/components/owner-not-found.js",
+                "app/components/owner-repo-tile.js",
+                "app/components/owner-sync-button.js",
+                "app/components/owner/migrate.js",
+                "app/components/owner/repositories.js",
+                "app/components/page-footer.js",
+                "app/components/pagination-navigation.js",
+                "app/components/paper-block.js",
+                "app/components/plan-usage.js",
+                "app/components/profile-accounts-wrapper.js",
+                "app/components/profile-menu.js",
+                "app/components/profile-nav.js",
+                "app/components/queue-times.js",
+                "app/components/queued-jobs.js",
+                "app/components/raw-config.js",
+                "app/components/remove-log-popup.js",
+                "app/components/repo-actions.js",
+                "app/components/repo-build-list.js",
+                "app/components/repo-not-found.js",
+                "app/components/repo-show-tabs.js",
+                "app/components/repo-show-tools.js",
+                "app/components/repo-status-badge.js",
+                "app/components/repo-wrapper.js",
+                "app/components/repos-list-item.js",
+                "app/components/repos-list-tabs.js",
+                "app/components/repos-list.js",
+                "app/components/repository-filter-form.js",
+                "app/components/repository-filter.js",
+                "app/components/repository-layout.js",
+                "app/components/repository-migration-modal.js",
+                "app/components/repository-sidebar.js",
+                "app/components/repository-status-toggle.js",
+                "app/components/request-config.js",
+                "app/components/request-icon.js",
+                "app/components/requests-item.js",
+                "app/components/running-jobs-item.js",
+                "app/components/running-jobs.js",
+                "app/components/sales-contact-form.js",
+                "app/components/sales-contact-thanks.js",
+                "app/components/scroll-here.js",
+                "app/components/settings-switch.js",
+                "app/components/show-more-button.js",
+                "app/components/ssh-key.js",
+                "app/components/status-icon.js",
+                "app/components/status-image-input.js",
+                "app/components/status-images.js",
+                "app/components/subscribe-button.js",
+                "app/components/subscription-status-banner.js",
+                "app/components/svg-image.js",
+                "app/components/sync-button.js",
+                "app/components/top-bar.js",
+                "app/components/top-forum-post-list.js",
+                "app/components/travis-form.js",
+                "app/components/travis-layout.js",
+                "app/components/travis-status.js",
+                "app/components/travis-switch.js",
+                "app/components/trigger-custom-build.js",
+                "app/components/ui-kit/badge.js",
+                "app/components/ui-kit/box.js",
+                "app/components/ui-kit/button-signin.js",
+                "app/components/ui-kit/button.js",
+                "app/components/ui-kit/code.js",
+                "app/components/ui-kit/grid-item.js",
+                "app/components/ui-kit/grid.js",
+                "app/components/ui-kit/image.js",
+                "app/components/ui-kit/link.js",
+                "app/components/ui-kit/note.js",
+                "app/components/ui-kit/switch.js",
+                "app/components/ui-kit/text.js",
+                "app/components/user-avatar.js",
+                "app/components/visibility-setting-list.js",
+                "app/components/x-tracer.js",
+                "app/components/zendesk-request-form.js",
+                "app/controllers/account.js",
+                "app/controllers/account/billing.js",
+                "app/controllers/account/billing/index.js",
+                "app/controllers/account/migrate.js",
+                "app/controllers/account/plan_usage.js",
+                "app/controllers/account/repositories.js",
+                "app/controllers/account/settings.js",
+                "app/controllers/application.js",
+                "app/controllers/branches.js",
+                "app/controllers/build.js",
+                "app/controllers/build/index.js",
+                "app/controllers/builds.js",
+                "app/controllers/caches.js",
+                "app/controllers/dashboard.js",
+                "app/controllers/dashboard/builds.js",
+                "app/controllers/dashboard/repositories.js",
+                "app/controllers/error.js",
+                "app/controllers/features-tracing.js",
+                "app/controllers/first-sync.js",
+                "app/controllers/flash.js",
+                "app/controllers/getting-started.js",
+                "app/controllers/github-apps-installation.js",
+                "app/controllers/help.js",
+                "app/controllers/index.js",
+                "app/controllers/job.js",
+                "app/controllers/loading.js",
+                "app/controllers/organization/billing.js",
+                "app/controllers/organization/migrate.js",
+                "app/controllers/organization/plan_usage.js",
+                "app/controllers/organization/repositories.js",
+                "app/controllers/organization/settings.js",
+                "app/controllers/owner.js",
+                "app/controllers/owner/repositories.js",
+                "app/controllers/plans/index.js",
+                "app/controllers/pull-requests.js",
+                "app/controllers/repo.js",
+                "app/controllers/repo/index.js",
+                "app/controllers/requests.js",
+                "app/controllers/search.js",
+                "app/controllers/settings.js",
+                "app/controllers/signin.js",
+                "app/controllers/signup.js",
+                "app/controllers/travisci-vs-jenkins/index.js",
+                "app/helpers/combine-validators.js",
+                "app/helpers/commit-link.js",
+                "app/helpers/config-get.js",
+                "app/helpers/form-validator.js",
+                "app/helpers/format-commit.js",
+                "app/helpers/format-currency.js",
+                "app/helpers/format-domain.js",
+                "app/helpers/format-duration.js",
+                "app/helpers/format-message.js",
+                "app/helpers/format-number.js",
+                "app/helpers/format-sha.js",
+                "app/helpers/format-time.js",
+                "app/helpers/humanize-state.js",
+                "app/helpers/indefinite-article.js",
+                "app/helpers/obfuscated-chars.js",
+                "app/helpers/pagination-query-params.js",
+                "app/helpers/pretty-date.js",
+                "app/helpers/short-compare-shas.js",
+                "app/helpers/travis-mb.js",
+                "app/helpers/vcs-color.js",
+                "app/helpers/vcs-icon.js",
+                "app/helpers/vcs-name.js",
+                "app/helpers/vcs-vocab.js",
+                "app/index.html",
+                "app/initializers/app.js",
+                "app/initializers/configure-inflector.js",
+                "app/initializers/services.js",
+                "app/initializers/tracer.js",
+                "app/instance-initializers/enterprise-environment.js",
+                "app/instance-initializers/pro-environment.js",
+                "app/instance-initializers/pusher.js",
+                "app/instance-initializers/raven-release.js",
+                "app/mixins/branch-searching.js",
+                "app/mixins/build-favicon.js",
+                "app/mixins/builds/load-more.js",
+                "app/mixins/components/form-select.js",
+                "app/mixins/components/with-config-validation.js",
+                "app/mixins/controller/account-repositories.js",
+                "app/mixins/controller/billing.js",
+                "app/mixins/controller/plan_usage.js",
+                "app/mixins/duration-attributes.js",
+                "app/mixins/duration-calculations.js",
+                "app/mixins/polling.js",
+                "app/mixins/route/account/billing.js",
+                "app/mixins/route/account/plan_usage.js",
+                "app/mixins/route/owner/migrate.js",
+                "app/mixins/route/owner/repositories.js",
+                "app/mixins/scroll-reset.js",
+                "app/mixins/tailwind-base.js",
+                "app/models/allowance.js",
+                "app/models/beta-feature.js",
+                "app/models/beta-migration-request.js",
+                "app/models/billing-info.js",
+                "app/models/branch.js",
+                "app/models/build.js",
+                "app/models/commit.js",
+                "app/models/coupon.js",
+                "app/models/credit-card-info.js",
+                "app/models/cron.js",
+                "app/models/discount.js",
+                "app/models/env-var.js",
+                "app/models/installation.js",
+                "app/models/invoice.js",
+                "app/models/invoices.js",
+                "app/models/job.js",
+                "app/models/lead.js",
+                "app/models/log.js",
+                "app/models/organization.js",
+                "app/models/owner.js",
+                "app/models/plan.js",
+                "app/models/preference.js",
+                "app/models/repo.js",
+                "app/models/request.js",
+                "app/models/ssh-key.js",
+                "app/models/stage.js",
+                "app/models/subscription.js",
+                "app/models/trial.js",
+                "app/models/user.js",
+                "app/models/v2-billing-info.js",
+                "app/models/v2-credit-card-info.js",
+                "app/models/v2-plan-config.js",
+                "app/models/v2-subscription.js",
+                "app/models/vcs-entity.js",
+                "app/resolver.js",
+                "app/router.js",
+                "app/routes/account-error.js",
+                "app/routes/account.js",
+                "app/routes/account/billing.js",
+                "app/routes/account/index.js",
+                "app/routes/account/migrate.js",
+                "app/routes/account/plan_usage.js",
+                "app/routes/account/repositories.js",
+                "app/routes/account/settings.js",
+                "app/routes/application.js",
+                "app/routes/basic.js",
+                "app/routes/branches.js",
+                "app/routes/build.js",
+                "app/routes/build/config.js",
+                "app/routes/builds.js",
+                "app/routes/caches.js",
+                "app/routes/confirm-user.js",
+                "app/routes/dashboard.js",
+                "app/routes/dashboard/builds.js",
+                "app/routes/dashboard/repositories.js",
+                "app/routes/error.js",
+                "app/routes/features-tracing.js",
+                "app/routes/first-sync.js",
+                "app/routes/getting-started.js",
+                "app/routes/github-apps-installation.js",
+                "app/routes/help.js",
+                "app/routes/index.js",
+                "app/routes/insufficient-oauth-permissions.js",
+                "app/routes/integration.js",
+                "app/routes/integration/bitbucket.js",
+                "app/routes/integration/index.js",
+                "app/routes/job.js",
+                "app/routes/job/config.js",
+                "app/routes/legacy-repo-url.js",
+                "app/routes/logo.js",
+                "app/routes/not-found.js",
+                "app/routes/organization.js",
+                "app/routes/organization/billing.js",
+                "app/routes/organization/index.js",
+                "app/routes/organization/migrate.js",
+                "app/routes/organization/plan_usage.js",
+                "app/routes/organization/repositories.js",
+                "app/routes/organization/settings.js",
+                "app/routes/owner.js",
+                "app/routes/owner/repositories.js",
+                "app/routes/page-not-found.js",
+                "app/routes/plans.js",
+                "app/routes/plans/index.js",
+                "app/routes/profile.js",
+                "app/routes/provider.js",
+                "app/routes/pull-requests.js",
+                "app/routes/repo.js",
+                "app/routes/repo/index.js",
+                "app/routes/request-user-confirmation.js",
+                "app/routes/requests.js",
+                "app/routes/search.js",
+                "app/routes/settings.js",
+                "app/routes/signin.js",
+                "app/routes/signup.js",
+                "app/routes/simple-layout.js",
+                "app/routes/team.js",
+                "app/routes/travisci-vs-jenkins.js",
+                "app/routes/unsubscribe.js",
+                "app/serializers/.eslintrc.js",
+                "app/serializers/account.js",
+                "app/serializers/allowance.js",
+                "app/serializers/application.js",
+                "app/serializers/beta-feature.js",
+                "app/serializers/beta-migration-request.js",
+                "app/serializers/branch.js",
+                "app/serializers/build.js",
+                "app/serializers/build_v2_fallback.js",
+                "app/serializers/commit.js",
+                "app/serializers/cron.js",
+                "app/serializers/env-var.js",
+                "app/serializers/invoice.js",
+                "app/serializers/job.js",
+                "app/serializers/job_v2_fallback.js",
+                "app/serializers/lead.js",
+                "app/serializers/organization.js",
+                "app/serializers/owner.js",
+                "app/serializers/plan.js",
+                "app/serializers/preference.js",
+                "app/serializers/repo.js",
+                "app/serializers/repo_v2_fallback.js",
+                "app/serializers/request.js",
+                "app/serializers/ssh_key.js",
+                "app/serializers/stage.js",
+                "app/serializers/subscription.js",
+                "app/serializers/trial.js",
+                "app/serializers/user.js",
+                "app/serializers/v2-subscription.js",
+                "app/serializers/v2_fallback.js",
+                "app/serializers/v3.js",
+                "app/services/accounts.js",
+                "app/services/ajax.js",
+                "app/services/animation.js",
+                "app/services/api.js",
+                "app/services/app-loading.js",
+                "app/services/auth.js",
+                "app/services/broadcasts.js",
+                "app/services/download.js",
+                "app/services/external-links.js",
+                "app/services/feature-flags.js",
+                "app/services/flashes.js",
+                "app/services/insights.js",
+                "app/services/job-config-fetcher.js",
+                "app/services/job-state.js",
+                "app/services/live-updates-record-fetcher.js",
+                "app/services/multi-vcs.js",
+                "app/services/permissions.js",
+                "app/services/polling.js",
+                "app/services/preferences.js",
+                "app/services/pusher.js",
+                "app/services/random-logo.js",
+                "app/services/raven.js",
+                "app/services/repositories.js",
+                "app/services/session-storage.js",
+                "app/services/status-images.js",
+                "app/services/storage.js",
+                "app/services/storage/auth.js",
+                "app/services/storage/utm.js",
+                "app/services/store.js",
+                "app/services/stripe.js",
+                "app/services/tab-states.js",
+                "app/services/tasks.js",
+                "app/services/trigger-build-popup.js",
+                "app/services/update-times.js",
+                "app/services/utm.js",
+                "app/styles/app.scss",
+                "app/styles/app/animation/barricade.scss",
+                "app/styles/app/animation/fade.scss",
+                "app/styles/app/animation/tractor.scss",
+                "app/styles/app/base.scss",
+                "app/styles/app/data.scss",
+                "app/styles/app/layout.scss",
+                "app/styles/app/layouts/ansi.scss",
+                "app/styles/app/layouts/billing.scss",
+                "app/styles/app/layouts/branches.scss",
+                "app/styles/app/layouts/broadcasts.scss",
+                "app/styles/app/layouts/caches.scss",
+                "app/styles/app/layouts/content.scss",
+                "app/styles/app/layouts/dashboard.scss",
+                "app/styles/app/layouts/error.scss",
+                "app/styles/app/layouts/features.scss",
+                "app/styles/app/layouts/footer.scss",
+                "app/styles/app/layouts/insights.scss",
+                "app/styles/app/layouts/jobs.scss",
+                "app/styles/app/layouts/log.scss",
+                "app/styles/app/layouts/missing-notice.scss",
+                "app/styles/app/layouts/owner.scss",
+                "app/styles/app/layouts/profile.scss",
+                "app/styles/app/layouts/pull-requests.scss",
+                "app/styles/app/layouts/repo.scss",
+                "app/styles/app/layouts/requests.scss",
+                "app/styles/app/layouts/settings.scss",
+                "app/styles/app/layouts/sidebar.scss",
+                "app/styles/app/layouts/striped.scss",
+                "app/styles/app/layouts/top.scss",
+                "app/styles/app/legacy/_functions.scss",
+                "app/styles/app/legacy/_global.scss",
+                "app/styles/app/legacy/_grid.scss",
+                "app/styles/app/mixins.scss",
+                "app/styles/app/modules/account.scss",
+                "app/styles/app/modules/avatar.scss",
+                "app/styles/app/modules/badge.scss",
+                "app/styles/app/modules/build-header.scss",
+                "app/styles/app/modules/build-messages.scss",
+                "app/styles/app/modules/build-tile.scss",
+                "app/styles/app/modules/buttons.scss",
+                "app/styles/app/modules/dashboard-row.scss",
+                "app/styles/app/modules/dropdown.scss",
+                "app/styles/app/modules/dropup.scss",
+                "app/styles/app/modules/email-unsubscribe.scss",
+                "app/styles/app/modules/enterprise-banner.scss",
+                "app/styles/app/modules/flash.scss",
+                "app/styles/app/modules/forms.scss",
+                "app/styles/app/modules/icons.scss",
+                "app/styles/app/modules/lastbuild.scss",
+                "app/styles/app/modules/loader.scss",
+                "app/styles/app/modules/loading-indicator.scss",
+                "app/styles/app/modules/loading-overlay.scss",
+                "app/styles/app/modules/loading-screen.scss",
+                "app/styles/app/modules/logo.scss",
+                "app/styles/app/modules/migrate-beta-dialog.scss",
+                "app/styles/app/modules/migrate.scss",
+                "app/styles/app/modules/modals.scss",
+                "app/styles/app/modules/navigation.scss",
+                "app/styles/app/modules/notice.scss",
+                "app/styles/app/modules/overlay-backdrop.scss",
+                "app/styles/app/modules/pagination.scss",
+                "app/styles/app/modules/paper-block.scss",
+                "app/styles/app/modules/popup.scss",
+                "app/styles/app/modules/prioritize-build.scss",
+                "app/styles/app/modules/row.scss",
+                "app/styles/app/modules/search.scss",
+                "app/styles/app/modules/status-icon.scss",
+                "app/styles/app/modules/switch.scss",
+                "app/styles/app/modules/sync-button.scss",
+                "app/styles/app/modules/tabs.scss",
+                "app/styles/app/modules/tofuburger.scss",
+                "app/styles/app/modules/tooltips.scss",
+                "app/styles/app/modules/tracer.scss",
+                "app/styles/app/modules/travis-form.scss",
+                "app/styles/app/modules/travis-status.scss",
+                "app/styles/app/modules/visibility-setting-list.scss",
+                "app/styles/app/modules/yaml.scss",
+                "app/styles/app/pages/help.scss",
+                "app/styles/app/pages/home-pro.scss",
+                "app/styles/app/pages/landing.scss",
+                "app/styles/app/pages/logo.scss",
+                "app/styles/app/pages/plans.scss",
+                "app/styles/app/power-select-vars.scss",
+                "app/styles/app/typography.scss",
+                "app/styles/app/vars.scss",
+                "app/styles/app/z-index.scss",
+                "app/styles/tailwind/base.scss",
+                "app/styles/tailwind/components.scss",
+                "app/styles/tailwind/utilities.scss",
+                "app/templates/account-error.hbs",
+                "app/templates/account-loading.hbs",
+                "app/templates/account.hbs",
+                "app/templates/account/billing-loading.hbs",
+                "app/templates/account/billing.hbs",
+                "app/templates/account/billing/index.hbs",
+                "app/templates/account/migrate.hbs",
+                "app/templates/account/plan_usage.hbs",
+                "app/templates/account/repositories-loading.hbs",
+                "app/templates/account/repositories.hbs",
+                "app/templates/account/settings-loading.hbs",
+                "app/templates/account/settings.hbs",
+                "app/templates/application-loading.hbs",
+                "app/templates/application.hbs",
+                "app/templates/branches.hbs",
+                "app/templates/build-error.hbs",
+                "app/templates/build.hbs",
+                "app/templates/build/config.hbs",
+                "app/templates/build/index.hbs",
+                "app/templates/builds.hbs",
+                "app/templates/caches.hbs",
+                "app/templates/components/account-token.hbs",
+                "app/templates/components/active-repo-count.hbs",
+                "app/templates/components/add-cron-job.hbs",
+                "app/templates/components/add-env-var.hbs",
+                "app/templates/components/add-ssh-key.hbs",
+                "app/templates/components/annotated-yaml.hbs",
+                "app/templates/components/beta-feature.hbs",
+                "app/templates/components/billing-manual.hbs",
+                "app/templates/components/billing-resubscribe-button.hbs",
+                "app/templates/components/billing-summary-status.hbs",
+                "app/templates/components/billing/account.hbs",
+                "app/templates/components/billing/address.hbs",
+                "app/templates/components/billing/authorization.hbs",
+                "app/templates/components/billing/auto-refill.hbs",
+                "app/templates/components/billing/billing-details.hbs",
+                "app/templates/components/billing/contact-details.hbs",
+                "app/templates/components/billing/credit-balance.hbs",
+                "app/templates/components/billing/education.hbs",
+                "app/templates/components/billing/information.hbs",
+                "app/templates/components/billing/invoices.hbs",
+                "app/templates/components/billing/oss-credit-toggle.hbs",
+                "app/templates/components/billing/payment-details.hbs",
+                "app/templates/components/billing/payment.hbs",
+                "app/templates/components/billing/postal-address.hbs",
+                "app/templates/components/billing/price-v2.hbs",
+                "app/templates/components/billing/price.hbs",
+                "app/templates/components/billing/process.hbs",
+                "app/templates/components/billing/select-addon.hbs",
+                "app/templates/components/billing/select-plan.hbs",
+                "app/templates/components/billing/selected-addon.hbs",
+                "app/templates/components/billing/selected-plan.hbs",
+                "app/templates/components/billing/subscription.hbs",
+                "app/templates/components/billing/summary-v2.hbs",
+                "app/templates/components/billing/summary.hbs",
+                "app/templates/components/billing/trial.hbs",
+                "app/templates/components/billing/user-usage.hbs",
+                "app/templates/components/billing/warning-message.hbs",
+                "app/templates/components/branch-row.hbs",
+                "app/templates/components/broadcast-tower.hbs",
+                "app/templates/components/build-count.hbs",
+                "app/templates/components/build-flow-diagram.hbs",
+                "app/templates/components/build-header.hbs",
+                "app/templates/components/build-layout.hbs",
+                "app/templates/components/build-message-line.hbs",
+                "app/templates/components/build-message.hbs",
+                "app/templates/components/build-messages-list.hbs",
+                "app/templates/components/build-minutes.hbs",
+                "app/templates/components/build-not-found.hbs",
+                "app/templates/components/build-status-chart.hbs",
+                "app/templates/components/build-tabs.hbs",
+                "app/templates/components/build-tile.hbs",
+                "app/templates/components/builds-backup-item.hbs",
+                "app/templates/components/builds-item.hbs",
+                "app/templates/components/button-activate-all-github.hbs",
+                "app/templates/components/caches-item.hbs",
+                "app/templates/components/created-by.hbs",
+                "app/templates/components/cron-job.hbs",
+                "app/templates/components/dashboard-row.hbs",
+                "app/templates/components/dialogs/cancel-subscription-modal.hbs",
+                "app/templates/components/dialogs/migrate-beta.hbs",
+                "app/templates/components/dialogs/prioritize-build-modal.hbs",
+                "app/templates/components/dialogs/switch-to-free-modal.hbs",
+                "app/templates/components/dialogs/user-management-modal.hbs",
+                "app/templates/components/dialogs/user-statistics-modal.hbs",
+                "app/templates/components/email-unsubscribe.hbs",
+                "app/templates/components/enterprise-banner.hbs",
+                "app/templates/components/env-var.hbs",
+                "app/templates/components/error-page-layout.hbs",
+                "app/templates/components/external-link-to.hbs",
+                "app/templates/components/feature-toggle.hbs",
+                "app/templates/components/flash-display.hbs",
+                "app/templates/components/flash-item.hbs",
+                "app/templates/components/flashes/negative-balance-private-and-public.hbs",
+                "app/templates/components/flashes/negative-balance-private.hbs",
+                "app/templates/components/flashes/negative-balance-public.hbs",
+                "app/templates/components/flashes/pending-user-licenses.hbs",
+                "app/templates/components/flashes/read-only-mode.hbs",
+                "app/templates/components/flashes/users-limit-exceeded.hbs",
+                "app/templates/components/forms/form-checkbox.hbs",
+                "app/templates/components/forms/form-field.hbs",
+                "app/templates/components/forms/form-slider.hbs",
+                "app/templates/components/forms/form-switch.hbs",
+                "app/templates/components/forms/multiple-inputs-field.hbs",
+                "app/templates/components/getting-started-step.hbs",
+                "app/templates/components/getting-started-steps-generic.hbs",
+                "app/templates/components/github-apps-repository.hbs",
+                "app/templates/components/header-broadcasts.hbs",
+                "app/templates/components/header-burger-menu.hbs",
+                "app/templates/components/header-links.hbs",
+                "app/templates/components/insights-date-display.hbs",
+                "app/templates/components/insights-glance.hbs",
+                "app/templates/components/insights-overlay.hbs",
+                "app/templates/components/insights-privacy-selector.hbs",
+                "app/templates/components/insights-tabs.hbs",
+                "app/templates/components/job-infrastructure-notification.hbs",
+                "app/templates/components/job-log.hbs",
+                "app/templates/components/job-not-found.hbs",
+                "app/templates/components/job-tabs.hbs",
+                "app/templates/components/jobs-item.hbs",
+                "app/templates/components/jobs-list.hbs",
+                "app/templates/components/landing-default-page.hbs",
+                "app/templates/components/landing-pro-page.hbs",
+                "app/templates/components/lastbuild-tile.hbs",
+                "app/templates/components/layouts/sidebar.hbs",
+                "app/templates/components/layouts/striped-section.hbs",
+                "app/templates/components/layouts/striped.hbs",
+                "app/templates/components/limit-concurrent-builds.hbs",
+                "app/templates/components/link-to-account.hbs",
+                "app/templates/components/load-more.hbs",
+                "app/templates/components/loading-indicator.hbs",
+                "app/templates/components/loading-overlay.hbs",
+                "app/templates/components/loading-page.hbs",
+                "app/templates/components/loading-screen.hbs",
+                "app/templates/components/log-content.hbs",
+                "app/templates/components/manage-subscription-button.hbs",
+                "app/templates/components/manual-subscription-help.hbs",
+                "app/templates/components/migration-banner.hbs",
+                "app/templates/components/missing-notice.hbs",
+                "app/templates/components/modal.hbs",
+                "app/templates/components/multi-signin-button.hbs",
+                "app/templates/components/my-build.hbs",
+                "app/templates/components/no-account.hbs",
+                "app/templates/components/no-builds.hbs",
+                "app/templates/components/no-repos.hbs",
+                "app/templates/components/not-active.hbs",
+                "app/templates/components/notice-banner.hbs",
+                "app/templates/components/org-item.hbs",
+                "app/templates/components/oss-usage-digit.hbs",
+                "app/templates/components/oss-usage-numbers.hbs",
+                "app/templates/components/overlay-backdrop.hbs",
+                "app/templates/components/owner-not-found.hbs",
+                "app/templates/components/owner-repo-tile.hbs",
+                "app/templates/components/owner-sync-button.hbs",
+                "app/templates/components/owner/migrate.hbs",
+                "app/templates/components/owner/repositories.hbs",
+                "app/templates/components/page-footer.hbs",
+                "app/templates/components/pagination-navigation.hbs",
+                "app/templates/components/paper-block.hbs",
+                "app/templates/components/plan_usage.hbs",
+                "app/templates/components/profile-menu.hbs",
+                "app/templates/components/profile-nav.hbs",
+                "app/templates/components/queue-times.hbs",
+                "app/templates/components/queued-jobs.hbs",
+                "app/templates/components/raw-config.hbs",
+                "app/templates/components/remove-log-popup.hbs",
+                "app/templates/components/repo-actions.hbs",
+                "app/templates/components/repo-build-list.hbs",
+                "app/templates/components/repo-not-found.hbs",
+                "app/templates/components/repo-show-tabs.hbs",
+                "app/templates/components/repo-show-tools.hbs",
+                "app/templates/components/repo-status-badge.hbs",
+                "app/templates/components/repos-list-item.hbs",
+                "app/templates/components/repos-list-tabs.hbs",
+                "app/templates/components/repos-list.hbs",
+                "app/templates/components/repository-filter-form.hbs",
+                "app/templates/components/repository-filter.hbs",
+                "app/templates/components/repository-layout.hbs",
+                "app/templates/components/repository-migration-modal.hbs",
+                "app/templates/components/repository-sidebar.hbs",
+                "app/templates/components/repository-status-toggle.hbs",
+                "app/templates/components/repository-visibility-icon.hbs",
+                "app/templates/components/request-config.hbs",
+                "app/templates/components/request-icon.hbs",
+                "app/templates/components/requests-item.hbs",
+                "app/templates/components/resubscribe-button.hbs",
+                "app/templates/components/running-jobs-item.hbs",
+                "app/templates/components/running-jobs.hbs",
+                "app/templates/components/sales-contact-form.hbs",
+                "app/templates/components/sales-contact-thanks.hbs",
+                "app/templates/components/scroll-here.hbs",
+                "app/templates/components/settings-switch.hbs",
+                "app/templates/components/show-more-button.hbs",
+                "app/templates/components/ssh-key.hbs",
+                "app/templates/components/status-icon.hbs",
+                "app/templates/components/status-images.hbs",
+                "app/templates/components/subscription-status-banner.hbs",
+                "app/templates/components/svg-image.hbs",
+                "app/templates/components/sync-button.hbs",
+                "app/templates/components/top-bar.hbs",
+                "app/templates/components/top-forum-post-list.hbs",
+                "app/templates/components/travis-form.hbs",
+                "app/templates/components/travis-status.hbs",
+                "app/templates/components/travis-switch.hbs",
+                "app/templates/components/trigger-custom-build.hbs",
+                "app/templates/components/ui-kit/badge.hbs",
+                "app/templates/components/ui-kit/box.hbs",
+                "app/templates/components/ui-kit/button-signin.hbs",
+                "app/templates/components/ui-kit/button.hbs",
+                "app/templates/components/ui-kit/code.hbs",
+                "app/templates/components/ui-kit/grid-item.hbs",
+                "app/templates/components/ui-kit/grid.hbs",
+                "app/templates/components/ui-kit/image.hbs",
+                "app/templates/components/ui-kit/link.hbs",
+                "app/templates/components/ui-kit/note.hbs",
+                "app/templates/components/ui-kit/switch.hbs",
+                "app/templates/components/ui-kit/text.hbs",
+                "app/templates/components/unconfirmed-user-banner.hbs",
+                "app/templates/components/user-avatar.hbs",
+                "app/templates/components/visibility-setting-list.hbs",
+                "app/templates/components/x-tracer.hbs",
+                "app/templates/components/zendesk-request-form.hbs",
+                "app/templates/confirm-user.hbs",
+                "app/templates/dashboard.hbs",
+                "app/templates/dashboard/builds.hbs",
+                "app/templates/dashboard/loading.hbs",
+                "app/templates/dashboard/repositories.hbs",
+                "app/templates/error.hbs",
+                "app/templates/error404.hbs",
+                "app/templates/features-tracing.hbs",
+                "app/templates/first-sync.hbs",
+                "app/templates/getting-started.hbs",
+                "app/templates/github_apps_installation.hbs",
+                "app/templates/head.hbs",
+                "app/templates/help.hbs",
+                "app/templates/index.hbs",
+                "app/templates/insufficient-oauth-permissions.hbs",
+                "app/templates/integration.hbs",
+                "app/templates/integration/bitbucket.hbs",
+                "app/templates/job-error.hbs",
+                "app/templates/job.hbs",
+                "app/templates/job/config.hbs",
+                "app/templates/job/index.hbs",
+                "app/templates/layouts/center-max.hbs",
+                "app/templates/layouts/center.hbs",
+                "app/templates/layouts/error.hbs",
+                "app/templates/layouts/landing-page.hbs",
+                "app/templates/layouts/profile.hbs",
+                "app/templates/layouts/striped.hbs",
+                "app/templates/layouts/support.hbs",
+                "app/templates/loading.hbs",
+                "app/templates/logo.hbs",
+                "app/templates/not-found.hbs",
+                "app/templates/organization.hbs",
+                "app/templates/organization/billing.hbs",
+                "app/templates/organization/migrate.hbs",
+                "app/templates/organization/plan_usage.hbs",
+                "app/templates/organization/repositories-loading.hbs",
+                "app/templates/organization/repositories.hbs",
+                "app/templates/organization/settings.hbs",
+                "app/templates/owner-error.hbs",
+                "app/templates/owner-loading.hbs",
+                "app/templates/owner.hbs",
+                "app/templates/owner/error.hbs",
+                "app/templates/owner/repositories.hbs",
+                "app/templates/plans.hbs",
+                "app/templates/plans/index.hbs",
+                "app/templates/plans/thank-you.hbs",
+                "app/templates/pull-requests.hbs",
+                "app/templates/repo-error.hbs",
+                "app/templates/repo.hbs",
+                "app/templates/repo/active-on-org.hbs",
+                "app/templates/repo/error.hbs",
+                "app/templates/repo/loading.hbs",
+                "app/templates/repo/no-build.hbs",
+                "app/templates/repo/not-active.hbs",
+                "app/templates/repos-list/empty.hbs",
+                "app/templates/requests.hbs",
+                "app/templates/search.hbs",
+                "app/templates/settings.hbs",
+                "app/templates/signin.hbs",
+                "app/templates/signup.hbs",
+                "app/templates/travisci-vs-jenkins/index.hbs",
+                "app/templates/travisci-vs-jenkins/thank-you.hbs",
+                "app/templates/unsubscribe.hbs",
+                "app/transitions.js",
+                "app/utils/.eslintrc.js",
+                "app/utils/abstract-method.js",
+                "app/utils/api-errors.js",
+                "app/utils/bind-generator.js",
+                "app/utils/color-for-state.js",
+                "app/utils/computed-limit.js",
+                "app/utils/countries.js",
+                "app/utils/dashboard-repositories-sort.js",
+                "app/utils/duration-from.js",
+                "app/utils/dynamic-query.js",
+                "app/utils/eventually.js",
+                "app/utils/expandable-record-array.js",
+                "app/utils/favicon-data-uris.js",
+                "app/utils/favicon-manager.js",
+                "app/utils/fetch-all.js",
+                "app/utils/fetch-live-paginated-collection.js",
+                "app/utils/filtered-array-manager.js",
+                "app/utils/form-validators.js",
+                "app/utils/format-commit.js",
+                "app/utils/format-config.js",
+                "app/utils/format-sha.js",
+                "app/utils/fuzzy-match.js",
+                "app/utils/job-config-arch.js",
+                "app/utils/job-config-language.js",
+                "app/utils/json-parser.js",
+                "app/utils/keys-map.js",
+                "app/utils/lines-selector.js",
+                "app/utils/live-paginated-collection.js",
+                "app/utils/log-folder.js",
+                "app/utils/log.js",
+                "app/utils/object-collect.js",
+                "app/utils/paginated-collection-promise.js",
+                "app/utils/paginated-collection.js",
+                "app/utils/promise-object.js",
+                "app/utils/pusher.js",
+                "app/utils/string-hash.js",
+                "app/utils/tailing.js",
+                "app/utils/time-ago-in-words.js",
+                "app/utils/time-in-words.js",
+                "app/utils/traverse-payload.js",
+                "app/utils/ui-kit/assertions.js",
+                "app/utils/ui-kit/colors.js",
+                "app/utils/ui-kit/concat.js",
+                "app/utils/ui-kit/prefix.js",
+                "app/utils/ui-kit/responsive.js",
+                "app/utils/ui-kit/variant.js",
+                "app/utils/vcs.js",
+                "app/utils/wrap-with-array.js",
+                "checkup-report-2021-09-23-13_37_59.sarif",
+                "config/deploy.js",
+                "config/deployment/deploy-local.sh",
+                "config/deployment/deploy-pull-request.sh",
+                "config/deployment/deploy-test-master.sh",
+                "config/deployment/update-github-status.sh",
+                "config/deprecation-workflow.js",
+                "config/dotenv.js",
+                "config/ember-try.js",
+                "config/environment.js",
+                "config/manifest.js",
+                "config/optional-features.json",
+                "config/plans.js",
+                "config/providers.js",
+                "config/screens.js",
+                "config/tailwind.js",
+                "config/targets.js",
+                "docker-compose.yml",
+                "ember-cli-build.js",
+                "mirage/.eslintrc.js",
+                "mirage/api-spec.js",
+                "mirage/config.js",
+                "mirage/factories/beta-migration-request.js",
+                "mirage/factories/branch.js",
+                "mirage/factories/broadcast.js",
+                "mirage/factories/build.js",
+                "mirage/factories/commit.js",
+                "mirage/factories/coupon.js",
+                "mirage/factories/cron.js",
+                "mirage/factories/env-var.js",
+                "mirage/factories/feature.js",
+                "mirage/factories/hook.js",
+                "mirage/factories/insight-metric.js",
+                "mirage/factories/job.js",
+                "mirage/factories/log.js",
+                "mirage/factories/message.js",
+                "mirage/factories/organization.js",
+                "mirage/factories/permissions.js",
+                "mirage/factories/plan.js",
+                "mirage/factories/repository.js",
+                "mirage/factories/request.js",
+                "mirage/factories/ssh-key.js",
+                "mirage/factories/stage.js",
+                "mirage/factories/subscription.js",
+                "mirage/factories/user.js",
+                "mirage/fixtures/preferences.js",
+                "mirage/fixtures/v2-plan-configs.js",
+                "mirage/models/allowance.js",
+                "mirage/models/billing-info.js",
+                "mirage/models/branch.js",
+                "mirage/models/broadcast.js",
+                "mirage/models/build.js",
+                "mirage/models/cache.js",
+                "mirage/models/commit.js",
+                "mirage/models/coupon.js",
+                "mirage/models/credit-card-info.js",
+                "mirage/models/cron.js",
+                "mirage/models/discount.js",
+                "mirage/models/env-var.js",
+                "mirage/models/feature.js",
+                "mirage/models/git-user.js",
+                "mirage/models/hook.js",
+                "mirage/models/insight-metric.js",
+                "mirage/models/installation.js",
+                "mirage/models/invoice.js",
+                "mirage/models/job.js",
+                "mirage/models/log.js",
+                "mirage/models/message.js",
+                "mirage/models/organization.js",
+                "mirage/models/permissions.js",
+                "mirage/models/plan.js",
+                "mirage/models/preference.js",
+                "mirage/models/repository.js",
+                "mirage/models/request.js",
+                "mirage/models/settings.js",
+                "mirage/models/ssh-key.js",
+                "mirage/models/stage.js",
+                "mirage/models/subscription.js",
+                "mirage/models/trial.js",
+                "mirage/models/user.js",
+                "mirage/models/v2-billing-info.js",
+                "mirage/models/v2-credit-card-info.js",
+                "mirage/models/v2-plan-config.js",
+                "mirage/models/v2-subscription.js",
+                "mirage/scenarios/default.js",
+                "mirage/serializers/allowance.js",
+                "mirage/serializers/application.js",
+                "mirage/serializers/branch.js",
+                "mirage/serializers/build.js",
+                "mirage/serializers/cache.js",
+                "mirage/serializers/commit-v3.js",
+                "mirage/serializers/commit.js",
+                "mirage/serializers/coupon.js",
+                "mirage/serializers/cron.js",
+                "mirage/serializers/feature.js",
+                "mirage/serializers/git-user.js",
+                "mirage/serializers/job.js",
+                "mirage/serializers/owner.js",
+                "mirage/serializers/preference.js",
+                "mirage/serializers/repository.js",
+                "mirage/serializers/stage.js",
+                "mirage/serializers/subscription.js",
+                "mirage/serializers/user-v3.js",
+                "mirage/serializers/user.js",
+                "mirage/serializers/v2-plan-config.js",
+                "mirage/serializers/v2-subscription.js",
+                "mirage/serializers/v2.js",
+                "mirage/serializers/v3.js",
+                "node_modules/.bin/acorn",
+                "node_modules/.bin/ansi-html",
+                "node_modules/.bin/ansi-to-html",
+                "node_modules/.bin/atob",
+                "node_modules/.bin/autoprefixer",
+                "node_modules/.bin/babylon",
+                "node_modules/.bin/browserslist",
+                "node_modules/.bin/can-symlink",
+                "node_modules/.bin/cdl",
+                "node_modules/.bin/cleancss",
+                "node_modules/.bin/cssesc",
+                "node_modules/.bin/csv2json",
+                "node_modules/.bin/csv2tsv",
+                "node_modules/.bin/detective",
+                "node_modules/.bin/dsv2dsv",
+                "node_modules/.bin/dsv2json",
+                "node_modules/.bin/ember",
+                "node_modules/.bin/ember-source-channel-url",
+                "node_modules/.bin/errno",
+                "node_modules/.bin/escodegen",
+                "node_modules/.bin/esgenerate",
+                "node_modules/.bin/eslint",
+                "node_modules/.bin/esparse",
+                "node_modules/.bin/esvalidate",
+                "node_modules/.bin/handlebars",
+                "node_modules/.bin/inline-source-map-comment",
+                "node_modules/.bin/js-yaml",
+                "node_modules/.bin/jsesc",
+                "node_modules/.bin/json2csv",
+                "node_modules/.bin/json2dsv",
+                "node_modules/.bin/json2tsv",
+                "node_modules/.bin/json2yaml",
+                "node_modules/.bin/json5",
+                "node_modules/.bin/loose-envify",
+                "node_modules/.bin/markdown-it",
+                "node_modules/.bin/miller-rabin",
+                "node_modules/.bin/mime",
+                "node_modules/.bin/mkdirp",
+                "node_modules/.bin/mustache",
+                "node_modules/.bin/node-which",
+                "node_modules/.bin/nopt",
+                "node_modules/.bin/parser",
+                "node_modules/.bin/purgecss",
+                "node_modules/.bin/qunit",
+                "node_modules/.bin/rc",
+                "node_modules/.bin/regjsparser",
+                "node_modules/.bin/rimraf",
+                "node_modules/.bin/rollup",
+                "node_modules/.bin/sane",
+                "node_modules/.bin/sass",
+                "node_modules/.bin/semver",
+                "node_modules/.bin/sha.js",
+                "node_modules/.bin/sort-package-json",
+                "node_modules/.bin/sshpk-conv",
+                "node_modules/.bin/sshpk-sign",
+                "node_modules/.bin/sshpk-verify",
+                "node_modules/.bin/svgo",
+                "node_modules/.bin/tailwind",
+                "node_modules/.bin/tailwindcss",
+                "node_modules/.bin/tap-parser",
+                "node_modules/.bin/terser",
+                "node_modules/.bin/testem",
+                "node_modules/.bin/tsv2csv",
+                "node_modules/.bin/tsv2json",
+                "node_modules/.bin/uglifyjs",
+                "node_modules/.bin/uuid",
+                "node_modules/.bin/watch",
+                "node_modules/.bin/webpack",
+                "node_modules/.bin/yaml2json",
+                "node_modules/.yarn-integrity",
+                "package-lock.json",
+                "package.json",
+                "public/500.html",
+                "public/check-browser-support.js",
+                "public/favicon.png",
+                "public/images/billing/account-unauthorized.svg",
+                "public/images/billing/heart.png",
+                "public/images/billing/icon-checkmark.svg",
+                "public/images/billing/icon-credit-card.svg",
+                "public/images/billing/icon-currency-EUR.svg",
+                "public/images/billing/icon-currency-USD.svg",
+                "public/images/config/alert.svg",
+                "public/images/config/error.svg",
+                "public/images/config/info.svg",
+                "public/images/config/warn.svg",
+                "public/images/error/404-hills-left.svg",
+                "public/images/error/404-hills-right.svg",
+                "public/images/error/500-hills-left.svg",
+                "public/images/error/500-hills-right.svg",
+                "public/images/error/500-hills-shade-left.svg",
+                "public/images/error/500-hills-shade-right.svg",
+                "public/images/error/500-road.svg",
+                "public/images/error/excavator.svg",
+                "public/images/error/maintenance-grass-shade-left.svg",
+                "public/images/error/maintenance-grass-shade-right.svg",
+                "public/images/error/maintenance-hills-left.svg",
+                "public/images/error/maintenance-hills-right.svg",
+                "public/images/error/maintenance-tractor.svg",
+                "public/images/error/pensive-travis.svg",
+                "public/images/favicon-gray.png",
+                "public/images/favicon-green.png",
+                "public/images/favicon-red.png",
+                "public/images/favicon-yellow.png",
+                "public/images/favicon.png",
+                "public/images/favicon.svg",
+                "public/images/getting-started/build-email-03.png",
+                "public/images/getting-started/build-email.jpg",
+                "public/images/getting-started/build-email.png",
+                "public/images/getting-started/first-build.jpg",
+                "public/images/getting-started/first-build.png",
+                "public/images/getting-started/first-project-no-recent.png",
+                "public/images/getting-started/getting-started-step-1-github.svg",
+                "public/images/getting-started/getting-started-step-1.svg",
+                "public/images/getting-started/getting-started-step-2.svg",
+                "public/images/getting-started/getting-started-step-3.svg",
+                "public/images/getting-started/mustache-no-spin.png",
+                "public/images/getting-started/mustache-spinner.gif",
+                "public/images/getting-started/new-project.jpg",
+                "public/images/getting-started/project-switch.png",
+                "public/images/getting-started/project_switch.png",
+                "public/images/getting-started/truck.gif",
+                "public/images/landing-page/Gh.svg",
+                "public/images/landing-page/PR.svg",
+                "public/images/landing-page/alex.png",
+                "public/images/landing-page/build-flow-small.png",
+                "public/images/landing-page/build-flow.png",
+                "public/images/landing-page/chris.png",
+                "public/images/landing-page/customers-facebook.svg",
+                "public/images/landing-page/customers-heroku.svg",
+                "public/images/landing-page/customers-mozilla.svg",
+                "public/images/landing-page/customers-rails.svg",
+                "public/images/landing-page/customers-temp-together.svg",
+                "public/images/landing-page/customers-twitter.svg",
+                "public/images/landing-page/customers-zendesk.svg",
+                "public/images/landing-page/dhh.png",
+                "public/images/landing-page/features-callouts-1.svg",
+                "public/images/landing-page/features-callouts-2.svg",
+                "public/images/landing-page/features-callouts-3.svg",
+                "public/images/landing-page/features-callouts-4.svg",
+                "public/images/landing-page/features-check.svg",
+                "public/images/landing-page/github.svg",
+                "public/images/landing-page/heroku.svg",
+                "public/images/landing-page/lang-clojure.svg",
+                "public/images/landing-page/lang-erlang.svg",
+                "public/images/landing-page/lang-go.svg",
+                "public/images/landing-page/lang-java.svg",
+                "public/images/landing-page/lang-node.svg",
+                "public/images/landing-page/lang-perl.svg",
+                "public/images/landing-page/lang-php.svg",
+                "public/images/landing-page/lang-python.svg",
+                "public/images/landing-page/lang-ruby.svg",
+                "public/images/landing-page/lang-scala.svg",
+                "public/images/landing-page/lang-xcode.svg",
+                "public/images/landing-page/laptop.png",
+                "public/images/landing-page/oss-num-0.svg",
+                "public/images/landing-page/oss-num-1.svg",
+                "public/images/landing-page/oss-num-2.svg",
+                "public/images/landing-page/oss-num-3.svg",
+                "public/images/landing-page/oss-num-4.svg",
+                "public/images/landing-page/oss-num-5.svg",
+                "public/images/landing-page/oss-num-6.svg",
+                "public/images/landing-page/oss-num-7.svg",
+                "public/images/landing-page/oss-num-8.svg",
+                "public/images/landing-page/oss-num-9.svg",
+                "public/images/landing-page/platform.svg",
+                "public/images/landing-page/pr-flow-small.png",
+                "public/images/landing-page/pr-flow.png",
+                "public/images/landing-page/pull-icon-1.svg",
+                "public/images/landing-page/pull-icon-2.svg",
+                "public/images/landing-page/pull-icon-3.svg",
+                "public/images/landing-page/pull-icon-4.svg",
+                "public/images/landing-page/pull-icon-5.svg",
+                "public/images/landing-page/push-icon-1.svg",
+                "public/images/landing-page/push-icon-2.svg",
+                "public/images/landing-page/push-icon-3.svg",
+                "public/images/landing-page/push-icon-4.svg",
+                "public/images/landing-page/push-icon-5.svg",
+                "public/images/landing-page/pypy.png",
+                "public/images/landing-page/rails.svg",
+                "public/images/landing-page/sign-in-mascot.svg",
+                "public/images/landing-page/signingithub-hover.svg",
+                "public/images/landing-page/signingithub.svg",
+                "public/images/landing-page/temp-repo-green.svg",
+                "public/images/landing-page/temp-repo-red.svg",
+                "public/images/landing-page/temp-repo-yellow.svg",
+                "public/images/landing-page/twitter-quote.svg",
+                "public/images/landing-page/twitter.svg",
+                "public/images/layout/made-in-berlin-badge.png",
+                "public/images/layout/travis-logo.png",
+                "public/images/logos/Tessa-1.eps",
+                "public/images/logos/Tessa-1.png",
+                "public/images/logos/Tessa-1.svg",
+                "public/images/logos/Tessa-2.eps",
+                "public/images/logos/Tessa-2.png",
+                "public/images/logos/Tessa-2.svg",
+                "public/images/logos/Tessa-3.eps",
+                "public/images/logos/Tessa-3.png",
+                "public/images/logos/Tessa-3.svg",
+                "public/images/logos/Tessa-4.eps",
+                "public/images/logos/Tessa-4.png",
+                "public/images/logos/Tessa-4.svg",
+                "public/images/logos/Tessa-pride-4.eps",
+                "public/images/logos/Tessa-pride-4.png",
+                "public/images/logos/Tessa-pride-4.svg",
+                "public/images/logos/Tessa-pride.eps",
+                "public/images/logos/Tessa-pride.png",
+                "public/images/logos/Tessa-pride.svg",
+                "public/images/logos/TravisCI-Full-Color-light.eps",
+                "public/images/logos/TravisCI-Full-Color-light.png",
+                "public/images/logos/TravisCI-Full-Color-vertical.eps",
+                "public/images/logos/TravisCI-Full-Color-vertical.png",
+                "public/images/logos/TravisCI-Full-Color.eps",
+                "public/images/logos/TravisCI-Full-Color.png",
+                "public/images/logos/TravisCI-Mascot-1.eps",
+                "public/images/logos/TravisCI-Mascot-1.png",
+                "public/images/logos/TravisCI-Mascot-1.svg",
+                "public/images/logos/TravisCI-Mascot-2.eps",
+                "public/images/logos/TravisCI-Mascot-2.png",
+                "public/images/logos/TravisCI-Mascot-2.svg",
+                "public/images/logos/TravisCI-Mascot-3.eps",
+                "public/images/logos/TravisCI-Mascot-3.png",
+                "public/images/logos/TravisCI-Mascot-3.svg",
+                "public/images/logos/TravisCI-Mascot-4.eps",
+                "public/images/logos/TravisCI-Mascot-4.png",
+                "public/images/logos/TravisCI-Mascot-4.svg",
+                "public/images/logos/TravisCI-Mascot-blue.eps",
+                "public/images/logos/TravisCI-Mascot-blue.png",
+                "public/images/logos/TravisCI-Mascot-blue.svg",
+                "public/images/logos/TravisCI-Mascot-grey.eps",
+                "public/images/logos/TravisCI-Mascot-grey.png",
+                "public/images/logos/TravisCI-Mascot-grey.svg",
+                "public/images/logos/TravisCI-Mascot-pride-4.eps",
+                "public/images/logos/TravisCI-Mascot-pride-4.png",
+                "public/images/logos/TravisCI-Mascot-pride-4.svg",
+                "public/images/logos/TravisCI-Mascot-pride.eps",
+                "public/images/logos/TravisCI-Mascot-pride.png",
+                "public/images/logos/TravisCI-Mascot-pride.svg",
+                "public/images/logos/TravisCI-Mascot-red.eps",
+                "public/images/logos/TravisCI-Mascot-red.png",
+                "public/images/logos/TravisCI-Mascot-red.svg",
+                "public/images/logos/logo-dark-bg-blue.eps",
+                "public/images/logos/logo-dark-bg-blue.png",
+                "public/images/logos/logo-dark-bg-grey.eps",
+                "public/images/logos/logo-dark-bg-grey.png",
+                "public/images/logos/logo-dark-bg-red.eps",
+                "public/images/logos/logo-dark-bg-red.png",
+                "public/images/logos/logo-light-bg-blue.eps",
+                "public/images/logos/logo-light-bg-blue.png",
+                "public/images/logos/logo-light-bg-grey.eps",
+                "public/images/logos/logo-light-bg-grey.png",
+                "public/images/logos/logo-light-bg-red.eps",
+                "public/images/logos/logo-light-bg-red.png",
+                "public/images/logos/mascot-bg-blue.eps",
+                "public/images/logos/mascot-bg-blue.png",
+                "public/images/logos/mascot-bg-grey.eps",
+                "public/images/logos/mascot-bg-grey.png",
+                "public/images/logos/mascot-bg-red.eps",
+                "public/images/logos/mascot-bg-red.png",
+                "public/images/mailer/arrow-error.png",
+                "public/images/mailer/arrow-failed.png",
+                "public/images/mailer/arrow-success.png",
+                "public/images/mailer/canceled-header-bg.png",
+                "public/images/mailer/clock.png",
+                "public/images/mailer/email-footer-travis-logo.png",
+                "public/images/mailer/error.png",
+                "public/images/mailer/errored-header-bg.png",
+                "public/images/mailer/failed-header-bg.png",
+                "public/images/mailer/failed.png",
+                "public/images/mailer/footer-logo-38x38.png",
+                "public/images/mailer/mascot-avatar-15px.png",
+                "public/images/mailer/mascot-avatar-40px.png",
+                "public/images/mailer/passed-header-bg.png",
+                "public/images/mailer/please-donate.png",
+                "public/images/mailer/stopwatch-error.png",
+                "public/images/mailer/stopwatch-failed.png",
+                "public/images/mailer/stopwatch-success.png",
+                "public/images/mailer/success.png",
+                "public/images/mailer/travis-mascot.png",
+                "public/images/messages/msg-alert.svg",
+                "public/images/messages/msg-error.svg",
+                "public/images/messages/msg-info.svg",
+                "public/images/messages/msg-warn.svg",
+                "public/images/pro-landing/TravisCI-logo-darkbg.svg",
+                "public/images/pro-landing/TravisCI-logo.svg",
+                "public/images/pro-landing/TravisCI-logolockup-spacingexample-darkbg.svg",
+                "public/images/pro-landing/TravisCI-logolockup-spacingexample.svg",
+                "public/images/pro-landing/TravisCI-mascot.svg",
+                "public/images/pro-landing/TravisCI-mascot2.svg",
+                "public/images/pro-landing/TravisCI-mascot3.svg",
+                "public/images/pro-landing/TravisCI-mascot4.svg",
+                "public/images/pro-landing/hero-header.png",
+                "public/images/pro-landing/sign-up-icon.svg",
+                "public/images/rgsoc.jpg",
+                "public/images/stroke-icons/checkmark.svg",
+                "public/images/stroke-icons/icon-alert.svg",
+                "public/images/stroke-icons/icon-api.svg",
+                "public/images/stroke-icons/icon-arch.svg",
+                "public/images/stroke-icons/icon-arrow-down.svg",
+                "public/images/stroke-icons/icon-arrowdown.svg",
+                "public/images/stroke-icons/icon-arrowtabs.svg",
+                "public/images/stroke-icons/icon-assembla.svg",
+                "public/images/stroke-icons/icon-bitbucket.svg",
+                "public/images/stroke-icons/icon-branch.svg",
+                "public/images/stroke-icons/icon-broadcast.svg",
+                "public/images/stroke-icons/icon-builds.svg",
+                "public/images/stroke-icons/icon-calendar.svg",
+                "public/images/stroke-icons/icon-canceled.svg",
+                "public/images/stroke-icons/icon-cancelled.png",
+                "public/images/stroke-icons/icon-clock.svg",
+                "public/images/stroke-icons/icon-close.svg",
+                "public/images/stroke-icons/icon-commit.svg",
+                "public/images/stroke-icons/icon-compare.svg",
+                "public/images/stroke-icons/icon-cones.svg",
+                "public/images/stroke-icons/icon-copy.svg",
+                "public/images/stroke-icons/icon-cronjobs.svg",
+                "public/images/stroke-icons/icon-debug.svg",
+                "public/images/stroke-icons/icon-deletelogs.svg",
+                "public/images/stroke-icons/icon-download.svg",
+                "public/images/stroke-icons/icon-downloadlogs.svg",
+                "public/images/stroke-icons/icon-environment.svg",
+                "public/images/stroke-icons/icon-errored.png",
+                "public/images/stroke-icons/icon-errored.svg",
+                "public/images/stroke-icons/icon-external-link.svg",
+                "public/images/stroke-icons/icon-failed.png",
+                "public/images/stroke-icons/icon-failed.svg",
+                "public/images/stroke-icons/icon-filter.svg",
+                "public/images/stroke-icons/icon-fingerprint.svg",
+                "public/images/stroke-icons/icon-flag.svg",
+                "public/images/stroke-icons/icon-freebsd.svg",
+                "public/images/stroke-icons/icon-github-white.svg",
+                "public/images/stroke-icons/icon-github.svg",
+                "public/images/stroke-icons/icon-gitlab.svg",
+                "public/images/stroke-icons/icon-hash.svg",
+                "public/images/stroke-icons/icon-help.svg",
+                "public/images/stroke-icons/icon-invoice.svg",
+                "public/images/stroke-icons/icon-key.svg",
+                "public/images/stroke-icons/icon-language.svg",
+                "public/images/stroke-icons/icon-linux.svg",
+                "public/images/stroke-icons/icon-lock.svg",
+                "public/images/stroke-icons/icon-mac.svg",
+                "public/images/stroke-icons/icon-megaphone.svg",
+                "public/images/stroke-icons/icon-migrate.svg",
+                "public/images/stroke-icons/icon-nextcron.svg",
+                "public/images/stroke-icons/icon-nobuilds.svg",
+                "public/images/stroke-icons/icon-os.svg",
+                "public/images/stroke-icons/icon-passed.png",
+                "public/images/stroke-icons/icon-passed.svg",
+                "public/images/stroke-icons/icon-plus.svg",
+                "public/images/stroke-icons/icon-prioritize.svg",
+                "public/images/stroke-icons/icon-private.svg",
+                "public/images/stroke-icons/icon-pull-request.svg",
+                "public/images/stroke-icons/icon-pullrequest.svg",
+                "public/images/stroke-icons/icon-push.svg",
+                "public/images/stroke-icons/icon-repooctocat.svg",
+                "public/images/stroke-icons/icon-restart.svg",
+                "public/images/stroke-icons/icon-running.png",
+                "public/images/stroke-icons/icon-running.svg",
+                "public/images/stroke-icons/icon-scales.svg",
+                "public/images/stroke-icons/icon-search.svg",
+                "public/images/stroke-icons/icon-seemore.svg",
+                "public/images/stroke-icons/icon-settings.svg",
+                "public/images/stroke-icons/icon-shared.svg",
+                "public/images/stroke-icons/icon-star.svg",
+                "public/images/stroke-icons/icon-stopwatch.svg",
+                "public/images/stroke-icons/icon-tag.svg",
+                "public/images/stroke-icons/icon-tofuburger.svg",
+                "public/images/stroke-icons/icon-trash-disabled.svg",
+                "public/images/stroke-icons/icon-trash.svg",
+                "public/images/stroke-icons/icon-windows.svg",
+                "public/images/svg/always-free.svg",
+                "public/images/svg/avatar-checkmark.svg",
+                "public/images/svg/barricade.svg",
+                "public/images/svg/bb-connect.svg",
+                "public/images/svg/bb-integrate.svg",
+                "public/images/svg/bitbucket-full.svg",
+                "public/images/svg/blue-blob.svg",
+                "public/images/svg/blue-waves.svg",
+                "public/images/svg/checkbox-checked.svg",
+                "public/images/svg/checkbox-unchecked.svg",
+                "public/images/svg/cloud.svg",
+                "public/images/svg/commandline.svg",
+                "public/images/svg/community.svg",
+                "public/images/svg/customer-logos-bittorrent.svg",
+                "public/images/svg/customer-logos-engineyard.svg",
+                "public/images/svg/customer-logos-heroku.svg",
+                "public/images/svg/customer-logos-moz.svg",
+                "public/images/svg/customer-logos-zendesk.svg",
+                "public/images/svg/customer-numbers.svg",
+                "public/images/svg/docs.svg",
+                "public/images/svg/engineyard.svg",
+                "public/images/svg/enterprise-servers.svg",
+                "public/images/svg/envelope.svg",
+                "public/images/svg/feature-icon-github.svg",
+                "public/images/svg/feature-icon-heroku.svg",
+                "public/images/svg/feature-icon-platform.svg",
+                "public/images/svg/feature-icon-pullrequests.svg",
+                "public/images/svg/form-error-icon.svg",
+                "public/images/svg/form-valid-icon.svg",
+                "public/images/svg/gitlab-logo.svg",
+                "public/images/svg/green-gradient-circle.svg",
+                "public/images/svg/grey-blob.svg",
+                "public/images/svg/grey-gradient-circle.svg",
+                "public/images/svg/hammer.svg",
+                "public/images/svg/hard-hat-success.svg",
+                "public/images/svg/hard-hat.svg",
+                "public/images/svg/hero-screen.svg",
+                "public/images/svg/icon-dropdown-arrow.svg",
+                "public/images/svg/icon-email.svg",
+                "public/images/svg/icon-encircled-help.svg",
+                "public/images/svg/icon-sign-out.svg",
+                "public/images/svg/job-name-icon.svg",
+                "public/images/svg/kubernetes.svg",
+                "public/images/svg/migrate-beta.svg",
+                "public/images/svg/migrated.svg",
+                "public/images/svg/moz.svg",
+                "public/images/svg/red-blob.svg",
+                "public/images/svg/red-dash-circle.svg",
+                "public/images/svg/sadmail.svg",
+                "public/images/svg/stage-canceled.svg",
+                "public/images/svg/stage-errored.svg",
+                "public/images/svg/stage-failed.svg",
+                "public/images/svg/stage-passed-green.svg",
+                "public/images/svg/stage-passed.svg",
+                "public/images/svg/tractor.svg",
+                "public/images/svg/travis-community.svg",
+                "public/images/svg/travis-console.svg",
+                "public/images/svg/travis-enterprise.svg",
+                "public/images/svg/travisci-logo-grayscale.svg",
+                "public/images/svg/waiting-checkmark.svg",
+                "public/images/svg/wheelbarrow.svg",
+                "public/images/svg/yellow-waves.svg",
+                "public/images/svg/zendesk.svg",
+                "public/images/travis-crying.png",
+                "public/images/travis-mascot-150.png",
+                "public/images/ui/default-avatar.png",
+                "public/images/ui/default-avatar.svg",
+                "public/images/ui/dismiss.svg",
+                "public/images/ui/flash-close.svg",
+                "public/images/ui/flash-error.svg",
+                "public/images/ui/flash-success.svg",
+                "public/images/ui/footer-logo.svg",
+                "public/images/ui/github-signin.svg",
+                "public/images/ui/help.svg",
+                "public/images/ui/icon-error-dismiss.svg",
+                "public/images/ui/icon-success-dismiss.svg",
+                "public/images/ui/icon-warning-dismiss.svg",
+                "public/images/ui/log.fold.closed.2.svg",
+                "public/images/ui/log.fold.closed.3.svg",
+                "public/images/ui/log.fold.closed.svg",
+                "public/images/ui/log.fold.open.2.svg",
+                "public/images/ui/log.fold.open.svg",
+                "public/images/ui/search.svg",
+                "public/images/ui/travis-ci-logo-hover.svg",
+                "public/images/ui/travis-ci-logo.svg",
+                "public/images/ui/workers-close.svg",
+                "public/images/ui/workers-open.svg",
+                "public/maintenance.html",
+                "public/robots.txt",
+                "public/ua-parser.min.js",
+                "public/unsupported-browser.html",
+                "public/version",
+                "server/index.js",
+                "ssl/server.crt",
+                "ssl/server.csr",
+                "ssl/server.key",
+                "testem.js",
+                "tests/acceptance/auth/automatic-sign-out-test.js",
+                "tests/acceptance/auth/first-sync-test.js",
+                "tests/acceptance/auth/github-apps-installation-redirect-test.js",
+                "tests/acceptance/auth/sign-out-test.js",
+                "tests/acceptance/builds/build-stages-test.js",
+                "tests/acceptance/builds/cancel-test.js",
+                "tests/acceptance/builds/current-tab-test.js",
+                "tests/acceptance/builds/debug-test.js",
+                "tests/acceptance/builds/invalid-build-test.js",
+                "tests/acceptance/builds/prioritize-test.js",
+                "tests/acceptance/builds/pull-requests-test.js",
+                "tests/acceptance/builds/restart-test.js",
+                "tests/acceptance/builds/view-pull-request-test.js",
+                "tests/acceptance/config/oss-feature-flags-test.js",
+                "tests/acceptance/config/yaml-test.js",
+                "tests/acceptance/dashboard/repositories-test.js",
+                "tests/acceptance/enterprise/banner-test.js",
+                "tests/acceptance/enterprise/beta-features-disabled-test.js",
+                "tests/acceptance/enterprise/navigation-test.js",
+                "tests/acceptance/feature-flags/app-boots-test.js",
+                "tests/acceptance/help-page-test.js",
+                "tests/acceptance/home/broadcasts-test.js",
+                "tests/acceptance/home/flashes-test.js",
+                "tests/acceptance/home/sidebar-tabs-test.js",
+                "tests/acceptance/home/utm-test.js",
+                "tests/acceptance/home/with-repositories-test.js",
+                "tests/acceptance/home/without-repositories-test.js",
+                "tests/acceptance/job/basic-layout-test.js",
+                "tests/acceptance/job/build-matrix-test.js",
+                "tests/acceptance/job/cancel-test.js",
+                "tests/acceptance/job/debug-test.js",
+                "tests/acceptance/job/delete-log-test.js",
+                "tests/acceptance/job/invalid-log-test.js",
+                "tests/acceptance/job/log-error-test.js",
+                "tests/acceptance/job/restart-test.js",
+                "tests/acceptance/layouts/cta-test.js",
+                "tests/acceptance/layouts/default-test.js",
+                "tests/acceptance/layouts/logo-test.js",
+                "tests/acceptance/layouts/plans-test.js",
+                "tests/acceptance/layouts/pro-test.js",
+                "tests/acceptance/logo-test.js",
+                "tests/acceptance/marketing/travisci-vs-jenkins-test.js",
+                "tests/acceptance/non-existent-routes-test.js",
+                "tests/acceptance/owner/insights-test.js",
+                "tests/acceptance/owner/not-found-test.js",
+                "tests/acceptance/owner/repos-test.js",
+                "tests/acceptance/plans-test.js",
+                "tests/acceptance/profile/basic-layout-test.js",
+                "tests/acceptance/profile/billing-test.js",
+                "tests/acceptance/profile/filtering-test.js",
+                "tests/acceptance/profile/migrate-test.js",
+                "tests/acceptance/profile/not-found-test.js",
+                "tests/acceptance/profile/plan-usage-test.js",
+                "tests/acceptance/profile/redirect-test.js",
+                "tests/acceptance/profile/sync-test.js",
+                "tests/acceptance/profile/unsubscribe-test.js",
+                "tests/acceptance/profile/update-repositories-test.js",
+                "tests/acceptance/profile/user-settings-test.js",
+                "tests/acceptance/profile/view-token-test.js",
+                "tests/acceptance/repo/active_on_org-test.js",
+                "tests/acceptance/repo/allowance-test.js",
+                "tests/acceptance/repo/branches-test.js",
+                "tests/acceptance/repo/build-list-routes-test.js",
+                "tests/acceptance/repo/caches-test.js",
+                "tests/acceptance/repo/not-active-test.js",
+                "tests/acceptance/repo/not-found-test.js",
+                "tests/acceptance/repo/requests-test.js",
+                "tests/acceptance/repo/settings-test.js",
+                "tests/acceptance/repo/show-public-repo-test.js",
+                "tests/acceptance/repo/show-test.js",
+                "tests/acceptance/repo/trigger-build-test.js",
+                "tests/acceptance/repo/view-migrated-test.js",
+                "tests/acceptance/search/flow-test.js",
+                "tests/acceptance/search/no-results-test.js",
+                "tests/acceptance/sign-in-test.js",
+                "tests/acceptance/sign-up-test.js",
+                "tests/assets/adal/difference-engine.svg",
+                "tests/assets/images/landing-page/envelope.svg",
+                "tests/assets/images/tiny.gif",
+                "tests/assets/musterfrau/a-repo.svg",
+                "tests/assets/org-login/repository-name.svg",
+                "tests/assets/org-login/yet-another-repository-name.svg",
+                "tests/assets/testuser/travis-web.svg",
+                "tests/assets/travis-ci/travis-api.svg",
+                "tests/assets/travis-ci/travis-web.svg",
+                "tests/assets/user-login/github-apps-locked-repository.svg",
+                "tests/helpers/extra-test-helpers.js",
+                "tests/helpers/generate-pusher-payload.js",
+                "tests/helpers/selectors.js",
+                "tests/helpers/setup-application-test.js",
+                "tests/helpers/sign-in-user.js",
+                "tests/helpers/sign-out-user.js",
+                "tests/helpers/stripe-mock.js",
+                "tests/helpers/stub-service.js",
+                "tests/helpers/stub-template.js",
+                "tests/helpers/visit-with-aborted-transition.js",
+                "tests/index.html",
+                "tests/integration/components/active-repo-count-test.js",
+                "tests/integration/components/add-env-var-test.js",
+                "tests/integration/components/add-ssh-key-test.js",
+                "tests/integration/components/beta-feature-test.js",
+                "tests/integration/components/billing-summary-status-test.js",
+                "tests/integration/components/billing/address-test.js",
+                "tests/integration/components/billing/information-test.js",
+                "tests/integration/components/billing/invoices-test.js",
+                "tests/integration/components/billing/payment-test.js",
+                "tests/integration/components/billing/process-test.js",
+                "tests/integration/components/billing/select-addon-test.js",
+                "tests/integration/components/billing/select-plan-test.js",
+                "tests/integration/components/billing/selected-addon-test.js",
+                "tests/integration/components/billing/selected-plan-test.js",
+                "tests/integration/components/billing/summary-test.js",
+                "tests/integration/components/billing/warning-message-test.js",
+                "tests/integration/components/branch-row-test.js",
+                "tests/integration/components/build-count-test.js",
+                "tests/integration/components/build-header-test.js",
+                "tests/integration/components/build-minutes-test.js",
+                "tests/integration/components/build-status-chart-test.js",
+                "tests/integration/components/builds-item-test.js",
+                "tests/integration/components/caches-item-test.js",
+                "tests/integration/components/dashboard-row-test.js",
+                "tests/integration/components/email-unsubscribe-test.js",
+                "tests/integration/components/enterprise-banner-test.js",
+                "tests/integration/components/env-var-test.js",
+                "tests/integration/components/external-link-to-test.js",
+                "tests/integration/components/feature-toggle-test.js",
+                "tests/integration/components/forms/form-slider-test.js",
+                "tests/integration/components/insights-date-display-test.js",
+                "tests/integration/components/insights-glance-test.js",
+                "tests/integration/components/insights-overlay-test.js",
+                "tests/integration/components/insights-privacy-selector-test.js",
+                "tests/integration/components/insights-tabs-test.js",
+                "tests/integration/components/jobs-item-test.js",
+                "tests/integration/components/jobs-list-test.js",
+                "tests/integration/components/lastbuild-tile-test.js",
+                "tests/integration/components/loading-indicator-test.js",
+                "tests/integration/components/no-account-test.js",
+                "tests/integration/components/oss-usage-digit-test.js",
+                "tests/integration/components/oss-usage-numbers-test.js",
+                "tests/integration/components/owner-not-found-test.js",
+                "tests/integration/components/owner-repo-tile-test.js",
+                "tests/integration/components/page-footer-test.js",
+                "tests/integration/components/pagination-navigation-test.js",
+                "tests/integration/components/paper-block-test.js",
+                "tests/integration/components/queue-times-test.js",
+                "tests/integration/components/repo-actions-test.js",
+                "tests/integration/components/repo-not-found-test.js",
+                "tests/integration/components/repository-migration-modal-test.js",
+                "tests/integration/components/repository-status-toggle-test.js",
+                "tests/integration/components/requests-item-test.js",
+                "tests/integration/components/ssh-key-test.js",
+                "tests/integration/components/status-images-test.js",
+                "tests/integration/components/templates/prioritize-build-modal-test.js",
+                "tests/integration/components/top-bar-test.js",
+                "tests/integration/components/top-forum-post-list-test.js",
+                "tests/integration/components/travis-status-test.js",
+                "tests/integration/components/trigger-custom-build-test.js",
+                "tests/integration/components/user-avatar-test.js",
+                "tests/integration/components/visibility-setting-list-test.js",
+                "tests/integration/helpers/format-currency-test.js",
+                "tests/integration/helpers/format-domain-test.js",
+                "tests/integration/helpers/obfuscated-chars-test.js",
+                "tests/integration/v2-serializer-test.js",
+                "tests/integration/v3-serializer-test.js",
+                "tests/pages/branches.js",
+                "tests/pages/build-list.js",
+                "tests/pages/build.js",
+                "tests/pages/caches.js",
+                "tests/pages/dashboard.js",
+                "tests/pages/enterprise-banner.js",
+                "tests/pages/footer.js",
+                "tests/pages/header/default.js",
+                "tests/pages/header/pro.js",
+                "tests/pages/help.js",
+                "tests/pages/helpers/join-texts.js",
+                "tests/pages/insights-owner.js",
+                "tests/pages/job-tabs.js",
+                "tests/pages/job.js",
+                "tests/pages/layouts/default.js",
+                "tests/pages/layouts/pro.js",
+                "tests/pages/owner.js",
+                "tests/pages/owner/non-existent.js",
+                "tests/pages/plans.js",
+                "tests/pages/profile.js",
+                "tests/pages/repo-not-active.js",
+                "tests/pages/repo-tabs/current.js",
+                "tests/pages/repo/non-existent.js",
+                "tests/pages/repo/show.js",
+                "tests/pages/requests.js",
+                "tests/pages/settings.js",
+                "tests/pages/sidebar.js",
+                "tests/pages/top.js",
+                "tests/pages/trigger-build.js",
+                "tests/pages/unsubscribe.js",
+                "tests/pages/user-management.js",
+                "tests/test-helper.js",
+                "tests/unit/adapters/v3-test.js",
+                "tests/unit/controllers/account/billing-test.js",
+                "tests/unit/helpers/format-message-test.js",
+                "tests/unit/instance-initializers/enterprise-environment-test.js",
+                "tests/unit/instance-initializers/pro-environment-test.js",
+                "tests/unit/mixins/polling-test.js",
+                "tests/unit/models/build-test.js",
+                "tests/unit/models/commit-test.js",
+                "tests/unit/models/job-test.js",
+                "tests/unit/routes/confirm-user-test.js",
+                "tests/unit/routes/request-user-confirmation-test.js",
+                "tests/unit/routes/signin-test.js",
+                "tests/unit/serializers/build-test.js",
+                "tests/unit/serializers/env-var-test.js",
+                "tests/unit/serializers/pusher-repo-test.js",
+                "tests/unit/serializers/repo-test.js",
+                "tests/unit/services/external-links-test.js",
+                "tests/unit/services/flashes-test.js",
+                "tests/unit/services/gtm-test.js",
+                "tests/unit/services/insights-test.js",
+                "tests/unit/services/live-updates-record-fetcher-test.js",
+                "tests/unit/services/permissions-test.js",
+                "tests/unit/services/polling-test.js",
+                "tests/unit/services/raven-test.js",
+                "tests/unit/services/status-images-test.js",
+                "tests/unit/services/store/record-version-test.js",
+                "tests/unit/services/stripe-test.js",
+                "tests/unit/services/trigger-build-popup-test.js",
+                "tests/unit/store-filter-test.js",
+                "tests/unit/store-paginated-test.js",
+                "tests/unit/utils/abstract-method-test.js",
+                "tests/unit/utils/api-errors-test.js",
+                "tests/unit/utils/computed-limit-test.js",
+                "tests/unit/utils/duration-from-test.js",
+                "tests/unit/utils/eventually-test.js",
+                "tests/unit/utils/favicon-manager-test.js",
+                "tests/unit/utils/format-commit-test.js",
+                "tests/unit/utils/format-sha-test.js",
+                "tests/unit/utils/fuzzy-match-test.js",
+                "tests/unit/utils/job-config-arch-test.js",
+                "tests/unit/utils/job-config-language-test.js",
+                "tests/unit/utils/paginated-collection-test.js",
+                "tests/unit/utils/time-in-words-test.js",
+                "tests/unit/utils/ui-kit/assertions-test.js",
+                "tests/unit/utils/ui-kit/responsive-test.js",
+                "tests/unit/utils/vcs-test.js",
+                "waiter/Rakefile",
+                "waiter/config.ru",
+                "waiter/lib/travis/utils/deep_merge.rb",
+                "waiter/lib/travis/web.rb",
+                "waiter/lib/travis/web/allow.rb",
+                "waiter/lib/travis/web/api_redirect.rb",
+                "waiter/lib/travis/web/app.rb",
+                "waiter/lib/travis/web/app/alt_versions.rb",
+                "waiter/lib/travis/web/app/mobile_redirect.rb",
+                "waiter/lib/travis/web/config.rb",
+                "waiter/lib/travis/web/sentry_deploy_hook.rb",
+                "waiter/lib/travis/web/set_token.rb",
+                "waiter/script/ci",
+                "waiter/script/prepare_deploy",
+                "waiter/script/server",
+                "waiter/spec/allow_spec.rb",
+                "waiter/spec/api_redirect_spec.rb",
+                "waiter/spec/app_spec.rb",
+                "waiter/spec/mobile_redirect_spec.rb",
+                "waiter/spec/spec_helper.rb",
+                "waiter/travis-web.gemspec",
+                "yarn.lock"
+              ],
+              "analyzedFilesCount": 1765,
+              "timings": {
+                "ember/ember-types": 5.984475027,
+                "javascript/eslint-summary": 14.756429524,
+                "ember/ember-test-types": 5.943720536,
+                "ember/ember-octane-migration-status": 7.705887458,
+                "ember/ember-template-lint-summary": 14.905044101,
+                "ember/ember-in-repo-addons-engines": 14.85132034,
+                "ember/ember-template-lint-disables": 19.903822409,
+                "javascript/eslint-disables": 20.288445336,
+                "javascript/lines-of-code": 20.30558286,
+                "javascript/outdated-dependencies": 41.072789303,
+                "ember/ember-dependencies": 48.378127353
+              }
+            }
+          }
+        }
+      },
+      "results": [
+        {
+          "message": {
+            "text": "Located component at app/components/feature-toggle.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/feature-toggle.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/flash-display.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/flash-display.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/flash-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/flash-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-checkbox.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-checkbox.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-field.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-field.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-input.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-input.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-select-multiple.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-select-multiple.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-select.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-select.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-slider.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-slider.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-switch.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-switch.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/form-textarea.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/form-textarea.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/forms/multiple-inputs-field.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/forms/multiple-inputs-field.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/getting-started-step.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/getting-started-step.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/getting-started-steps-generic.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/getting-started-steps-generic.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/github-apps-repository.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/github-apps-repository.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/header-broadcasts.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/header-broadcasts.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/header-burger-menu.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/header-burger-menu.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/header-links.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/header-links.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/insights-date-display.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/insights-date-display.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/insights-glance.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/insights-glance.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/insights-overlay.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/insights-overlay.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/insights-privacy-selector.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/insights-privacy-selector.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/insights-tabs.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/insights-tabs.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/job-infrastructure-notification.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/job-infrastructure-notification.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/job-log.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/job-log.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/job-tabs.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/job-tabs.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/job-wrapper.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/job-wrapper.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/jobs-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/jobs-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/jobs-list.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/jobs-list.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/landing-default-page.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/landing-default-page.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/landing-pro-page.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/landing-pro-page.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/lastbuild-tile.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/lastbuild-tile.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/layouts/sidebar.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/layouts/sidebar.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/layouts/striped-section.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/layouts/striped-section.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/layouts/striped.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/layouts/striped.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/limit-concurrent-builds.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/limit-concurrent-builds.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/link-to-account.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/link-to-account.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/load-more.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/load-more.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/loading-indicator.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/loading-indicator.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/loading-overlay.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/loading-overlay.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/loading-page.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/loading-page.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/loading-screen.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/loading-screen.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/log-content.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/log-content.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/manual-subscription-help.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/manual-subscription-help.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/migration-banner.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/migration-banner.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/modal.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/modal.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/multi-signin-button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/multi-signin-button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/my-build.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/my-build.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/new-subscription-button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/new-subscription-button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/no-repos.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/no-repos.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/not-active.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/not-active.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/org-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/org-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/oss-usage-digit.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/oss-usage-digit.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/oss-usage-numbers.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/oss-usage-numbers.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/overlay-backdrop.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/overlay-backdrop.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/owner-not-found.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/owner-not-found.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/owner-repo-tile.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/owner-repo-tile.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/owner-sync-button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/owner-sync-button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/owner/migrate.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/owner/migrate.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/owner/repositories.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/owner/repositories.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/page-footer.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/page-footer.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/pagination-navigation.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/pagination-navigation.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/paper-block.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/paper-block.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/plan-usage.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/plan-usage.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/profile-accounts-wrapper.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/profile-accounts-wrapper.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/profile-menu.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/profile-menu.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/profile-nav.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/profile-nav.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/queue-times.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/queue-times.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/queued-jobs.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/queued-jobs.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/raw-config.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/raw-config.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/remove-log-popup.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/remove-log-popup.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-actions.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-actions.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-build-list.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-build-list.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-not-found.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-not-found.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-show-tabs.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-show-tabs.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-show-tools.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-show-tools.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-status-badge.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-status-badge.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repo-wrapper.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repo-wrapper.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repos-list-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repos-list-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repos-list-tabs.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repos-list-tabs.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repos-list.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repos-list.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repository-filter-form.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repository-filter-form.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repository-filter.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repository-filter.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repository-layout.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repository-layout.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repository-migration-modal.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repository-migration-modal.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repository-sidebar.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repository-sidebar.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/repository-status-toggle.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/repository-status-toggle.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/request-config.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/request-config.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/request-icon.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/request-icon.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/requests-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/requests-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/running-jobs-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/running-jobs-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/running-jobs.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/running-jobs.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/sales-contact-form.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/sales-contact-form.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/sales-contact-thanks.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/sales-contact-thanks.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/scroll-here.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/scroll-here.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/settings-switch.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/settings-switch.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/show-more-button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/show-more-button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ssh-key.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ssh-key.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/status-icon.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/status-icon.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/status-image-input.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/status-image-input.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/status-images.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/status-images.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/subscribe-button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/subscribe-button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/subscription-status-banner.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/subscription-status-banner.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/svg-image.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/svg-image.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/sync-button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/sync-button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/top-bar.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/top-bar.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/top-forum-post-list.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/top-forum-post-list.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/travis-form.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/travis-form.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/travis-layout.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/travis-layout.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/travis-status.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/travis-status.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/travis-switch.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/travis-switch.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/trigger-custom-build.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/trigger-custom-build.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/badge.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/badge.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/box.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/box.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/button-signin.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/button-signin.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/button.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/button.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/code.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/code.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/grid-item.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/grid-item.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/grid.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/grid.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/image.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/image.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/link.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/link.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/note.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/note.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/switch.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/switch.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/ui-kit/text.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/ui-kit/text.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/user-avatar.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/user-avatar.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/visibility-setting-list.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/visibility-setting-list.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/x-tracer.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/x-tracer.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/components/zendesk-request-form.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/components/zendesk-request-form.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/mixins/components/form-select.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/mixins/components/form-select.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at app/mixins/components/with-config-validation.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/mixins/components/with-config-validation.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/active-repo-count-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/active-repo-count-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/add-env-var-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/add-env-var-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/add-ssh-key-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/add-ssh-key-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/beta-feature-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/beta-feature-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing-summary-status-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing-summary-status-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/address-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/address-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/information-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/information-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/invoices-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/invoices-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/payment-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/payment-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/process-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/process-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/select-addon-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/select-addon-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/select-plan-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/select-plan-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/selected-addon-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/selected-addon-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/selected-plan-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/selected-plan-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/summary-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/summary-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/billing/warning-message-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/billing/warning-message-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/branch-row-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/branch-row-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/build-count-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/build-count-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located component at tests/integration/components/build-header-test.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "components"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "tests/integration/components/build-header-test.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located helper at app/helpers/format-message.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "helpers"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/helpers/format-message.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Located helper at app/helpers/format-number.js"
+          },
+          "ruleId": "ember-types",
+          "kind": "informational",
+          "level": "note",
+          "properties": {
+            "type": "helpers"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "app/helpers/format-number.js"
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "message": {
+            "text": "Ember dependency information for ember-web-app"
+          },
+          "ruleId": "ember-dependencies",
+          "kind": "review",
+          "level": "note",
+          "properties": {
+            "packageName": "ember-web-app",
+            "packageVersion": "^3.0.1",
+            "latestVersion": "5.0.1",
+            "type": "devDependency"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/Users/zhanwang/personal/travis-web/package.json"
+                },
+                "region": {
+                  "startLine": 90,
+                  "startColumn": 4,
+                  "endLine": 90,
+                  "endColumn": 29
+                }
+              }
+            }
+          ],
+          "ruleIndex": 8
+        },
+        {
+          "message": {
+            "text": "Ember dependency information for ember-window-mock"
+          },
+          "ruleId": "ember-dependencies",
+          "kind": "review",
+          "level": "note",
+          "properties": {
+            "packageName": "ember-window-mock",
+            "packageVersion": "^0.5.0",
+            "latestVersion": "0.7.2",
+            "type": "devDependency"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/Users/zhanwang/personal/travis-web/package.json"
+                },
+                "region": {
+                  "startLine": 91,
+                  "startColumn": 4,
+                  "endLine": 91,
+                  "endColumn": 33
+                }
+              }
+            }
+          ],
+          "ruleIndex": 8
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "arguments": [
+            "--paths",
+            ".",
+            "--configPath",
+            ".checkuprc",
+            "--cwd",
+            "/Users/zhanwang/personal/travis-web"
+          ],
+          "startTimeUtc": "2021-09-23T21:05:06.375Z",
+          "endTimeUtc": "2021-09-23T21:06:03.950Z"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cli/tests/formatters/stylish-test.ts
+++ b/packages/cli/tests/formatters/stylish-test.ts
@@ -1,0 +1,482 @@
+import { CheckupLogParser, FormatterOptions } from '@checkup/core';
+import stripAnsi from 'strip-ansi';
+import StylishFormatter from '../../src/formatters/stylish.js';
+import { getFixture } from '../__utils__/get-fixture.js';
+
+describe('Stylish formatter', () => {
+  it('can generate string from format', async () => {
+    const log = getFixture('checkup-result-short.sarif');
+    const logParser = new CheckupLogParser(log);
+    const options: FormatterOptions = {
+      cwd: '',
+      format: 'stylish',
+    };
+
+    let formatter = new StylishFormatter(options);
+
+    const result = stripAnsi(formatter.format(logParser));
+
+    expect(result).toMatchInlineSnapshot(`
+      "
+      app/components/feature-toggle.js
+        0:0  metrics  Located component at app/components/feature-toggle.js  ember-types
+
+      app/components/flash-display.js
+        0:0  metrics  Located component at app/components/flash-display.js  ember-types
+
+      app/components/flash-item.js
+        0:0  metrics  Located component at app/components/flash-item.js  ember-types
+
+      app/components/forms/form-checkbox.js
+        0:0  metrics  Located component at app/components/forms/form-checkbox.js  ember-types
+
+      app/components/forms/form-field.js
+        0:0  metrics  Located component at app/components/forms/form-field.js  ember-types
+
+      app/components/forms/form-input.js
+        0:0  metrics  Located component at app/components/forms/form-input.js  ember-types
+
+      app/components/forms/form-select-multiple.js
+        0:0  metrics  Located component at app/components/forms/form-select-multiple.js  ember-types
+
+      app/components/forms/form-select.js
+        0:0  metrics  Located component at app/components/forms/form-select.js  ember-types
+
+      app/components/forms/form-slider.js
+        0:0  metrics  Located component at app/components/forms/form-slider.js  ember-types
+
+      app/components/forms/form-switch.js
+        0:0  metrics  Located component at app/components/forms/form-switch.js  ember-types
+
+      app/components/forms/form-textarea.js
+        0:0  metrics  Located component at app/components/forms/form-textarea.js  ember-types
+
+      app/components/forms/multiple-inputs-field.js
+        0:0  metrics  Located component at app/components/forms/multiple-inputs-field.js  ember-types
+
+      app/components/getting-started-step.js
+        0:0  metrics  Located component at app/components/getting-started-step.js  ember-types
+
+      app/components/getting-started-steps-generic.js
+        0:0  metrics  Located component at app/components/getting-started-steps-generic.js  ember-types
+
+      app/components/github-apps-repository.js
+        0:0  metrics  Located component at app/components/github-apps-repository.js  ember-types
+
+      app/components/header-broadcasts.js
+        0:0  metrics  Located component at app/components/header-broadcasts.js  ember-types
+
+      app/components/header-burger-menu.js
+        0:0  metrics  Located component at app/components/header-burger-menu.js  ember-types
+
+      app/components/header-links.js
+        0:0  metrics  Located component at app/components/header-links.js  ember-types
+
+      app/components/insights-date-display.js
+        0:0  metrics  Located component at app/components/insights-date-display.js  ember-types
+
+      app/components/insights-glance.js
+        0:0  metrics  Located component at app/components/insights-glance.js  ember-types
+
+      app/components/insights-overlay.js
+        0:0  metrics  Located component at app/components/insights-overlay.js  ember-types
+
+      app/components/insights-privacy-selector.js
+        0:0  metrics  Located component at app/components/insights-privacy-selector.js  ember-types
+
+      app/components/insights-tabs.js
+        0:0  metrics  Located component at app/components/insights-tabs.js  ember-types
+
+      app/components/job-infrastructure-notification.js
+        0:0  metrics  Located component at app/components/job-infrastructure-notification.js  ember-types
+
+      app/components/job-log.js
+        0:0  metrics  Located component at app/components/job-log.js  ember-types
+
+      app/components/job-tabs.js
+        0:0  metrics  Located component at app/components/job-tabs.js  ember-types
+
+      app/components/job-wrapper.js
+        0:0  metrics  Located component at app/components/job-wrapper.js  ember-types
+
+      app/components/jobs-item.js
+        0:0  metrics  Located component at app/components/jobs-item.js  ember-types
+
+      app/components/jobs-list.js
+        0:0  metrics  Located component at app/components/jobs-list.js  ember-types
+
+      app/components/landing-default-page.js
+        0:0  metrics  Located component at app/components/landing-default-page.js  ember-types
+
+      app/components/landing-pro-page.js
+        0:0  metrics  Located component at app/components/landing-pro-page.js  ember-types
+
+      app/components/lastbuild-tile.js
+        0:0  metrics  Located component at app/components/lastbuild-tile.js  ember-types
+
+      app/components/layouts/sidebar.js
+        0:0  metrics  Located component at app/components/layouts/sidebar.js  ember-types
+
+      app/components/layouts/striped-section.js
+        0:0  metrics  Located component at app/components/layouts/striped-section.js  ember-types
+
+      app/components/layouts/striped.js
+        0:0  metrics  Located component at app/components/layouts/striped.js  ember-types
+
+      app/components/limit-concurrent-builds.js
+        0:0  metrics  Located component at app/components/limit-concurrent-builds.js  ember-types
+
+      app/components/link-to-account.js
+        0:0  metrics  Located component at app/components/link-to-account.js  ember-types
+
+      app/components/load-more.js
+        0:0  metrics  Located component at app/components/load-more.js  ember-types
+
+      app/components/loading-indicator.js
+        0:0  metrics  Located component at app/components/loading-indicator.js  ember-types
+
+      app/components/loading-overlay.js
+        0:0  metrics  Located component at app/components/loading-overlay.js  ember-types
+
+      app/components/loading-page.js
+        0:0  metrics  Located component at app/components/loading-page.js  ember-types
+
+      app/components/loading-screen.js
+        0:0  metrics  Located component at app/components/loading-screen.js  ember-types
+
+      app/components/log-content.js
+        0:0  metrics  Located component at app/components/log-content.js  ember-types
+
+      app/components/manual-subscription-help.js
+        0:0  metrics  Located component at app/components/manual-subscription-help.js  ember-types
+
+      app/components/migration-banner.js
+        0:0  metrics  Located component at app/components/migration-banner.js  ember-types
+
+      app/components/modal.js
+        0:0  metrics  Located component at app/components/modal.js  ember-types
+
+      app/components/multi-signin-button.js
+        0:0  metrics  Located component at app/components/multi-signin-button.js  ember-types
+
+      app/components/my-build.js
+        0:0  metrics  Located component at app/components/my-build.js  ember-types
+
+      app/components/new-subscription-button.js
+        0:0  metrics  Located component at app/components/new-subscription-button.js  ember-types
+
+      app/components/no-repos.js
+        0:0  metrics  Located component at app/components/no-repos.js  ember-types
+
+      app/components/not-active.js
+        0:0  metrics  Located component at app/components/not-active.js  ember-types
+
+      app/components/org-item.js
+        0:0  metrics  Located component at app/components/org-item.js  ember-types
+
+      app/components/oss-usage-digit.js
+        0:0  metrics  Located component at app/components/oss-usage-digit.js  ember-types
+
+      app/components/oss-usage-numbers.js
+        0:0  metrics  Located component at app/components/oss-usage-numbers.js  ember-types
+
+      app/components/overlay-backdrop.js
+        0:0  metrics  Located component at app/components/overlay-backdrop.js  ember-types
+
+      app/components/owner-not-found.js
+        0:0  metrics  Located component at app/components/owner-not-found.js  ember-types
+
+      app/components/owner-repo-tile.js
+        0:0  metrics  Located component at app/components/owner-repo-tile.js  ember-types
+
+      app/components/owner-sync-button.js
+        0:0  metrics  Located component at app/components/owner-sync-button.js  ember-types
+
+      app/components/owner/migrate.js
+        0:0  metrics  Located component at app/components/owner/migrate.js  ember-types
+
+      app/components/owner/repositories.js
+        0:0  metrics  Located component at app/components/owner/repositories.js  ember-types
+
+      app/components/page-footer.js
+        0:0  metrics  Located component at app/components/page-footer.js  ember-types
+
+      app/components/pagination-navigation.js
+        0:0  metrics  Located component at app/components/pagination-navigation.js  ember-types
+
+      app/components/paper-block.js
+        0:0  metrics  Located component at app/components/paper-block.js  ember-types
+
+      app/components/plan-usage.js
+        0:0  metrics  Located component at app/components/plan-usage.js  ember-types
+
+      app/components/profile-accounts-wrapper.js
+        0:0  metrics  Located component at app/components/profile-accounts-wrapper.js  ember-types
+
+      app/components/profile-menu.js
+        0:0  metrics  Located component at app/components/profile-menu.js  ember-types
+
+      app/components/profile-nav.js
+        0:0  metrics  Located component at app/components/profile-nav.js  ember-types
+
+      app/components/queue-times.js
+        0:0  metrics  Located component at app/components/queue-times.js  ember-types
+
+      app/components/queued-jobs.js
+        0:0  metrics  Located component at app/components/queued-jobs.js  ember-types
+
+      app/components/raw-config.js
+        0:0  metrics  Located component at app/components/raw-config.js  ember-types
+
+      app/components/remove-log-popup.js
+        0:0  metrics  Located component at app/components/remove-log-popup.js  ember-types
+
+      app/components/repo-actions.js
+        0:0  metrics  Located component at app/components/repo-actions.js  ember-types
+
+      app/components/repo-build-list.js
+        0:0  metrics  Located component at app/components/repo-build-list.js  ember-types
+
+      app/components/repo-not-found.js
+        0:0  metrics  Located component at app/components/repo-not-found.js  ember-types
+
+      app/components/repo-show-tabs.js
+        0:0  metrics  Located component at app/components/repo-show-tabs.js  ember-types
+
+      app/components/repo-show-tools.js
+        0:0  metrics  Located component at app/components/repo-show-tools.js  ember-types
+
+      app/components/repo-status-badge.js
+        0:0  metrics  Located component at app/components/repo-status-badge.js  ember-types
+
+      app/components/repo-wrapper.js
+        0:0  metrics  Located component at app/components/repo-wrapper.js  ember-types
+
+      app/components/repos-list-item.js
+        0:0  metrics  Located component at app/components/repos-list-item.js  ember-types
+
+      app/components/repos-list-tabs.js
+        0:0  metrics  Located component at app/components/repos-list-tabs.js  ember-types
+
+      app/components/repos-list.js
+        0:0  metrics  Located component at app/components/repos-list.js  ember-types
+
+      app/components/repository-filter-form.js
+        0:0  metrics  Located component at app/components/repository-filter-form.js  ember-types
+
+      app/components/repository-filter.js
+        0:0  metrics  Located component at app/components/repository-filter.js  ember-types
+
+      app/components/repository-layout.js
+        0:0  metrics  Located component at app/components/repository-layout.js  ember-types
+
+      app/components/repository-migration-modal.js
+        0:0  metrics  Located component at app/components/repository-migration-modal.js  ember-types
+
+      app/components/repository-sidebar.js
+        0:0  metrics  Located component at app/components/repository-sidebar.js  ember-types
+
+      app/components/repository-status-toggle.js
+        0:0  metrics  Located component at app/components/repository-status-toggle.js  ember-types
+
+      app/components/request-config.js
+        0:0  metrics  Located component at app/components/request-config.js  ember-types
+
+      app/components/request-icon.js
+        0:0  metrics  Located component at app/components/request-icon.js  ember-types
+
+      app/components/requests-item.js
+        0:0  metrics  Located component at app/components/requests-item.js  ember-types
+
+      app/components/running-jobs-item.js
+        0:0  metrics  Located component at app/components/running-jobs-item.js  ember-types
+
+      app/components/running-jobs.js
+        0:0  metrics  Located component at app/components/running-jobs.js  ember-types
+
+      app/components/sales-contact-form.js
+        0:0  metrics  Located component at app/components/sales-contact-form.js  ember-types
+
+      app/components/sales-contact-thanks.js
+        0:0  metrics  Located component at app/components/sales-contact-thanks.js  ember-types
+
+      app/components/scroll-here.js
+        0:0  metrics  Located component at app/components/scroll-here.js  ember-types
+
+      app/components/settings-switch.js
+        0:0  metrics  Located component at app/components/settings-switch.js  ember-types
+
+      app/components/show-more-button.js
+        0:0  metrics  Located component at app/components/show-more-button.js  ember-types
+
+      app/components/ssh-key.js
+        0:0  metrics  Located component at app/components/ssh-key.js  ember-types
+
+      app/components/status-icon.js
+        0:0  metrics  Located component at app/components/status-icon.js  ember-types
+
+      app/components/status-image-input.js
+        0:0  metrics  Located component at app/components/status-image-input.js  ember-types
+
+      app/components/status-images.js
+        0:0  metrics  Located component at app/components/status-images.js  ember-types
+
+      app/components/subscribe-button.js
+        0:0  metrics  Located component at app/components/subscribe-button.js  ember-types
+
+      app/components/subscription-status-banner.js
+        0:0  metrics  Located component at app/components/subscription-status-banner.js  ember-types
+
+      app/components/svg-image.js
+        0:0  metrics  Located component at app/components/svg-image.js  ember-types
+
+      app/components/sync-button.js
+        0:0  metrics  Located component at app/components/sync-button.js  ember-types
+
+      app/components/top-bar.js
+        0:0  metrics  Located component at app/components/top-bar.js  ember-types
+
+      app/components/top-forum-post-list.js
+        0:0  metrics  Located component at app/components/top-forum-post-list.js  ember-types
+
+      app/components/travis-form.js
+        0:0  metrics  Located component at app/components/travis-form.js  ember-types
+
+      app/components/travis-layout.js
+        0:0  metrics  Located component at app/components/travis-layout.js  ember-types
+
+      app/components/travis-status.js
+        0:0  metrics  Located component at app/components/travis-status.js  ember-types
+
+      app/components/travis-switch.js
+        0:0  metrics  Located component at app/components/travis-switch.js  ember-types
+
+      app/components/trigger-custom-build.js
+        0:0  metrics  Located component at app/components/trigger-custom-build.js  ember-types
+
+      app/components/ui-kit/badge.js
+        0:0  metrics  Located component at app/components/ui-kit/badge.js  ember-types
+
+      app/components/ui-kit/box.js
+        0:0  metrics  Located component at app/components/ui-kit/box.js  ember-types
+
+      app/components/ui-kit/button-signin.js
+        0:0  metrics  Located component at app/components/ui-kit/button-signin.js  ember-types
+
+      app/components/ui-kit/button.js
+        0:0  metrics  Located component at app/components/ui-kit/button.js  ember-types
+
+      app/components/ui-kit/code.js
+        0:0  metrics  Located component at app/components/ui-kit/code.js  ember-types
+
+      app/components/ui-kit/grid-item.js
+        0:0  metrics  Located component at app/components/ui-kit/grid-item.js  ember-types
+
+      app/components/ui-kit/grid.js
+        0:0  metrics  Located component at app/components/ui-kit/grid.js  ember-types
+
+      app/components/ui-kit/image.js
+        0:0  metrics  Located component at app/components/ui-kit/image.js  ember-types
+
+      app/components/ui-kit/link.js
+        0:0  metrics  Located component at app/components/ui-kit/link.js  ember-types
+
+      app/components/ui-kit/note.js
+        0:0  metrics  Located component at app/components/ui-kit/note.js  ember-types
+
+      app/components/ui-kit/switch.js
+        0:0  metrics  Located component at app/components/ui-kit/switch.js  ember-types
+
+      app/components/ui-kit/text.js
+        0:0  metrics  Located component at app/components/ui-kit/text.js  ember-types
+
+      app/components/user-avatar.js
+        0:0  metrics  Located component at app/components/user-avatar.js  ember-types
+
+      app/components/visibility-setting-list.js
+        0:0  metrics  Located component at app/components/visibility-setting-list.js  ember-types
+
+      app/components/x-tracer.js
+        0:0  metrics  Located component at app/components/x-tracer.js  ember-types
+
+      app/components/zendesk-request-form.js
+        0:0  metrics  Located component at app/components/zendesk-request-form.js  ember-types
+
+      app/mixins/components/form-select.js
+        0:0  metrics  Located component at app/mixins/components/form-select.js  ember-types
+
+      app/mixins/components/with-config-validation.js
+        0:0  metrics  Located component at app/mixins/components/with-config-validation.js  ember-types
+
+      tests/integration/components/active-repo-count-test.js
+        0:0  metrics  Located component at tests/integration/components/active-repo-count-test.js  ember-types
+
+      tests/integration/components/add-env-var-test.js
+        0:0  metrics  Located component at tests/integration/components/add-env-var-test.js  ember-types
+
+      tests/integration/components/add-ssh-key-test.js
+        0:0  metrics  Located component at tests/integration/components/add-ssh-key-test.js  ember-types
+
+      tests/integration/components/beta-feature-test.js
+        0:0  metrics  Located component at tests/integration/components/beta-feature-test.js  ember-types
+
+      tests/integration/components/billing-summary-status-test.js
+        0:0  metrics  Located component at tests/integration/components/billing-summary-status-test.js  ember-types
+
+      tests/integration/components/billing/address-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/address-test.js  ember-types
+
+      tests/integration/components/billing/information-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/information-test.js  ember-types
+
+      tests/integration/components/billing/invoices-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/invoices-test.js  ember-types
+
+      tests/integration/components/billing/payment-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/payment-test.js  ember-types
+
+      tests/integration/components/billing/process-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/process-test.js  ember-types
+
+      tests/integration/components/billing/select-addon-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/select-addon-test.js  ember-types
+
+      tests/integration/components/billing/select-plan-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/select-plan-test.js  ember-types
+
+      tests/integration/components/billing/selected-addon-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/selected-addon-test.js  ember-types
+
+      tests/integration/components/billing/selected-plan-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/selected-plan-test.js  ember-types
+
+      tests/integration/components/billing/summary-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/summary-test.js  ember-types
+
+      tests/integration/components/billing/warning-message-test.js
+        0:0  metrics  Located component at tests/integration/components/billing/warning-message-test.js  ember-types
+
+      tests/integration/components/branch-row-test.js
+        0:0  metrics  Located component at tests/integration/components/branch-row-test.js  ember-types
+
+      tests/integration/components/build-count-test.js
+        0:0  metrics  Located component at tests/integration/components/build-count-test.js  ember-types
+
+      tests/integration/components/build-header-test.js
+        0:0  metrics  Located component at tests/integration/components/build-header-test.js  ember-types
+
+      app/helpers/format-message.js
+        0:0  metrics  Located helper at app/helpers/format-message.js  ember-types
+
+      app/helpers/format-number.js
+        0:0  metrics  Located helper at app/helpers/format-number.js  ember-types
+
+      /Users/zhanwang/personal/travis-web/package.json
+        90:4  dependencies  Ember dependency information for ember-web-app      ember-dependencies
+        91:4  dependencies  Ember dependency information for ember-window-mock  ember-dependencies
+
+      ✅ 153 results (metrics 151, dependencies 2)
+      "
+    `);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,7 @@
     "micromatch": "^4.0.2",
     "node-fetch": "^3.2.8",
     "npm-check": "^5.9.2",
+    "object-path": "^0.11.8",
     "ow": "^0.28.1",
     "pkg-up": "^3.1.0",
     "promise.hash.helper": "^1.0.8",
@@ -66,6 +67,7 @@
     "@types/chalk": "^2.2.0",
     "@types/eslint": "^7.2.2",
     "@types/lodash.merge": "^4.6.7",
+    "@types/object-path": "^0.11.1",
     "@types/resolve": "^1.20.2",
     "@types/wrap-ansi": "^3.0.0",
     "mockdate": "^3.0.5"

--- a/packages/core/src/data/checkup-log-parser.ts
+++ b/packages/core/src/data/checkup-log-parser.ts
@@ -1,5 +1,5 @@
 import objectPath from 'object-path';
-import { Log, Result } from 'sarif';
+import { Log, ReportingDescriptor, Result } from 'sarif';
 import { RuleResults } from '../types/checkup-log.js';
 import { TaskName } from '../types/tasks.js';
 
@@ -133,7 +133,11 @@ export default class CheckupLogParser {
     return this._resultsByFile;
   }
 
-  getPropertyValue(object: object, path: string) {
+  getRule(id: string): ReportingDescriptor | undefined {
+    return this.rules.find((rule) => rule.id === id);
+  }
+
+  getPropertyValue(object: any, path: string) {
     return objectPath.get(object, path);
   }
 }

--- a/packages/core/src/types/tasks.ts
+++ b/packages/core/src/types/tasks.ts
@@ -91,6 +91,7 @@ export interface TaskContext {
 
 export enum OutputFormat {
   summary = 'summary',
+  stylish = 'stylish',
   json = 'json',
   pretty = 'pretty',
   sonarqube = 'sonarqube',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11225,7 +11225,7 @@ test-exclude@^6.0.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 textextensions@^5.12.0, textextensions@^5.13.0:
   version "5.14.0"
@@ -11421,9 +11421,9 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.11.0, type-fest@^0.12.0, type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.0.1, type-fest@^1.0.2, type-fest@^2.13.0, type-fest@^2.16.0, type-fest@^2.3.4, type-fest@^2.5.1:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
-  integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.1.tgz#a94f068c60b5a2d6beccccffa711210d7dd99b38"
+  integrity sha512-UKCINsd4qiATXD6OIlnQw9t1ux/n2ld+Nl0kzPbCONhCaUIS/BhJbNw14w6584HCQWf3frBK8vmWnGZq/sbPHQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
We've spent a lot of time with the Pretty formatter, in multiple incarnations. The latest, which leverages the excellent Ink library, provides some pretty robust functionality, but sadly has also resulted in a lot of maintenance burden. The amount of benefit it gives is outweighed by the additional maintenance cost, all for a formatter.

As such, we're deprecating the pretty formatter and its associated infra (`@checkup/ui` package). This will be done in a follow up PR.

To replace it, we're outputting the SARIF in a familiar format used by other static analysis tools, such as `eslint` and `ember-template-lint`. 

New `stylish` formatter:

<img width="1280" alt="Screen Shot 2022-08-23 at 12 12 20 PM" src="https://user-images.githubusercontent.com/180990/186245459-51623784-f30c-4f13-a664-c5e6d79de6b7.png">

This formatter has a number of improvements over the pretty formatter:

1. It works with SARIF, and is very fault-tolerant
2. It outputs both location information, and category
3. It provides a useful summary
4. It resembles other static analysis tool outputs.

