### PR TITLE
Update ember-template-lint-summary-task and ember-octane-migration-status-task to disregard *.d.ts files

### DIFF
--- a/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-octane-migration-status-task.ts
@@ -211,7 +211,7 @@ export default class EmberOctaneMigrationStatusTask extends BaseMigrationTask im
     let esLintablePaths = this.context.paths.filterByGlob([
       '**/*.js',
       '**/*.gjs',
-      '**/*.ts',
+      '**/!(*.d).ts',
       '**/*.gts',
     ]);
 
@@ -223,7 +223,7 @@ export default class EmberOctaneMigrationStatusTask extends BaseMigrationTask im
       '**/*.hbs',
       '**/*.js',
       '**/*.gjs',
-      '**/*.ts',
+      '**/!(*.d).ts',
       '**/*.gts',
     ]);
 

--- a/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
+++ b/packages/checkup-plugin-ember/src/tasks/ember-template-lint-summary-task.ts
@@ -56,7 +56,7 @@ export default class TemplateLintSummaryTask extends BaseTask implements Task {
       '**/*.hbs',
       '**/*.js',
       '**/*.gjs',
-      '**/*.ts',
+      '**/!(*.d).ts',
       '**/*.gts',
     ]);
 


### PR DESCRIPTION
Avoid running checkup on autogenerated files