### PR TITLE
Remove gts/gjs from eslint-disable-task glob since babel parser does not support it

### DIFF
--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -42,12 +42,7 @@ export default class EslintDisableTask extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    let esLintablePaths = this.context.paths.filterByGlob([
-      '**/*.js',
-      '**/*.gjs',
-      '**/*.ts',
-      '**/*.gts',
-    ]);
+    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js', '**/*.ts']);
     let eslintDisables: NormalizedLintResult[] = await this.getEslintDisables(
       esLintablePaths,
       this.context.options.cwd


### PR DESCRIPTION
- Fixes https://github.com/checkupjs/checkup/issues/1347 which has more info
- gjs/gts files requires using the `eslint-plugin-ember` eslint plugin to do the preprocessing for `<template>` tags
- The task `eslint-summary-task` uses the `eslintrc` file so it works as expected
