### PR TITLE
Fixes segfault in generators

### DIFF
--- a/packages/cli/bin/checkup.js
+++ b/packages/cli/bin/checkup.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import 'v8-compile-cache';
 import { createRequire } from 'module';
 import importLocal from 'import-local';
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,11 +53,10 @@
     "text-table": "^0.2.0",
     "tmp": "^0.2.1",
     "tslib": "^2",
-    "v8-compile-cache": "^2.3.0",
     "wrap-ansi": "^7.0.0",
     "yargs": "^16.2.0",
     "yargs-unparser": "^2.0.0",
-    "yeoman-environment": "^3.9.1",
+    "yeoman-environment": "^3.10.0",
     "yeoman-generator": "^5.4.2"
   },
   "devDependencies": {

--- a/packages/cli/src/api/generator.ts
+++ b/packages/cli/src/api/generator.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { createRequire } from 'module';
-import * as debug from 'debug';
+import debug from 'debug';
 import { CheckupError, ErrorKind } from '@checkup/core';
 import yeomanEnv from 'yeoman-environment';
 import fs from 'fs-extra';
@@ -49,6 +49,7 @@ export default class Generator {
     try {
       // @ts-ignore
       await env.run(`checkup:${type}`, generatorOptions, null);
+
       // this is ugly, but I couldn't find the correct configuration to ignore
       // generating the yeoman repository directory in the cwd
       let yoRepoPath = join(this.options.path, '.yo-repository');

--- a/packages/cli/src/generators/base-generator.ts
+++ b/packages/cli/src/generators/base-generator.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import { existsSync, mkdirSync } from 'fs';
 import Generator from 'yeoman-generator';
 import chalk from 'chalk';
-import { extend } from 'lodash';
+import _ from 'lodash';
 import { getPackageJson } from '@checkup/core';
 
 const require = createRequire(import.meta.url);
@@ -52,7 +52,7 @@ function isInsideProject(path: string): boolean {
   return existsSync(join(path, '.checkuprc'));
 }
 
-extend(Generator.prototype, require('yeoman-generator/lib/actions/install'));
+_.extend(Generator.prototype, require('yeoman-generator/lib/actions/install'));
 
 export default abstract class GeneratorBase extends Generator {
   abstract works: Works;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path';
-import * as crypto from 'crypto';
+import crypto from 'crypto';
 import { createRequire } from 'module';
 import Ajv from 'ajv';
 import fetch from 'node-fetch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6718,6 +6718,11 @@ isarray@^2.0.5:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
+isbinaryfile@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
+  integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
+
 isbinaryfile@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
@@ -12168,10 +12173,10 @@ yargs@^17.1.0, yargs@^17.3.1, yargs@^17.4.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-yeoman-environment@^3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-3.9.1.tgz#21912bdee4b1d302a5c25a7d31338fa092ea7116"
-  integrity sha512-IdRnbQt/DSOSnao0oD9c+or1X2UrL+fx9eC0O7Lq/MGZV68nhv9k77MqG+hEAySPSlyCpocVlhfQwV62hczk5Q==
+yeoman-environment@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-3.10.0.tgz#d8c56571b68d16b4af8abfb950f83acc503eed77"
+  integrity sha512-sYtSxBK9daq21QjoskJTHKLQ1xEsRPURkmFV/aM8HS8ZlQVzwx57Rz1zCs8EGPhK4vqsmTE8H92Gp1jg1fT3EA==
   dependencies:
     "@npmcli/arborist" "^4.0.4"
     are-we-there-yet "^2.0.0"
@@ -12191,6 +12196,7 @@ yeoman-environment@^3.9.1:
     grouped-queue "^2.0.0"
     inquirer "^8.0.0"
     is-scoped "^2.1.0"
+    isbinaryfile "^4.0.10"
     lodash "^4.17.10"
     log-symbols "^4.0.0"
     mem-fs "^1.2.0 || ^2.0.0"


### PR DESCRIPTION
There were 2 imports that were using the `import * as ...` syntax, which caused errors on the imports in ESM. This fixes those, in addition to removing `v8-compile-cache`, which doesn't work with ESM.