### PR TITLE
Update eslint-summary-task to disregard *.d.ts files

### DIFF
--- a/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-summary-task.ts
@@ -65,7 +65,7 @@ export default class EslintSummaryTask extends BaseTask implements Task {
     let esLintablePaths = this.context.paths.filterByGlob([
       '**/*.js',
       '**/*.gjs',
-      '**/*.ts',
+      '**/!(*.d).ts',
       '**/*.gts',
     ]);
     let lintResults = await this.analyzer.analyze(esLintablePaths);


### PR DESCRIPTION
Avoid running checkup on autogenerated files