### PR TITLE
Fix `fs-extra` imports

### DIFF
--- a/packages/cli/src/generators/plugin.ts
+++ b/packages/cli/src/generators/plugin.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { readdirSync, existsSync } from 'fs';
-import { readJsonSync } from 'fs-extra';
+import fs from 'fs-extra';
 import { Answers } from 'inquirer';
 import { CheckupError, ErrorKind, dirname } from '@checkup/core';
 import BaseGenerator, { Works } from './base-generator.js';
@@ -72,7 +72,10 @@ export default class PluginGenerator extends BaseGenerator {
           },
         ]);
 
-    const checkupVersion = readJsonSync(join(dirname(import.meta), '../../package.json')).version;
+    const checkupVersion = fs.readJsonSync(
+      join(dirname(import.meta), '../../package.json')
+    ).version;
+
     this.options.checkupVersion = checkupVersion;
     this.options.typescript = this.answers.typescript;
     this.options.description = this.answers.description;

--- a/packages/cli/tests/__utils__/get-fixture.ts
+++ b/packages/cli/tests/__utils__/get-fixture.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, resolve } from 'path';
-import { readJsonSync } from 'fs-extra';
+import fs from 'fs-extra';
 import { dirname } from '@checkup/core';
 
 export function getFixture(fixturePath: string) {
@@ -7,5 +7,5 @@ export function getFixture(fixturePath: string) {
     ? fixturePath
     : resolve(dirname(import.meta), '..', '__fixtures__', fixturePath);
 
-  return readJsonSync(path);
+  return fs.readJsonSync(path);
 }

--- a/packages/cli/tests/cli-test.ts
+++ b/packages/cli/tests/cli-test.ts
@@ -6,7 +6,7 @@ import execa from 'execa';
 import stringify from 'json-stable-stringify';
 import { dirname, trimCwd } from '@checkup/core';
 import type { Log } from 'sarif';
-import { copyFileSync } from 'fs-extra';
+import fs from 'fs-extra';
 import stripAnsi from 'strip-ansi';
 import { FakeProject } from './__utils__/fake-project';
 
@@ -227,8 +227,8 @@ describe('cli-test', () => {
     let formatterDirPath = join(project.baseDir, 'node_modules', 'checkup-formatter-test');
 
     mkdirSync(formatterDirPath);
-    copyFileSync(join(fixturePath, 'index.js'), join(formatterDirPath, 'index.js'));
-    copyFileSync(join(fixturePath, 'package.json'), join(formatterDirPath, 'package.json'));
+    fs.copyFileSync(join(fixturePath, 'index.js'), join(formatterDirPath, 'index.js'));
+    fs.copyFileSync(join(fixturePath, 'package.json'), join(formatterDirPath, 'package.json'));
 
     let result = await run(['run', '.', '--format', 'checkup-formatter-test']);
 
@@ -255,8 +255,8 @@ describe('cli-test', () => {
     let formatterDirPath = join(project.baseDir, 'node_modules', 'checkup-formatter-test');
 
     mkdirSync(formatterDirPath);
-    copyFileSync(join(fixturePath, 'index.js'), join(formatterDirPath, 'index.js'));
-    copyFileSync(join(fixturePath, 'package.json'), join(formatterDirPath, 'package.json'));
+    fs.copyFileSync(join(fixturePath, 'index.js'), join(formatterDirPath, 'index.js'));
+    fs.copyFileSync(join(fixturePath, 'package.json'), join(formatterDirPath, 'package.json'));
 
     let result = await run(['run', '.', '--format', 'test']);
 

--- a/packages/core/tests/config-test.ts
+++ b/packages/core/tests/config-test.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { readJsonSync, writeJsonSync, writeFileSync } from 'fs-extra';
+import fs from 'fs-extra';
 import {
   resolveConfigPath,
   readConfig,
@@ -32,7 +32,7 @@ describe('config', () => {
 
     it('throws if config format is invalid', () => {
       let configPath = resolveConfigPath(tmp);
-      writeJsonSync(configPath, {
+      fs.writeJsonSync(configPath, {
         plugins: [],
         task: {},
       });
@@ -44,7 +44,7 @@ describe('config', () => {
 
     it('throws if JSON is invalid', () => {
       let configPath = resolveConfigPath(tmp);
-      writeFileSync(
+      fs.writeFileSync(
         configPath,
         `{
         plugins: ['javascript'],
@@ -61,7 +61,7 @@ describe('config', () => {
 
     it('throws if invalid paths are passed in via config', () => {
       let configPath = resolveConfigPath(tmp);
-      writeJsonSync(configPath, {
+      fs.writeJsonSync(configPath, {
         plugins: [],
         tasks: {},
         excludePaths: 'foo', // excludePaths should be an array
@@ -206,7 +206,7 @@ describe('config', () => {
     it('writes default config if no config is passed', () => {
       let path = writeConfig(tmp);
 
-      expect(readJsonSync(path)).toMatchInlineSnapshot(`
+      expect(fs.readJsonSync(path)).toMatchInlineSnapshot(`
 {
   "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
   "excludePaths": [],
@@ -224,7 +224,7 @@ describe('config', () => {
         },
       });
 
-      expect(readJsonSync(path)).toMatchInlineSnapshot(`
+      expect(fs.readJsonSync(path)).toMatchInlineSnapshot(`
 {
   "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
   "excludePaths": [],

--- a/packages/core/tests/data/checkup-log-parser-test.ts
+++ b/packages/core/tests/data/checkup-log-parser-test.ts
@@ -1,11 +1,11 @@
 import { resolve } from 'path';
 import { dirname } from '@checkup/core';
-import { readJsonSync } from 'fs-extra';
+import fs from 'fs-extra';
 import CheckupLogParser from '../../src/data/checkup-log-parser';
 
 describe('checkup-log-parser-test', () => {
   it('can parse a single task log', () => {
-    let log = readJsonSync(
+    let log = fs.readJsonSync(
       resolve(dirname(import.meta), '../__fixtures__/checkup-result-single-task.sarif')
     );
 
@@ -86,7 +86,7 @@ describe('checkup-log-parser-test', () => {
   });
 
   it('can parse a multiple task log', () => {
-    let log = readJsonSync(
+    let log = fs.readJsonSync(
       resolve(dirname(import.meta), '../__fixtures__/checkup-result-all-tasks.sarif')
     );
 

--- a/packages/plugin/src/generate-docs.ts
+++ b/packages/plugin/src/generate-docs.ts
@@ -1,14 +1,14 @@
 import { join, extname, parse } from 'path';
-import { ensureDir, readdir, readFile, existsSync, writeFile } from 'fs-extra';
+import fs from 'fs-extra';
 import * as t from '@babel/types';
 import { dirname, getPluginName, getShorthandName, TypeScriptAnalyzer } from '@checkup/core';
 
 function getDocsFile(docsFilePath: string) {
-  if (existsSync(docsFilePath)) {
-    return readFile(docsFilePath, 'utf-8');
+  if (fs.existsSync(docsFilePath)) {
+    return fs.readFile(docsFilePath, 'utf-8');
   }
 
-  return readFile(join(dirname(import.meta), '..', 'templates', 'task-template.md'), 'utf-8');
+  return fs.readFile(join(dirname(import.meta), '..', 'templates', 'task-template.md'), 'utf-8');
 }
 
 function replaceContent(contents: string, replacement: string, tagName: string) {
@@ -35,14 +35,14 @@ export async function generate(baseDir: string = process.cwd()) {
   let docsDir = join(baseDir, 'docs', 'tasks');
   let tasksDir = join(baseDir, 'lib', 'tasks');
 
-  ensureDir(docsDir);
+  fs.ensureDir(docsDir);
 
-  let taskPaths = (await readdir(join(baseDir, 'lib', 'tasks'))).filter(
+  let taskPaths = (await fs.readdir(join(baseDir, 'lib', 'tasks'))).filter(
     (file) => extname(file) === '.js'
   );
 
   for (let taskPath of taskPaths) {
-    let taskSource = await readFile(join(tasksDir, taskPath), 'utf-8');
+    let taskSource = await fs.readFile(join(tasksDir, taskPath), 'utf-8');
     let taskName: string = '';
     let taskDescription: string = '';
 
@@ -82,6 +82,6 @@ checkup run --task ${pluginName}/${taskName}
       docsFileContents = replaceContent(docsFileContents, replacer.replacement, replacer.tagName);
     });
 
-    await writeFile(docsFilePath, docsFileContents);
+    await fs.writeFile(docsFilePath, docsFileContents);
   }
 }

--- a/packages/ui/tests/components/bar-test.tsx
+++ b/packages/ui/tests/components/bar-test.tsx
@@ -1,14 +1,17 @@
 import { resolve } from 'path';
 import * as React from 'react';
 import { render } from 'ink-testing-library';
-import { readJsonSync } from 'fs-extra';
+import fs from 'fs-extra';
 import { CheckupLogParser, dirname } from '@checkup/core';
 import stripAnsi from 'strip-ansi';
 import { Bar } from '../../src/components/Bar';
 
 describe('Bar', () => {
   it('can render task result as expected via bar component', async () => {
-    const log = readJsonSync(resolve(dirname(import.meta), '../__fixtures__/checkup-result.sarif'));
+    const log = fs.readJsonSync(
+      resolve(dirname(import.meta), '../__fixtures__/checkup-result.sarif')
+    );
+
     const logParser = new CheckupLogParser(log);
     const taskResults = logParser.resultsByRule;
     const taskResult = [...taskResults.values()][0];


### PR DESCRIPTION
`fs-extra` v9 is a cjs module, so it doesn't have named exports.
If this lib wants to (reliably) use named exports, it should upgrade `fs-extra` to v11,
and import the named exports from `fs-extra/esm`.

More info: https://github.com/jprichardson/node-fs-extra#esm

I'm not sure how most of these imports work fine in this lib (maybe because of TS?), but the error mentioned in #1368 is consistently reproducible.

You can also easily reproduce the error by running a JS file with the following contents:

```js
import { readJsonSync } from 'fs-extra';
console.log(readJsonSync);
```

Closes #1368.