### PR TITLE
Update eslint-disable-task to disregard *.d.ts files and use recast typescript parser

### DIFF
--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -42,7 +42,7 @@ export default class EslintDisableTask extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js', '**/!(*.d).ts']);
+    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js']);
     let eslintDisables: NormalizedLintResult[] = await this.getEslintDisables(
       esLintablePaths,
       this.context.options.cwd

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -42,7 +42,7 @@ export default class EslintDisableTask extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js']);
+    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js', '**/!(*.d).ts']);
     let eslintDisables: NormalizedLintResult[] = await this.getEslintDisables(
       esLintablePaths,
       this.context.options.cwd
@@ -110,7 +110,7 @@ export default class EslintDisableTask extends BaseTask implements Task {
             parse,
             visit,
             {
-              parser: await import('recast/parsers/babel.js'),
+              parser: await import('recast/parsers/typescript.js'),
             }
           );
           analyzer.analyze(accumulator.visitors);

--- a/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
+++ b/packages/checkup-plugin-javascript/src/tasks/eslint-disable-task.ts
@@ -42,7 +42,7 @@ export default class EslintDisableTask extends BaseTask implements Task {
   }
 
   async run(): Promise<Result[]> {
-    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js', '**/*.ts']);
+    let esLintablePaths = this.context.paths.filterByGlob(['**/*.js', '**/!(*.d).ts']);
     let eslintDisables: NormalizedLintResult[] = await this.getEslintDisables(
       esLintablePaths,
       this.context.options.cwd


### PR DESCRIPTION
- Avoid running checkup on autogenerated files
- Fix parsing issue when given a typescript file by using the typescript parser

Example error:
```
{"message":{"text":"javascript/eslint-disables generated an error during execution"},"level":"error","associatedRule":{"id":"javascript/eslint-disables"},"exception":{"message":"Error occurred at file.ts. Unexpected token, expected \",\" (24:29)"
```